### PR TITLE
feat: add permission rule engine with policy integration

### DIFF
--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -11,8 +11,10 @@ from .events import ChangeCallback, ChangeEvent, ChangeEventType
 from .permissions import (
     AsyncPermissionHandler,
     PermissionHandler,
+    PermissionPolicy,
     PermissionRequest,
     PermissionResult,
+    PermissionRule,
 )
 from .tool import Tool, ToolMetadata, ToolTag
 from .tool_registry import ToolRegistry
@@ -29,8 +31,10 @@ __all__ = [
     "ExecutionLogEntry",
     "ExecutionStatus",
     "PermissionHandler",
+    "PermissionPolicy",
     "PermissionRequest",
     "PermissionResult",
+    "PermissionRule",
     "TokenAuth",
     "Tool",
     "ToolMetadata",

--- a/src/toolregistry/permissions/__init__.py
+++ b/src/toolregistry/permissions/__init__.py
@@ -1,11 +1,14 @@
 """Permission system for tool authorization."""
 
 from .handler import AsyncPermissionHandler, PermissionHandler
+from .policy import PermissionPolicy, PermissionRule
 from .types import PermissionRequest, PermissionResult
 
 __all__ = [
     "AsyncPermissionHandler",
     "PermissionHandler",
+    "PermissionPolicy",
     "PermissionRequest",
     "PermissionResult",
+    "PermissionRule",
 ]

--- a/src/toolregistry/permissions/builtin_rules.py
+++ b/src/toolregistry/permissions/builtin_rules.py
@@ -1,0 +1,40 @@
+"""Built-in permission rules for common tool classification patterns."""
+
+from ..tool import ToolTag
+from .policy import PermissionRule
+from .types import PermissionResult
+
+ALLOW_READONLY = PermissionRule(
+    name="allow_readonly",
+    match=lambda t, p: ToolTag.READ_ONLY in t.metadata.tags,
+    result=PermissionResult.ALLOW,
+    reason="Tool is read-only",
+)
+
+ASK_DESTRUCTIVE = PermissionRule(
+    name="ask_destructive",
+    match=lambda t, p: ToolTag.DESTRUCTIVE in t.metadata.tags,
+    result=PermissionResult.ASK,
+    reason="Tool is marked as destructive",
+)
+
+DENY_PRIVILEGED = PermissionRule(
+    name="deny_privileged",
+    match=lambda t, p: ToolTag.PRIVILEGED in t.metadata.tags,
+    result=PermissionResult.DENY,
+    reason="Tool requires elevated permissions",
+)
+
+ASK_NETWORK = PermissionRule(
+    name="ask_network",
+    match=lambda t, p: ToolTag.NETWORK in t.metadata.tags,
+    result=PermissionResult.ASK,
+    reason="Tool requires network access",
+)
+
+ASK_FILE_SYSTEM = PermissionRule(
+    name="ask_file_system",
+    match=lambda t, p: ToolTag.FILE_SYSTEM in t.metadata.tags,
+    result=PermissionResult.ASK,
+    reason="Tool accesses the file system",
+)

--- a/src/toolregistry/permissions/policy.py
+++ b/src/toolregistry/permissions/policy.py
@@ -1,0 +1,75 @@
+"""Permission policy: composable rules with first-match-wins evaluation."""
+
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import Callable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..tool import Tool
+from .handler import AsyncPermissionHandler, PermissionHandler
+from .types import PermissionResult
+
+
+class PermissionRule(BaseModel):
+    """A single permission rule that maps a match predicate to a result.
+
+    Rules are evaluated in order; the first rule whose ``match`` returns
+    ``True`` determines the outcome.
+
+    Attributes:
+        name: Human-readable identifier for this rule.
+        match: Predicate receiving ``(tool, parameters)`` and returning
+            ``True`` when this rule applies.
+        result: The permission decision when the rule matches.
+        reason: Explanation surfaced in ``PermissionRequest`` when the
+            result is ``ASK`` or ``DENY``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    match: Callable[[Tool, dict[str, Any]], bool] = Field(exclude=True)
+    result: PermissionResult
+    reason: str = ""
+
+
+class PermissionPolicy(BaseModel):
+    """An ordered collection of permission rules with a fallback.
+
+    Evaluation follows first-match-wins semantics: rules are checked in
+    list order and the first rule whose ``match`` returns ``True``
+    produces the final decision (subject to handler resolution for
+    ``ASK``).  If no rule matches, ``fallback`` is used.
+
+    Attributes:
+        rules: Ordered list of permission rules.
+        fallback: Result when no rule matches.  Defaults to ``DENY``
+            (safe by default).
+        handler: Optional handler invoked when a rule returns ``ASK``.
+            Takes precedence over the registry-level handler set via
+            ``set_permission_handler()``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    rules: list[PermissionRule] = Field(default_factory=list)
+    fallback: PermissionResult = PermissionResult.DENY
+    handler: PermissionHandler | AsyncPermissionHandler | None = Field(
+        default=None, exclude=True
+    )
+
+    def evaluate(
+        self, tool: Tool, parameters: dict[str, Any]
+    ) -> PermissionResult | PermissionRule:
+        """Evaluate rules against a tool call.
+
+        Returns:
+            The matched ``PermissionRule`` if a rule matches, or the
+            ``fallback`` ``PermissionResult`` if no rule matches.
+        """
+        for rule in self.rules:
+            if rule.match(tool, parameters):
+                return rule
+        return self.fallback

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -13,7 +13,10 @@ from .executor import Executor
 from .permissions import (
     AsyncPermissionHandler,
     PermissionHandler,
+    PermissionPolicy,
+    PermissionRequest,
     PermissionResult,
+    PermissionRule,
 )
 from .tool import Tool
 from .types import (
@@ -81,6 +84,7 @@ class ToolRegistry:
             None
         )
         self._permission_fallback: PermissionResult = PermissionResult.DENY
+        self._permission_policy: PermissionPolicy | None = None
         self._execution_log: ExecutionLog | None = None
         self._admin_server: AdminServer | None = None
 
@@ -183,12 +187,36 @@ class ToolRegistry:
                     )
                     self._execution_log.add(entry)
             else:
-                enabled_calls.append(tc)
-                call_start_times[tc.id] = time.perf_counter()
+                # Parse arguments early for permission check
                 try:
-                    call_arguments[tc.id] = json.loads(tc.arguments)
+                    args = json.loads(tc.arguments)
                 except (json.JSONDecodeError, TypeError):
-                    call_arguments[tc.id] = {}
+                    args = {}
+
+                # Evaluate permission policy
+                tool_obj = self.get_tool(tc.name)
+                if tool_obj is not None:
+                    decision = self._resolve_permission(tool_obj, args)
+                else:
+                    decision = PermissionResult.ALLOW
+
+                if decision == PermissionResult.DENY:
+                    tool_responses[tc.id] = (
+                        f"Error: Tool '{tc.name}' denied by permission policy."
+                    )
+                    if self._execution_log is not None:
+                        entry = ExecutionLogEntry.create(
+                            tool_name=tc.name,
+                            status=ExecutionStatus.ERROR,
+                            duration_ms=0.0,
+                            arguments=args,
+                            error="Denied by permission policy",
+                        )
+                        self._execution_log.add(entry)
+                else:
+                    enabled_calls.append(tc)
+                    call_start_times[tc.id] = time.perf_counter()
+                    call_arguments[tc.id] = args
 
         # Execute only enabled tool calls
         if enabled_calls:
@@ -1008,6 +1036,123 @@ class ToolRegistry:
     def permission_fallback(self) -> PermissionResult:
         """The fallback result used when no handler is available for ASK."""
         return self._permission_fallback
+
+    # ============== Permission Policy ==============
+
+    def set_permission_policy(self, policy: PermissionPolicy) -> None:
+        """Set a permission policy with composable rules.
+
+        The policy is evaluated on every tool call inside
+        ``execute_tool_calls()``.  Rules are checked in order
+        (first match wins).  When a rule returns ``ASK``, the
+        handler is resolved as: policy handler > registry-level
+        handler > fallback.
+
+        Args:
+            policy: The permission policy to apply.
+        """
+        self._permission_policy = policy
+
+    def get_permission_policy(self) -> PermissionPolicy | None:
+        """Return the currently set permission policy, if any."""
+        return self._permission_policy
+
+    def remove_permission_policy(self) -> None:
+        """Remove the permission policy.  No permission checks
+        will be performed on tool calls until a new policy is set."""
+        self._permission_policy = None
+
+    def _resolve_permission(
+        self,
+        tool: Tool,
+        parameters: dict[str, Any],
+    ) -> PermissionResult:
+        """Evaluate the permission policy for a single tool call.
+
+        Returns ``ALLOW`` when no policy is configured.
+
+        Resolution order for ASK results:
+            1. Policy-level handler
+            2. Registry-level handler (``set_permission_handler``)
+            3. Policy fallback / registry fallback
+        """
+        import asyncio
+
+        policy = self._permission_policy
+        if policy is None:
+            return PermissionResult.ALLOW
+
+        outcome = policy.evaluate(tool, parameters)
+
+        # No rule matched — use fallback
+        if isinstance(outcome, PermissionResult):
+            result = outcome
+            rule_name = ""
+            reason = ""
+        else:
+            # A PermissionRule matched
+            rule: PermissionRule = outcome
+            result = rule.result
+            rule_name = rule.name
+            reason = rule.reason
+
+        if result == PermissionResult.ALLOW:
+            return PermissionResult.ALLOW
+
+        if result == PermissionResult.DENY:
+            self._emit_change(
+                ChangeEvent(
+                    event_type=ChangeEventType.PERMISSION_DENIED,
+                    tool_name=tool.name,
+                    reason=reason,
+                    metadata={"rule_name": rule_name, "parameters": parameters},
+                )
+            )
+            return PermissionResult.DENY
+
+        # result == ASK — resolve via handler
+        handler = policy.handler or self._permission_handler
+        request = PermissionRequest(
+            tool_name=tool.name,
+            parameters=parameters,
+            reason=reason,
+            rule_name=rule_name,
+            metadata=tool.metadata,
+        )
+        self._emit_change(
+            ChangeEvent(
+                event_type=ChangeEventType.PERMISSION_ASKED,
+                tool_name=tool.name,
+                reason=reason,
+                metadata={"rule_name": rule_name, "parameters": parameters},
+            )
+        )
+
+        if handler is None:
+            fallback = (
+                policy.fallback
+                if policy.fallback != PermissionResult.ASK
+                else self._permission_fallback
+            )
+            return fallback
+
+        import inspect
+
+        if inspect.iscoroutinefunction(handler.handle):
+            try:
+                asyncio.get_running_loop()
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    decision = pool.submit(
+                        asyncio.run, handler.handle(request)
+                    ).result()
+            except RuntimeError:
+                decision = asyncio.run(handler.handle(request))
+        else:
+            decision = handler.handle(request)
+
+        return decision
 
     # ============== Execution Logging ==============
 

--- a/tests/test_permission_policy.py
+++ b/tests/test_permission_policy.py
@@ -1,0 +1,393 @@
+"""Tests for PermissionRule, PermissionPolicy, built-in rules,
+and execute_tool_calls integration."""
+
+import json
+
+from toolregistry import (
+    PermissionPolicy,
+    PermissionRequest,
+    PermissionResult,
+    PermissionRule,
+    Tool,
+    ToolMetadata,
+    ToolRegistry,
+    ToolTag,
+)
+from toolregistry.events import ChangeEvent, ChangeEventType
+from toolregistry.permissions.builtin_rules import (
+    ALLOW_READONLY,
+    ASK_DESTRUCTIVE,
+    ASK_FILE_SYSTEM,
+    ASK_NETWORK,
+    DENY_PRIVILEGED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name: str = "test_tool", tags: set[ToolTag] | None = None) -> Tool:
+    def _fn(x: int = 0) -> int:
+        return x
+
+    meta = ToolMetadata(tags=tags or set())
+    return Tool.from_function(_fn, name=name, metadata=meta)
+
+
+class _AllowHandler:
+    def handle(self, request: PermissionRequest) -> PermissionResult:
+        return PermissionResult.ALLOW
+
+
+class _DenyHandler:
+    def handle(self, request: PermissionRequest) -> PermissionResult:
+        return PermissionResult.DENY
+
+
+class _RecordingHandler:
+    """Records requests for assertion."""
+
+    def __init__(self, decision: PermissionResult = PermissionResult.ALLOW):
+        self.requests: list[PermissionRequest] = []
+        self.decision = decision
+
+    def handle(self, request: PermissionRequest) -> PermissionResult:
+        self.requests.append(request)
+        return self.decision
+
+
+# ---------------------------------------------------------------------------
+# PermissionRule
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionRule:
+    def test_basic_match(self):
+        rule = PermissionRule(
+            name="test",
+            match=lambda t, p: t.name == "target",
+            result=PermissionResult.DENY,
+        )
+        tool_match = _make_tool("target")
+        tool_other = _make_tool("other")
+        assert rule.match(tool_match, {}) is True
+        assert rule.match(tool_other, {}) is False
+
+    def test_match_with_parameters(self):
+        rule = PermissionRule(
+            name="block_rm",
+            match=lambda t, p: p.get("path", "").startswith("/etc"),
+            result=PermissionResult.DENY,
+            reason="Cannot touch /etc",
+        )
+        tool = _make_tool()
+        assert rule.match(tool, {"path": "/etc/passwd"}) is True
+        assert rule.match(tool, {"path": "/tmp/foo"}) is False
+
+    def test_match_with_tags(self):
+        rule = PermissionRule(
+            name="tag_check",
+            match=lambda t, p: ToolTag.DESTRUCTIVE in t.metadata.tags,
+            result=PermissionResult.ASK,
+        )
+        tool_d = _make_tool(tags={ToolTag.DESTRUCTIVE})
+        tool_r = _make_tool(tags={ToolTag.READ_ONLY})
+        assert rule.match(tool_d, {}) is True
+        assert rule.match(tool_r, {}) is False
+
+
+# ---------------------------------------------------------------------------
+# PermissionPolicy.evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionPolicy:
+    def test_first_match_wins(self):
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    name="allow_all",
+                    match=lambda t, p: True,
+                    result=PermissionResult.ALLOW,
+                ),
+                PermissionRule(
+                    name="deny_all",
+                    match=lambda t, p: True,
+                    result=PermissionResult.DENY,
+                ),
+            ],
+        )
+        outcome = policy.evaluate(_make_tool(), {})
+        assert isinstance(outcome, PermissionRule)
+        assert outcome.result == PermissionResult.ALLOW
+
+    def test_fallback_when_no_match(self):
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    name="never",
+                    match=lambda t, p: False,
+                    result=PermissionResult.DENY,
+                ),
+            ],
+            fallback=PermissionResult.ALLOW,
+        )
+        outcome = policy.evaluate(_make_tool(), {})
+        assert outcome == PermissionResult.ALLOW
+
+    def test_default_fallback_is_deny(self):
+        policy = PermissionPolicy(rules=[])
+        outcome = policy.evaluate(_make_tool(), {})
+        assert outcome == PermissionResult.DENY
+
+    def test_empty_rules_returns_fallback(self):
+        policy = PermissionPolicy(rules=[], fallback=PermissionResult.ALLOW)
+        outcome = policy.evaluate(_make_tool(), {})
+        assert outcome == PermissionResult.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# Built-in rules
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinRules:
+    def test_allow_readonly(self):
+        tool_ro = _make_tool(tags={ToolTag.READ_ONLY})
+        tool_other = _make_tool(tags={ToolTag.NETWORK})
+        assert ALLOW_READONLY.match(tool_ro, {}) is True
+        assert ALLOW_READONLY.result == PermissionResult.ALLOW
+        assert ALLOW_READONLY.match(tool_other, {}) is False
+
+    def test_ask_destructive(self):
+        tool = _make_tool(tags={ToolTag.DESTRUCTIVE})
+        assert ASK_DESTRUCTIVE.match(tool, {}) is True
+        assert ASK_DESTRUCTIVE.result == PermissionResult.ASK
+
+    def test_deny_privileged(self):
+        tool = _make_tool(tags={ToolTag.PRIVILEGED})
+        assert DENY_PRIVILEGED.match(tool, {}) is True
+        assert DENY_PRIVILEGED.result == PermissionResult.DENY
+
+    def test_ask_network(self):
+        tool = _make_tool(tags={ToolTag.NETWORK})
+        assert ASK_NETWORK.match(tool, {}) is True
+        assert ASK_NETWORK.result == PermissionResult.ASK
+
+    def test_ask_file_system(self):
+        tool = _make_tool(tags={ToolTag.FILE_SYSTEM})
+        assert ASK_FILE_SYSTEM.match(tool, {}) is True
+        assert ASK_FILE_SYSTEM.result == PermissionResult.ASK
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry integration
+# ---------------------------------------------------------------------------
+
+
+def _registry_with_tool(
+    tags: set[ToolTag] | None = None,
+) -> tuple[ToolRegistry, str]:
+    """Create a registry with a single tool, return (registry, tool_name)."""
+    reg = ToolRegistry()
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    tool = Tool.from_function(add, metadata=ToolMetadata(tags=tags or set()))
+    reg.register(tool)
+    return reg, tool.name
+
+
+def _make_tool_call(name: str, args: dict | None = None) -> dict:
+    return {
+        "id": f"call_{name}",
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(args or {}),
+        },
+    }
+
+
+class TestRegistryPolicyIntegration:
+    def test_no_policy_allows_all(self):
+        reg, name = _registry_with_tool()
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert str(results[f"call_{name}"]) == "3"
+
+    def test_deny_rule_blocks_execution(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[
+                    PermissionRule(
+                        name="deny_destructive",
+                        match=lambda t, p: ToolTag.DESTRUCTIVE in t.metadata.tags,
+                        result=PermissionResult.DENY,
+                        reason="Destructive tools blocked",
+                    ),
+                ],
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert "denied by permission policy" in results[f"call_{name}"].lower()
+
+    def test_allow_rule_permits_execution(self):
+        reg, name = _registry_with_tool(tags={ToolTag.READ_ONLY})
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[ALLOW_READONLY],
+                fallback=PermissionResult.DENY,
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert str(results[f"call_{name}"]) == "3"
+
+    def test_ask_with_handler_allow(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        handler = _RecordingHandler(PermissionResult.ALLOW)
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[ASK_DESTRUCTIVE],
+                handler=handler,
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert str(results[f"call_{name}"]) == "3"
+        assert len(handler.requests) == 1
+        assert handler.requests[0].tool_name == name
+
+    def test_ask_with_handler_deny(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        handler = _RecordingHandler(PermissionResult.DENY)
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[ASK_DESTRUCTIVE],
+                handler=handler,
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert "denied" in results[f"call_{name}"].lower()
+
+    def test_ask_no_handler_uses_fallback(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[ASK_DESTRUCTIVE],
+                fallback=PermissionResult.DENY,
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert "denied" in results[f"call_{name}"].lower()
+
+    def test_ask_uses_registry_handler_when_policy_has_none(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        handler = _RecordingHandler(PermissionResult.ALLOW)
+        reg.set_permission_handler(handler)
+        reg.set_permission_policy(PermissionPolicy(rules=[ASK_DESTRUCTIVE]))
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert str(results[f"call_{name}"]) == "3"
+        assert len(handler.requests) == 1
+
+    def test_policy_handler_takes_precedence(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        registry_handler = _RecordingHandler(PermissionResult.DENY)
+        policy_handler = _RecordingHandler(PermissionResult.ALLOW)
+        reg.set_permission_handler(registry_handler)
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[ASK_DESTRUCTIVE],
+                handler=policy_handler,
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        # Policy handler should be used, not registry handler
+        assert str(results[f"call_{name}"]) == "3"
+        assert len(policy_handler.requests) == 1
+        assert len(registry_handler.requests) == 0
+
+    def test_remove_policy(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[
+                    PermissionRule(
+                        name="deny_all",
+                        match=lambda t, p: True,
+                        result=PermissionResult.DENY,
+                    ),
+                ],
+            )
+        )
+        reg.remove_permission_policy()
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert str(results[f"call_{name}"]) == "3"
+
+    def test_fallback_no_match_no_handler(self):
+        reg, name = _registry_with_tool()
+        reg.set_permission_policy(
+            PermissionPolicy(
+                rules=[
+                    PermissionRule(
+                        name="never_matches",
+                        match=lambda t, p: False,
+                        result=PermissionResult.ALLOW,
+                    ),
+                ],
+                fallback=PermissionResult.DENY,
+            )
+        )
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        results = reg.execute_tool_calls([tc])
+        assert "denied" in results[f"call_{name}"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Events emitted during permission evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionEvents:
+    def test_deny_emits_permission_denied(self):
+        reg, name = _registry_with_tool(tags={ToolTag.PRIVILEGED})
+        events: list[ChangeEvent] = []
+        reg.on_change(events.append)
+        reg.set_permission_policy(PermissionPolicy(rules=[DENY_PRIVILEGED]))
+
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        reg.execute_tool_calls([tc])
+
+        denied = [
+            e for e in events if e.event_type == ChangeEventType.PERMISSION_DENIED
+        ]
+        assert len(denied) == 1
+        assert denied[0].tool_name == name
+
+    def test_ask_emits_permission_asked(self):
+        reg, name = _registry_with_tool(tags={ToolTag.DESTRUCTIVE})
+        events: list[ChangeEvent] = []
+        reg.on_change(events.append)
+        handler = _RecordingHandler(PermissionResult.ALLOW)
+        reg.set_permission_policy(
+            PermissionPolicy(rules=[ASK_DESTRUCTIVE], handler=handler)
+        )
+
+        tc = _make_tool_call(name, {"a": 1, "b": 2})
+        reg.execute_tool_calls([tc])
+
+        asked = [e for e in events if e.event_type == ChangeEventType.PERMISSION_ASKED]
+        assert len(asked) == 1
+        assert asked[0].tool_name == name


### PR DESCRIPTION
Closes #82

## Summary
- `PermissionRule` model with match predicate and result
- `PermissionPolicy` model with ordered rules, fallback, optional handler
- Built-in rules: `ALLOW_READONLY`, `ASK_DESTRUCTIVE`, `DENY_PRIVILEGED`, `ASK_NETWORK`, `ASK_FILE_SYSTEM`
- `set_permission_policy()`/`get`/`remove` on ToolRegistry
- Permission check integrated into `execute_tool_calls()` flow
- Handler resolution: policy handler > registry handler > fallback
- `PERMISSION_DENIED`/`PERMISSION_ASKED` events emitted

## Dependencies
- Blocked by: #80 (merged via #84), #81 (merged via #85)