### PR TITLE
feat: add permission handler protocol and registry integration

### DIFF
--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -8,6 +8,12 @@ from .admin import (
     TokenAuth,
 )
 from .events import ChangeCallback, ChangeEvent, ChangeEventType
+from .permissions import (
+    AsyncPermissionHandler,
+    PermissionHandler,
+    PermissionRequest,
+    PermissionResult,
+)
 from .tool import Tool, ToolMetadata, ToolTag
 from .tool_registry import ToolRegistry
 
@@ -15,12 +21,16 @@ __all__ = [
     "AdminInfo",
     "AdminRequestHandler",
     "AdminServer",
+    "AsyncPermissionHandler",
     "ChangeCallback",
     "ChangeEvent",
     "ChangeEventType",
     "ExecutionLog",
     "ExecutionLogEntry",
     "ExecutionStatus",
+    "PermissionHandler",
+    "PermissionRequest",
+    "PermissionResult",
     "TokenAuth",
     "Tool",
     "ToolMetadata",

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -28,6 +28,8 @@ class ChangeEventType(str, Enum):
     DISABLE = "disable"
     REFRESH = "refresh"
     REFRESH_ALL = "refresh_all"
+    PERMISSION_DENIED = "permission_denied"
+    PERMISSION_ASKED = "permission_asked"
 
 
 @dataclass(frozen=True)

--- a/src/toolregistry/permissions/__init__.py
+++ b/src/toolregistry/permissions/__init__.py
@@ -1,0 +1,11 @@
+"""Permission system for tool authorization."""
+
+from .handler import AsyncPermissionHandler, PermissionHandler
+from .types import PermissionRequest, PermissionResult
+
+__all__ = [
+    "AsyncPermissionHandler",
+    "PermissionHandler",
+    "PermissionRequest",
+    "PermissionResult",
+]

--- a/src/toolregistry/permissions/handler.py
+++ b/src/toolregistry/permissions/handler.py
@@ -1,0 +1,43 @@
+"""Permission handler protocols for tool authorization."""
+
+from typing import Protocol, runtime_checkable
+
+from .types import PermissionRequest, PermissionResult
+
+
+@runtime_checkable
+class PermissionHandler(Protocol):
+    """Synchronous handler invoked when a permission rule returns ASK.
+
+    Implementations decide whether to allow or deny a tool call,
+    typically by prompting the user or consulting an external policy
+    service.
+
+    Example:
+        ```python
+        class CLIPermissionHandler:
+            def handle(self, request: PermissionRequest) -> PermissionResult:
+                answer = input(f"Allow {request.tool_name}? [y/N] ")
+                return PermissionResult.ALLOW if answer.lower() == "y" else PermissionResult.DENY
+        ```
+    """
+
+    def handle(self, request: PermissionRequest) -> PermissionResult: ...
+
+
+@runtime_checkable
+class AsyncPermissionHandler(Protocol):
+    """Asynchronous handler invoked when a permission rule returns ASK.
+
+    Same contract as PermissionHandler but for async contexts.
+
+    Example:
+        ```python
+        class WebSocketPermissionHandler:
+            async def handle(self, request: PermissionRequest) -> PermissionResult:
+                response = await ws.ask_user(request.tool_name, request.reason)
+                return PermissionResult.ALLOW if response == "yes" else PermissionResult.DENY
+        ```
+    """
+
+    async def handle(self, request: PermissionRequest) -> PermissionResult: ...

--- a/src/toolregistry/permissions/types.py
+++ b/src/toolregistry/permissions/types.py
@@ -1,0 +1,40 @@
+"""Core types for the permission system."""
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ..tool import ToolMetadata
+
+
+class PermissionResult(str, Enum):
+    """Three-state permission decision.
+
+    Attributes:
+        ALLOW: The tool call is permitted.
+        DENY: The tool call is rejected.
+        ASK: The decision should be delegated to a PermissionHandler.
+    """
+
+    ALLOW = "allow"
+    DENY = "deny"
+    ASK = "ask"
+
+
+class PermissionRequest(BaseModel):
+    """Context passed to a PermissionHandler when a rule returns ASK.
+
+    Attributes:
+        tool_name: Name of the tool being invoked.
+        parameters: Arguments the caller intends to pass.
+        reason: Human-readable explanation of why confirmation is needed.
+        rule_name: Name of the rule that triggered the ASK result.
+        metadata: The tool's ToolMetadata for handler reference.
+    """
+
+    tool_name: str
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    reason: str = ""
+    rule_name: str = ""
+    metadata: ToolMetadata = Field(default_factory=ToolMetadata)

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -10,6 +10,11 @@ from collections.abc import Callable
 
 from .events import ChangeCallback, ChangeEvent, ChangeEventType
 from .executor import Executor
+from .permissions import (
+    AsyncPermissionHandler,
+    PermissionHandler,
+    PermissionResult,
+)
 from .tool import Tool
 from .types import (
     API_FORMATS,
@@ -72,6 +77,10 @@ class ToolRegistry:
         self._executor = Executor()
         self._change_callbacks: list[ChangeCallback] = []
         self._callback_lock = threading.Lock()
+        self._permission_handler: PermissionHandler | AsyncPermissionHandler | None = (
+            None
+        )
+        self._permission_fallback: PermissionResult = PermissionResult.DENY
         self._execution_log: ExecutionLog | None = None
         self._admin_server: AdminServer | None = None
 
@@ -958,6 +967,47 @@ class ToolRegistry:
         """
         tool = self.get_tool(tool_name)
         return tool.callable if tool else None
+
+    # ============== Permission Handler ==============
+
+    def set_permission_handler(
+        self,
+        handler: PermissionHandler | AsyncPermissionHandler,
+        *,
+        fallback: PermissionResult = PermissionResult.DENY,
+    ) -> None:
+        """Register a permission handler for tool authorization.
+
+        The handler is invoked when a permission rule returns
+        ``PermissionResult.ASK``.  If no handler is set and a rule
+        returns ASK, the *fallback* result is used instead.
+
+        Args:
+            handler: A sync or async handler implementing the
+                ``PermissionHandler`` / ``AsyncPermissionHandler``
+                protocol.
+            fallback: Result to use when the handler is absent or when
+                a rule returns ASK but no handler is registered.
+                Defaults to ``PermissionResult.DENY`` (safe by default).
+        """
+        self._permission_handler = handler
+        self._permission_fallback = fallback
+
+    def get_permission_handler(
+        self,
+    ) -> PermissionHandler | AsyncPermissionHandler | None:
+        """Return the currently registered permission handler, if any."""
+        return self._permission_handler
+
+    def remove_permission_handler(self) -> None:
+        """Remove the permission handler and reset fallback to DENY."""
+        self._permission_handler = None
+        self._permission_fallback = PermissionResult.DENY
+
+    @property
+    def permission_fallback(self) -> PermissionResult:
+        """The fallback result used when no handler is available for ASK."""
+        return self._permission_fallback
 
     # ============== Execution Logging ==============
 

--- a/tests/test_permission_handler.py
+++ b/tests/test_permission_handler.py
@@ -1,0 +1,165 @@
+"""Tests for the permission handler system (types, protocols, registry integration)."""
+
+import asyncio
+
+from toolregistry import (
+    PermissionHandler,
+    AsyncPermissionHandler,
+    PermissionRequest,
+    PermissionResult,
+    ToolMetadata,
+    ToolRegistry,
+    ToolTag,
+)
+from toolregistry.events import ChangeEventType
+
+
+# ---------------------------------------------------------------------------
+# PermissionResult
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionResult:
+    def test_values(self):
+        assert PermissionResult.ALLOW == "allow"
+        assert PermissionResult.DENY == "deny"
+        assert PermissionResult.ASK == "ask"
+
+    def test_members(self):
+        assert set(PermissionResult) == {
+            PermissionResult.ALLOW,
+            PermissionResult.DENY,
+            PermissionResult.ASK,
+        }
+
+
+# ---------------------------------------------------------------------------
+# PermissionRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionRequest:
+    def test_defaults(self):
+        req = PermissionRequest(tool_name="my_tool")
+        assert req.tool_name == "my_tool"
+        assert req.parameters == {}
+        assert req.reason == ""
+        assert req.rule_name == ""
+        assert isinstance(req.metadata, ToolMetadata)
+
+    def test_full_construction(self):
+        meta = ToolMetadata(tags={ToolTag.DESTRUCTIVE}, timeout=10.0)
+        req = PermissionRequest(
+            tool_name="delete_file",
+            parameters={"path": "/tmp/foo"},
+            reason="Tool is destructive",
+            rule_name="ask_destructive",
+            metadata=meta,
+        )
+        assert req.tool_name == "delete_file"
+        assert req.parameters == {"path": "/tmp/foo"}
+        assert req.reason == "Tool is destructive"
+        assert req.rule_name == "ask_destructive"
+        assert ToolTag.DESTRUCTIVE in req.metadata.tags
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class AlwaysAllowHandler:
+    def handle(self, request: PermissionRequest) -> PermissionResult:
+        return PermissionResult.ALLOW
+
+
+class AlwaysDenyHandler:
+    def handle(self, request: PermissionRequest) -> PermissionResult:
+        return PermissionResult.DENY
+
+
+class AsyncAlwaysAllowHandler:
+    async def handle(self, request: PermissionRequest) -> PermissionResult:
+        return PermissionResult.ALLOW
+
+
+class TestProtocolConformance:
+    def test_sync_handler_isinstance(self):
+        assert isinstance(AlwaysAllowHandler(), PermissionHandler)
+
+    def test_async_handler_isinstance(self):
+        assert isinstance(AsyncAlwaysAllowHandler(), AsyncPermissionHandler)
+
+    def test_sync_handler_invoke(self):
+        handler = AlwaysAllowHandler()
+        result = handler.handle(PermissionRequest(tool_name="test"))
+        assert result == PermissionResult.ALLOW
+
+    def test_async_handler_invoke(self):
+        handler = AsyncAlwaysAllowHandler()
+        result = asyncio.run(handler.handle(PermissionRequest(tool_name="test")))
+        assert result == PermissionResult.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry permission handler integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryPermissionHandler:
+    def test_no_handler_by_default(self):
+        reg = ToolRegistry()
+        assert reg.get_permission_handler() is None
+
+    def test_default_fallback_is_deny(self):
+        reg = ToolRegistry()
+        assert reg.permission_fallback == PermissionResult.DENY
+
+    def test_set_sync_handler(self):
+        reg = ToolRegistry()
+        handler = AlwaysAllowHandler()
+        reg.set_permission_handler(handler)
+        assert reg.get_permission_handler() is handler
+
+    def test_set_async_handler(self):
+        reg = ToolRegistry()
+        handler = AsyncAlwaysAllowHandler()
+        reg.set_permission_handler(handler)
+        assert reg.get_permission_handler() is handler
+
+    def test_set_handler_with_custom_fallback(self):
+        reg = ToolRegistry()
+        reg.set_permission_handler(
+            AlwaysDenyHandler(),
+            fallback=PermissionResult.ALLOW,
+        )
+        assert reg.permission_fallback == PermissionResult.ALLOW
+
+    def test_remove_handler(self):
+        reg = ToolRegistry()
+        reg.set_permission_handler(
+            AlwaysAllowHandler(),
+            fallback=PermissionResult.ALLOW,
+        )
+        reg.remove_permission_handler()
+        assert reg.get_permission_handler() is None
+        assert reg.permission_fallback == PermissionResult.DENY
+
+    def test_replace_handler(self):
+        reg = ToolRegistry()
+        reg.set_permission_handler(AlwaysAllowHandler())
+        reg.set_permission_handler(AlwaysDenyHandler())
+        assert isinstance(reg.get_permission_handler(), AlwaysDenyHandler)
+
+
+# ---------------------------------------------------------------------------
+# ChangeEventType new members
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionEvents:
+    def test_permission_denied_event_exists(self):
+        assert ChangeEventType.PERMISSION_DENIED == "permission_denied"
+
+    def test_permission_asked_event_exists(self):
+        assert ChangeEventType.PERMISSION_ASKED == "permission_asked"


### PR DESCRIPTION
Closes #81

## Summary
- Create `toolregistry/permissions/` module with `PermissionResult` enum (allow/deny/ask), `PermissionRequest` model, and sync/async `PermissionHandler` protocols
- Add `PERMISSION_DENIED` and `PERMISSION_ASKED` to `ChangeEventType`
- Add `set_permission_handler()`, `get_permission_handler()`, `remove_permission_handler()` and `permission_fallback` to `ToolRegistry`
- Configurable fallback (default DENY) when no handler is registered

## Dependencies
- Blocked by: #80 (merged via #84)