### PR TITLE
feat: add two-level enable/disable with reason tracking

### DIFF
--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -67,6 +67,7 @@ class ToolRegistry:
         self.name = name
         self._tools: Dict[str, Tool] = {}
         self._sub_registries: Set[str] = set()
+        self._disabled: Dict[str, str] = {}
         self._executor = Executor()
 
     def __contains__(self, name: str) -> bool:
@@ -126,6 +127,9 @@ class ToolRegistry:
     ) -> Dict[str, str]:
         """Execute tool calls with concurrency using dill for serialization.
 
+        Disabled tools are rejected with an error message instead of being
+        executed.
+
         Args:
             tool_calls: List of tool calls to be executed in any supported format.
             execution_mode: Execution mode to use; defaults to the Executor's current mode.
@@ -135,9 +139,27 @@ class ToolRegistry:
         """
         generic_tool_calls = convert_tool_calls(tool_calls)
 
-        return self._executor.execute_tool_calls(
-            self.get_tool, generic_tool_calls, execution_mode
-        )
+        # Separate enabled and disabled tool calls
+        enabled_calls = []
+        tool_responses: Dict[str, str] = {}
+
+        for tc in generic_tool_calls:
+            if not self.is_enabled(tc.name):
+                reason = self.get_disable_reason(tc.name) or "Tool is disabled"
+                tool_responses[tc.id] = (
+                    f"Error: Tool '{tc.name}' is disabled. Reason: {reason}"
+                )
+            else:
+                enabled_calls.append(tc)
+
+        # Execute only enabled tool calls
+        if enabled_calls:
+            executed_responses = self._executor.execute_tool_calls(
+                self.get_tool, enabled_calls, execution_mode
+            )
+            tool_responses.update(executed_responses)
+
+        return tool_responses
 
     def recover_tool_call_assistant_message(
         self,
@@ -340,6 +362,59 @@ class ToolRegistry:
             self.reduce_namespace()
 
         return new_registry
+
+    # ============== Enable/Disable ==============
+
+    def disable(self, name: str, reason: str = "") -> None:
+        """Disable a tool or namespace. Uses raw name (not normalized).
+
+        Args:
+            name: The tool name or namespace to disable.
+            reason: Optional reason for disabling.
+        """
+        self._disabled[name] = reason
+
+    def enable(self, name: str) -> None:
+        """Re-enable a tool or namespace.
+
+        Args:
+            name: The tool name or namespace to re-enable.
+        """
+        self._disabled.pop(name, None)
+
+    def is_enabled(self, tool_name: str) -> bool:
+        """Check if a tool is enabled (not disabled at method or group level).
+
+        Args:
+            tool_name: The tool name to check.
+
+        Returns:
+            True if the tool is enabled, False otherwise.
+        """
+        if tool_name in self._disabled:
+            return False
+        tool = self._tools.get(tool_name)
+        if tool and tool.namespace and tool.namespace in self._disabled:
+            return False
+        return True
+
+    def get_disable_reason(self, tool_name: str) -> Optional[str]:
+        """Get the reason a tool is disabled, or None if enabled.
+
+        Method-level disable takes priority over group-level.
+
+        Args:
+            tool_name: The tool name to check.
+
+        Returns:
+            The disable reason string, or None if the tool is enabled.
+        """
+        if tool_name in self._disabled:
+            return self._disabled[tool_name]
+        tool = self._tools.get(tool_name)
+        if tool and tool.namespace:
+            return self._disabled.get(tool.namespace)
+        return None
 
     # ============== Registration Methods ==============
     def register(
@@ -646,15 +721,22 @@ class ToolRegistry:
 
     # ============== Presentation ==============
     def list_tools(self) -> List[str]:
-        """List all registered tools.
+        """List enabled tools only.
 
         Returns:
-            List[str]: A list of tool names.
+            List[str]: A list of enabled tool names.
         """
-
-        return list(self._tools.keys())
+        return [n for n in self._tools if self.is_enabled(n)]
 
     get_available_tools = list_tools  # Alias for backward compatibility
+
+    def list_all_tools(self) -> List[str]:
+        """List all tools including disabled (for admin panel).
+
+        Returns:
+            List[str]: A list of all tool names.
+        """
+        return list(self._tools.keys())
 
     def get_tools_json(
         self,
@@ -662,7 +744,9 @@ class ToolRegistry:
         *,
         api_format: API_FORMATS = "openai",
     ) -> List[Dict[str, Any]]:
-        """Get the JSON representation of all registered tools, following JSON Schema.
+        """Get the JSON representation of registered tools, following JSON Schema.
+
+        When no specific tool_name is given, only enabled tools are returned.
 
         Args:
             tool_name (Optional[str]): Optional name of specific tool to get schema for.
@@ -677,7 +761,8 @@ class ToolRegistry:
             target_tool = self.get_tool(tool_name)
             tools = [target_tool] if target_tool else []
         else:
-            tools = list(self._tools.values())
+            # Only return enabled tools
+            tools = [t for t in self._tools.values() if self.is_enabled(t.name)]
 
         return [tool.get_json_schema(api_format) for tool in tools]
 

--- a/tests/test_enable_disable.py
+++ b/tests/test_enable_disable.py
@@ -1,0 +1,384 @@
+"""Tests for Tool enable/disable functionality (Phase 3)."""
+
+import json
+
+from toolregistry.tool_registry import ToolRegistry
+from toolregistry.types import (
+    ChatCompletionMessageFunctionToolCall,
+    Function,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+def subtract(a: int, b: int) -> int:
+    """Subtract b from a."""
+    return a - b
+
+
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+class MathTools:
+    @staticmethod
+    def square(x: int) -> int:
+        """Square a number."""
+        return x * x
+
+    @staticmethod
+    def double(x: int) -> int:
+        """Double a number."""
+        return x * 2
+
+    @staticmethod
+    def negate(x: int) -> int:
+        """Negate a number."""
+        return -x
+
+
+# ===========================================================================
+# 1. Basic disable/enable
+# ===========================================================================
+
+
+class TestBasicDisableEnable:
+    """Verify basic disable and enable operations on individual tools."""
+
+    def test_tool_enabled_by_default(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        assert registry.is_enabled("add") is True
+
+    def test_disable_tool(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add")
+        assert registry.is_enabled("add") is False
+
+    def test_enable_after_disable(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add")
+        assert registry.is_enabled("add") is False
+        registry.enable("add")
+        assert registry.is_enabled("add") is True
+
+    def test_disable_with_reason(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add", reason="under maintenance")
+        assert registry.get_disable_reason("add") == "under maintenance"
+
+    def test_enable_clears_reason(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add", reason="under maintenance")
+        registry.enable("add")
+        assert registry.get_disable_reason("add") is None
+
+
+# ===========================================================================
+# 2. Namespace-level disable
+# ===========================================================================
+
+
+class TestNamespaceDisable:
+    """Verify disabling/enabling at the namespace level."""
+
+    def test_disable_namespace_disables_all_tools(self):
+        registry = ToolRegistry(name="test")
+        registry.register_from_class(MathTools, with_namespace=True)
+        tools = registry.list_all_tools()
+        assert len(tools) == 3
+
+        registry.disable("math_tools")
+        for tool_name in tools:
+            assert registry.is_enabled(tool_name) is False
+
+    def test_disable_namespace_reason_propagates(self):
+        registry = ToolRegistry(name="test")
+        registry.register_from_class(MathTools, with_namespace=True)
+        tools = registry.list_all_tools()
+
+        registry.disable("math_tools", reason="namespace disabled")
+        for tool_name in tools:
+            assert registry.get_disable_reason(tool_name) == "namespace disabled"
+
+    def test_enable_namespace_enables_all_tools(self):
+        registry = ToolRegistry(name="test")
+        registry.register_from_class(MathTools, with_namespace=True)
+        tools = registry.list_all_tools()
+
+        registry.disable("math_tools")
+        for tool_name in tools:
+            assert registry.is_enabled(tool_name) is False
+
+        registry.enable("math_tools")
+        for tool_name in tools:
+            assert registry.is_enabled(tool_name) is True
+
+
+# ===========================================================================
+# 3. Method-level overrides namespace-level
+# ===========================================================================
+
+
+class TestMethodOverridesNamespace:
+    """Verify that method-level disable reason takes priority over namespace-level."""
+
+    def test_method_reason_overrides_namespace_reason(self):
+        registry = ToolRegistry(name="test")
+        registry.register_from_class(MathTools, with_namespace=True)
+        tools = registry.list_all_tools()
+
+        # Disable namespace
+        registry.disable("math_tools", reason="namespace disabled")
+
+        # Also disable a specific tool with a different reason
+        specific_tool = tools[0]
+        registry.disable(specific_tool, reason="method disabled")
+
+        # Method-level reason takes priority
+        assert registry.get_disable_reason(specific_tool) == "method disabled"
+
+        # Other tools in namespace still get namespace reason
+        for tool_name in tools[1:]:
+            assert registry.get_disable_reason(tool_name) == "namespace disabled"
+
+    def test_both_method_and_namespace_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register_from_class(MathTools, with_namespace=True)
+        tools = registry.list_all_tools()
+
+        specific_tool = tools[0]
+        registry.disable("math_tools", reason="namespace disabled")
+        registry.disable(specific_tool, reason="method disabled")
+
+        # All tools should be disabled
+        for tool_name in tools:
+            assert registry.is_enabled(tool_name) is False
+
+
+# ===========================================================================
+# 4. list_tools vs list_all_tools
+# ===========================================================================
+
+
+class TestListToolsFiltering:
+    """Verify that list_tools only returns enabled tools."""
+
+    def test_list_tools_excludes_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+        registry.register(multiply)
+
+        registry.disable("subtract")
+
+        enabled = registry.list_tools()
+        assert "add" in enabled
+        assert "subtract" not in enabled
+        assert "multiply" in enabled
+
+    def test_list_all_tools_includes_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+        registry.register(multiply)
+
+        registry.disable("subtract")
+
+        all_tools = registry.list_all_tools()
+        assert "add" in all_tools
+        assert "subtract" in all_tools
+        assert "multiply" in all_tools
+
+    def test_get_available_tools_matches_list_tools(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+
+        registry.disable("subtract")
+
+        assert registry.get_available_tools() == registry.list_tools()
+
+    def test_list_tools_empty_when_all_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+
+        registry.disable("add")
+        registry.disable("subtract")
+
+        assert registry.list_tools() == []
+        assert len(registry.list_all_tools()) == 2
+
+
+# ===========================================================================
+# 5. get_tools_json filtering
+# ===========================================================================
+
+
+class TestGetToolsJsonFiltering:
+    """Verify that get_tools_json filters disabled tools."""
+
+    def test_get_tools_json_excludes_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+        registry.register(multiply)
+
+        registry.disable("subtract")
+
+        schemas = registry.get_tools_json()
+        schema_names = [
+            s["function"]["name"]
+            for s in schemas
+            if "function" in s and "name" in s["function"]
+        ]
+        assert "add" in schema_names
+        assert "subtract" not in schema_names
+        assert "multiply" in schema_names
+
+    def test_get_tools_json_specific_tool_returns_even_if_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+
+        registry.disable("subtract")
+
+        # Querying a specific tool by name should still return its schema
+        schemas = registry.get_tools_json(tool_name="subtract")
+        assert len(schemas) == 1
+        assert schemas[0]["function"]["name"] == "subtract"
+
+    def test_get_tools_json_all_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+
+        registry.disable("add")
+        registry.disable("subtract")
+
+        schemas = registry.get_tools_json()
+        assert schemas == []
+
+
+# ===========================================================================
+# 6. execute_tool_calls with disabled tools
+# ===========================================================================
+
+
+class TestExecuteToolCallsDisabled:
+    """Verify that execute_tool_calls rejects disabled tools."""
+
+    def _make_tool_call(self, name: str, arguments: dict, call_id: str = "call_1"):
+        """Create a ChatCompletionMessageFunctionToolCall for testing."""
+        return ChatCompletionMessageFunctionToolCall(
+            id=call_id,
+            function=Function(
+                name=name,
+                arguments=json.dumps(arguments),
+            ),
+        )
+
+    def test_execute_enabled_tool(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+
+        tool_call = self._make_tool_call("add", {"a": 3, "b": 4})
+        results = registry.execute_tool_calls([tool_call])
+        assert str(results["call_1"]) == "7"
+
+    def test_execute_disabled_tool_returns_error(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add", reason="under maintenance")
+
+        tool_call = self._make_tool_call("add", {"a": 3, "b": 4})
+        results = registry.execute_tool_calls([tool_call])
+        assert "call_1" in results
+        assert "disabled" in results["call_1"].lower()
+        assert "under maintenance" in results["call_1"]
+
+    def test_execute_mixed_enabled_disabled(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.register(subtract)
+
+        registry.disable("subtract", reason="deprecated")
+
+        tc_add = self._make_tool_call("add", {"a": 1, "b": 2}, call_id="call_add")
+        tc_sub = self._make_tool_call("subtract", {"a": 5, "b": 3}, call_id="call_sub")
+        results = registry.execute_tool_calls([tc_add, tc_sub])
+
+        assert str(results["call_add"]) == "3"
+        assert "disabled" in results["call_sub"].lower()
+        assert "deprecated" in results["call_sub"]
+
+    def test_execute_disabled_tool_default_reason(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add")
+
+        tool_call = self._make_tool_call("add", {"a": 1, "b": 2})
+        results = registry.execute_tool_calls([tool_call])
+        assert "disabled" in results["call_1"].lower()
+
+
+# ===========================================================================
+# 7. Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Verify edge cases for enable/disable operations."""
+
+    def test_disable_nonexistent_name_no_error(self):
+        registry = ToolRegistry(name="test")
+        # Should not raise
+        registry.disable("nonexistent_tool")
+
+    def test_enable_non_disabled_name_no_error(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        # Should not raise
+        registry.enable("add")
+
+    def test_is_enabled_nonexistent_tool_returns_true(self):
+        registry = ToolRegistry(name="test")
+        # Non-existent tool is not in _disabled, so returns True
+        assert registry.is_enabled("nonexistent_tool") is True
+
+    def test_get_disable_reason_nonexistent_tool_returns_none(self):
+        registry = ToolRegistry(name="test")
+        assert registry.get_disable_reason("nonexistent_tool") is None
+
+    def test_disable_with_empty_reason(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add", reason="")
+        assert registry.is_enabled("add") is False
+        assert registry.get_disable_reason("add") == ""
+
+    def test_disable_same_tool_twice_updates_reason(self):
+        registry = ToolRegistry(name="test")
+        registry.register(add)
+        registry.disable("add", reason="first reason")
+        registry.disable("add", reason="second reason")
+        assert registry.get_disable_reason("add") == "second reason"
+
+    def test_enable_nonexistent_name_no_error(self):
+        registry = ToolRegistry(name="test")
+        # Should not raise even if name was never disabled
+        registry.enable("never_disabled")


### PR DESCRIPTION
## Phase 3 — Enable/Disable with Reason

Implements [Issue #53](https://github.com/Oaklight/ToolRegistry/issues/53).

### Changes

**Phase 3a — Two-Level Enable/Disable:**
- Added `_disabled: Dict[str, str]` to `ToolRegistry.__init__`
- Added `disable(name, reason)`, `enable(name)`, `is_enabled(tool_name)`, `get_disable_reason(tool_name)`
- Supports both method-level and namespace-level disable with reason tracking
- Method-level disable takes priority over namespace-level

**Phase 3b — Integration with existing methods:**
- `list_tools()` now only returns enabled tools
- Added `list_all_tools()` for admin panel use (returns all including disabled)
- `get_tools_json()` filters disabled tools when no specific tool_name given
- `execute_tool_calls()` returns error message for disabled tools instead of executing

### Tests
- 28 new tests in `tests/test_enable_disable.py`
- All 77 tests pass (28 new + 49 existing), no regressions