### PR TITLE
feat: add locality field to ToolMetadata

### DIFF
--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -33,6 +33,10 @@ class ToolMetadata(BaseModel):
         is_async: Whether the tool requires async execution.
         is_concurrency_safe: Whether the tool can be run concurrently.
         timeout: Per-call timeout in seconds. None means no limit.
+        locality: Execution location requirement. ``"local"`` for tools that
+            must run on the user's machine (e.g. file-system, shell),
+            ``"remote"`` for tools best served by a remote server
+            (e.g. web search), ``"any"`` (default) for location-agnostic tools.
         tags: Predefined tags from ToolTag enum.
         custom_tags: User-defined free-form string tags.
         extra: Arbitrary key-value pairs for application-specific use.
@@ -41,6 +45,7 @@ class ToolMetadata(BaseModel):
     is_async: bool = False
     is_concurrency_safe: bool = True
     timeout: float | None = None
+    locality: Literal["local", "remote", "any"] = "any"
 
     tags: set[ToolTag] = Field(default_factory=set)
     custom_tags: set[str] = Field(default_factory=set)

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -32,6 +32,7 @@ class TestToolMetadata:
         assert m.is_async is False
         assert m.is_concurrency_safe is True
         assert m.timeout is None
+        assert m.locality == "any"
         assert m.tags == set()
         assert m.custom_tags == set()
         assert m.extra == {}
@@ -45,6 +46,17 @@ class TestToolMetadata:
 
     def test_all_tags_empty(self):
         assert ToolMetadata().all_tags == set()
+
+    def test_locality_values(self):
+        for val in ("local", "remote", "any"):
+            m = ToolMetadata(locality=val)
+            assert m.locality == val
+
+    def test_locality_invalid(self):
+        import pytest
+
+        with pytest.raises(Exception):
+            ToolMetadata(locality="cloud")
 
     def test_extra_arbitrary_data(self):
         m = ToolMetadata(extra={"author": "alice", "version": 2})
@@ -90,10 +102,12 @@ class TestToolMetadataIntegration:
             tags={ToolTag.NETWORK, ToolTag.SLOW},
             timeout=30.0,
             custom_tags={"api"},
+            locality="remote",
         )
         tool = Tool.from_function(_sync_func, metadata=meta)
         assert tool.metadata.tags == {ToolTag.NETWORK, ToolTag.SLOW}
         assert tool.metadata.timeout == 30.0
+        assert tool.metadata.locality == "remote"
         assert "api" in tool.metadata.custom_tags
         # is_async should be auto-detected (False), even if metadata said True
         assert tool.is_async is False


### PR DESCRIPTION
## Summary
- Adds `locality: Literal["local", "remote", "any"]` field to `ToolMetadata` for execution location routing
- Default value `"any"` preserves backward compatibility

## Test plan
- [x] `test_defaults` updated to assert `locality == "any"`
- [x] `test_locality_values` covers all 3 valid values
- [x] `test_locality_invalid` rejects invalid values
- [x] `test_from_function_custom_metadata` verifies locality passes through

Closes #89