### PR TITLE
Mcp wrapper fix

### DIFF
--- a/examples/mcp_related/cicada_mcp_calculator_example.py
+++ b/examples/mcp_related/cicada_mcp_calculator_example.py
@@ -36,13 +36,19 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Process some integers.")
     parser.add_argument(
-        "--mode", default="stdio", choices=["stdio", "sse"], help="Mode of transport"
+        "--mode",
+        default="stdio",
+        choices=["stdio", "streamable-http", "sse"],
+        help="Mode of transport",
     )
     args = parser.parse_args()
 
     if args.mode == "sse":
         # SSE
         transport = f"http://localhost:{PORT}/sse"
+    elif args.mode == "streamable-http":
+        # Streamable HTTP
+        transport = f"http://localhost:{PORT}/mcp"
     else:
         # stdio
         transport = "/home/pding/projects/toolregistry/examples/mcp_related/mcp_servers/math_server.py"

--- a/examples/mcp_related/mcp_servers/math_server.py
+++ b/examples/mcp_related/mcp_servers/math_server.py
@@ -14,7 +14,7 @@ mcp = FastMCP(server_name)
 
 
 # Register all math tools
-@mcp.tool()
+@mcp.tool("my-math_add")  # Add a custom name for the tool to test normalization logic
 def add(a: float, b: float) -> float:
     """Add two numbers"""
     return a + b

--- a/examples/mcp_related/mcp_servers/math_server.py
+++ b/examples/mcp_related/mcp_servers/math_server.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         "--mode",
         type=str,
         default="stdio",
-        choices=["stdio", "sse"],
+        choices=["stdio", "streamable-http", "sse"],
         help="Server transport mode: stdio, sse, ws or http",
     )
     parser.add_argument(
@@ -72,6 +72,12 @@ if __name__ == "__main__":
     elif args.mode == "sse":
         mcp.run(
             transport="sse",
+            host="localhost",
+            port=args.port,
+        )
+    else:  # arg.mode == 'streamable-http'
+        mcp.run(
+            transport="streamable-http",
             host="localhost",
             port=args.port,
         )

--- a/examples/mcp_related/openai_mcp_calculator_example.py
+++ b/examples/mcp_related/openai_mcp_calculator_example.py
@@ -71,13 +71,19 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Process some integers.")
     parser.add_argument(
-        "--mode", default="stdio", choices=["stdio", "sse"], help="Mode of transport"
+        "--mode",
+        default="stdio",
+        choices=["stdio", "streamable-http", "sse"],
+        help="Mode of transport",
     )
     args = parser.parse_args()
 
     if args.mode == "sse":
         # SSE
         transport = f"http://localhost:{PORT}/sse"
+    elif args.mode == "streamable-http":
+        # Streamable HTTP
+        transport = f"http://localhost:{PORT}/mcp"
     else:
         # stdio
         transport = "/home/pding/projects/toolregistry/examples/mcp_related/mcp_servers/math_server.py"
@@ -85,6 +91,8 @@ if __name__ == "__main__":
     tool_registry.register_from_mcp(transport, with_namespace=True)
 
     print(tool_registry.get_available_tools())
+    print(tool_registry.get_tools_json())
+    # exit()
 
     # Make the chat completion request
     response = client.chat.completions.create(

--- a/src/toolregistry/mcp_integration.py
+++ b/src/toolregistry/mcp_integration.py
@@ -323,17 +323,17 @@ class MCPTool(Tool):
         Returns:
             MCPTool: A new instance of MCPTool configured with the provided parameters.
         """
-        func_name = normalize_tool_name(name)
 
         wrapper = MCPToolWrapper(
             transport=transport,
-            name=func_name,
+            name=name,
             params=(
                 list(input_schema.get("properties", {}).keys()) if input_schema else []
             ),
         )
+
         tool = cls(
-            name=func_name,
+            name=normalize_tool_name(name),
             description=description,
             parameters=input_schema,
             callable=wrapper,


### PR DESCRIPTION
Correctly handle the MCP tool name normalization logic. Only apply at the MCPTool level; the wrapper still keeps the original name.