### PR TITLE
refactor: remove hub optional dependency from pyproject.toml

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -17,8 +17,7 @@ Full documentation is available at [https://toolregistry.readthedocs.io](https:/
 
 > **Important Notice**: As of version 0.4.14, the hub tools have been spun off into a separate package [`toolregistry-hub`](https://pypi.org/project/toolregistry-hub/). This standalone package provides a collection of ready-to-use tools for LLM function calling and can be used independently or alongside ToolRegistry. This spinoff enables separate development, distribution, and versioning of the hub tools, making it easier to maintain and update them without affecting the core ToolRegistry functionality.
 
-- **Standalone Package**: [`pip install toolregistry-hub`](https://pypi.org/project/toolregistry-hub/)
-- **With ToolRegistry**: `pip install toolregistry[hub]`
+- **Install**: [`pip install toolregistry-hub`](https://pypi.org/project/toolregistry-hub/)
 - **PyPI**: [toolregistry-hub on PyPI](https://pypi.org/project/toolregistry-hub/)
 - **GitHub**: [toolregistry-hub on GitHub](https://github.com/Oaklight/toolregistry-hub/)
 
@@ -57,25 +56,16 @@ Below is a table summarizing available extra modules:
 | mcp          | Python >= 3.10     | pip install toolregistry[mcp]       |
 | openapi      | Python >= 3.8      | pip install toolregistry[openapi]   |
 | langchain    | Python >= 3.9      | pip install toolregistry[langchain] |
-| hub          | Python >= 3.8      | pip install toolregistry[hub]       |
 
 ### Hub Tools Installation
 
-**Note**: As of recent versions, the hub tools have been moved to a separate package `toolregistry-hub`. You can install hub tools in two ways:
+The hub tools are available as a separate package `toolregistry-hub`:
 
-1. **Standalone installation**:
+```bash
+pip install toolregistry-hub
+```
 
-   ```bash
-   pip install toolregistry-hub
-   ```
-
-2. **Via extras**:
-
-   ```bash
-   pip install toolregistry[hub]
-   ```
-
-Both methods provide the same functionality. The standalone installation allows you to use hub tools independently or with other compatible libraries.
+This allows you to use hub tools independently or alongside ToolRegistry.
 
 ## Examples
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,8 +17,7 @@
 
 > **重要通知**：从版本 0.4.14 开始，hub 工具已分离为独立包 [`toolregistry-hub`](https://pypi.org/project/toolregistry-hub/)。这个独立包提供了一个即用型工具集合，专为 LLM 函数调用设计，可以独立使用或与 ToolRegistry 一起使用。这种分离使得 hub 工具能够独立开发、分发和版本控制，更容易维护和更新，而不会影响核心 ToolRegistry 功能。
 
-- **独立包**：[`pip install toolregistry-hub`](https://pypi.org/project/toolregistry-hub/)
-- **与 ToolRegistry 一起**：`pip install toolregistry[hub]`
+- **安装**：[`pip install toolregistry-hub`](https://pypi.org/project/toolregistry-hub/)
 - **PyPI**: [toolregistry-hub on PyPI](https://pypi.org/project/toolregistry-hub/)
 - **GitHub**: [toolregistry-hub on GitHub](https://github.com/Oaklight/toolregistry-hub/)
 
@@ -57,25 +56,16 @@ pip install toolregistry[mcp,openapi]
 | mcp       | Python >= 3.10 | pip install toolregistry[mcp]       |
 | openapi   | Python >= 3.8  | pip install toolregistry[openapi]   |
 | langchain | Python >= 3.9  | pip install toolregistry[langchain] |
-| hub       | Python >= 3.8  | pip install toolregistry[hub]       |
 
 ### Hub 工具安装
 
-**注意**：从最新版本开始，hub 工具已移至独立包 `toolregistry-hub`。您可以通过两种方式安装 hub 工具：
+Hub 工具作为独立包 `toolregistry-hub` 提供：
 
-1. **独立安装**：
+```bash
+pip install toolregistry-hub
+```
 
-   ```bash
-   pip install toolregistry-hub
-   ```
-
-2. **通过额外模块**：
-
-   ```bash
-   pip install toolregistry[hub]
-   ```
-
-两种方法提供相同的功能。独立安装允许您独立使用 hub 工具或与其他兼容库一起使用。
+这允许您独立使用 hub 工具或与 ToolRegistry 一起使用。
 
 ## 示例
 

--- a/docs/source/hub/index.md
+++ b/docs/source/hub/index.md
@@ -14,11 +14,7 @@ To install the standalone `toolregistry-hub` package, use the following command:
 pip install toolregistry-hub
 ```
 
-For integration with the main `toolregistry` package, you can install it as an optional dependency:
-
-```bash
-pip install toolregistry[hub]
-```
+For integration with the main `toolregistry` package, the `from toolregistry.hub import ...` import path is also supported when `toolregistry-hub` is installed.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/source/usage/installation.md
+++ b/docs/source/usage/installation.md
@@ -34,28 +34,19 @@ Below is a table summarizing available extra modules:
 
 | Extra Module | Python Requirement | Example Command                     |
 | ------------ | ------------------ | ----------------------------------- |
-| hub          | Python >= 3.8      | pip install toolregistry[hub]       |
 | mcp          | Python >= 3.10     | pip install toolregistry[mcp]       |
 | openapi      | Python >= 3.8      | pip install toolregistry[openapi]   |
 | langchain    | Python >= 3.9      | pip install toolregistry[langchain] |
 
 ### Hub Tools Installation
 
-**Note**: Starting 0.4.14, the hub tools have been moved to a separate package `toolregistry-hub`. You can install hub tools in two ways:
+The hub tools are available as a separate package `toolregistry-hub`:
 
-1. **Standalone installation**:
+```bash
+pip install toolregistry-hub
+```
 
-   ```bash
-   pip install toolregistry-hub
-   ```
-
-2. **Via extras**:
-
-   ```bash
-   pip install toolregistry[hub]
-   ```
-
-Both methods provide the same functionality. The standalone installation allows you to use hub tools independently or with other compatible libraries.
+This allows you to use hub tools independently or alongside ToolRegistry.
 
 ### Installation from Source
 

--- a/docs/source/usage/integrations/hub.md
+++ b/docs/source/usage/integrations/hub.md
@@ -8,10 +8,9 @@ Split from the main package in version: 0.4.14
 ```{important}
 **Hub Tools Package Update**: starting 0.4.14, hub tools have been moved to a separate package `toolregistry-hub`. You can install it via:
 
-- `pip install toolregistry-hub` (standalone installation)
-- `pip install toolregistry[hub]` (as an extra dependency)
+- `pip install toolregistry-hub`
 
-Both methods provide the same functionality. The standalone installation allows you to use hub tools independently or with other compatible libraries.
+This allows you to use hub tools independently or alongside ToolRegistry.
 ```
 
 ## Introduction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-hub = ["toolregistry-hub>=0.4.14"] # hub module split start from 0.4.14
 mcp = ["fastmcp>=2.3.0"]
 openapi = [
     "PyYAML>=6.0.2",  # safe load both json and yaml

--- a/src/toolregistry/hub/__init__.py
+++ b/src/toolregistry/hub/__init__.py
@@ -26,5 +26,4 @@ except ImportError:
     raise ImportError(
         "The toolregistry_hub package is not installed. "
         "Please install it with: `pip install toolregistry-hub`"
-        "or `pip install toolregistry[hub]`"
     )


### PR DESCRIPTION
## Summary

Remove the `hub` optional dependency (`pip install toolregistry[hub]`) from `pyproject.toml` to eliminate the potential circular dependency with `toolregistry-hub`.

## Changes

- **pyproject.toml**: Remove `hub = ["toolregistry-hub>=0.4.14"]` from `[project.optional-dependencies]`
- **hub/__init__.py**: Update ImportError message to only suggest `pip install toolregistry-hub`
- **README_en.md / README_zh.md**: Remove `pip install toolregistry[hub]` references
- **docs/**: Update installation and hub integration docs

## Notes

- The `from toolregistry.hub import Calculator` import path still works when both packages are installed
- Users should now install hub tools via: `pip install toolregistry-hub`
- Companion issue: Oaklight/toolregistry-hub#29

Closes #50