### PR TITLE
feat: persistent connections for MCP and OpenAPI

### DIFF
--- a/src/toolregistry/_registration.py
+++ b/src/toolregistry/_registration.py
@@ -33,6 +33,8 @@ class RegistrationMixin:
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        self._mcp_integrations: list = []
+        self._openapi_integrations: list = []
 
     def register(
         self,
@@ -80,6 +82,7 @@ class RegistrationMixin:
         self,
         transport: str | dict[str, Any] | Path,
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ):
         """Register all tools from an MCP server (synchronous entry point).
 
@@ -95,6 +98,8 @@ class RegistrationMixin:
                 - If `True`, the namespace is derived from the server info name.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            persistent (bool): If True (default), keep the connection open
+                across tool calls. If False, create a new connection per call.
 
         Examples:
             ```python
@@ -113,12 +118,14 @@ class RegistrationMixin:
         """
         MCPIntegration = _import_mcp_integration()
         mcp = MCPIntegration(cast("ToolRegistry", self))
-        return mcp.register_mcp_tools(transport, with_namespace)
+        mcp.register_mcp_tools(transport, with_namespace, persistent)
+        self._mcp_integrations.append(mcp)
 
     async def register_from_mcp_async(
         self,
         transport: str | dict[str, Any] | Path,
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ):
         """Async implementation to register all tools from an MCP server.
 
@@ -134,6 +141,8 @@ class RegistrationMixin:
                 - If `True`, the namespace is derived from the server info name.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            persistent (bool): If True (default), keep the connection open
+                across tool calls. If False, create a new connection per call.
 
         Examples:
             ```python
@@ -152,13 +161,15 @@ class RegistrationMixin:
         """
         MCPIntegration = _import_mcp_integration()
         mcp = MCPIntegration(cast("ToolRegistry", self))
-        return await mcp.register_mcp_tools_async(transport, with_namespace)
+        await mcp.register_mcp_tools_async(transport, with_namespace, persistent)
+        self._mcp_integrations.append(mcp)
 
     def register_from_openapi(
         self,
         client: HttpxClientConfig,
         openapi_spec: dict[str, Any],
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ):
         """Registers tools from OpenAPI specification synchronously.
 
@@ -170,19 +181,23 @@ class RegistrationMixin:
                 - `True`: Namespace is derived from OpenAPI info.title.
                 - `str`: Use the provided string as namespace.
                 Defaults to False.
+            persistent (bool): If True (default), reuse a persistent HTTP
+                client for connection pooling.
 
         Returns:
             Any: Result of the OpenAPI tool registration process.
         """
         OpenAPIIntegration = _import_openapi_integration()
         openapi = OpenAPIIntegration(cast("ToolRegistry", self))
-        return openapi.register_openapi_tools(client, openapi_spec, with_namespace)
+        openapi.register_openapi_tools(client, openapi_spec, with_namespace, persistent)
+        self._openapi_integrations.append(openapi)
 
     async def register_from_openapi_async(
         self,
         client: HttpxClientConfig,
         openapi_spec: dict[str, Any],
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ):
         """Registers tools from OpenAPI specification asynchronously.
 
@@ -194,15 +209,18 @@ class RegistrationMixin:
                 - `True`: Namespace is derived from OpenAPI info.title.
                 - `str`: Use the provided string as namespace.
                 Defaults to False.
+            persistent (bool): If True (default), reuse a persistent HTTP
+                client for connection pooling.
 
         Returns:
             Any: Result of the OpenAPI tool registration process.
         """
         OpenAPIIntegration = _import_openapi_integration()
         openapi = OpenAPIIntegration(cast("ToolRegistry", self))
-        return await openapi.register_openapi_tools_async(
-            client, openapi_spec, with_namespace
+        await openapi.register_openapi_tools_async(
+            client, openapi_spec, with_namespace, persistent
         )
+        self._openapi_integrations.append(openapi)
 
     def register_from_langchain(
         self,

--- a/src/toolregistry/mcp/__init__.py
+++ b/src/toolregistry/mcp/__init__.py
@@ -1,6 +1,8 @@
+from .connection import MCPConnectionManager
 from .integration import MCPIntegration, MCPTool, MCPToolWrapper
 
 __all__ = [
+    "MCPConnectionManager",
     "MCPIntegration",
     "MCPTool",
     "MCPToolWrapper",

--- a/src/toolregistry/mcp/client.py
+++ b/src/toolregistry/mcp/client.py
@@ -128,6 +128,15 @@ class MCPClient:
         return await self._session.call_tool(name, arguments)
 
     @property
+    def is_connected(self) -> bool:
+        """Whether the client has an active session.
+
+        Returns:
+            True if connected with an active session, False otherwise.
+        """
+        return self._session is not None
+
+    @property
     def session(self) -> ClientSession | None:
         """Access the underlying ClientSession.
 

--- a/src/toolregistry/mcp/connection.py
+++ b/src/toolregistry/mcp/connection.py
@@ -1,0 +1,119 @@
+"""Persistent connection manager for MCP servers."""
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from mcp.types import CallToolResult
+
+from .client import MCPClient
+
+
+class MCPConnectionManager:
+    """Persistent connection manager for an MCP server.
+
+    All tools registered from the same server share this connection.
+    Supports lazy connect on first call and auto-reconnect on failure.
+
+    Args:
+        transport: MCP server source (URL, dict, or Path).
+        headers: Optional HTTP headers for SSE/streamable-http transports.
+        persistent: If True (default), keep the connection open across calls.
+            If False, create a new connection per call (original behavior).
+    """
+
+    def __init__(
+        self,
+        transport: str | dict | Path,
+        headers: dict[str, str] | None = None,
+        persistent: bool = True,
+    ) -> None:
+        self._transport = transport
+        self._headers = headers
+        self._persistent = persistent
+        self._client: MCPClient | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def transport(self) -> str | dict | Path:
+        """The transport source for the MCP server."""
+        return self._transport
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether an active session exists."""
+        return self._client is not None and self._client.is_connected
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        """Call a tool on the MCP server.
+
+        Uses persistent or per-request connection based on config.
+
+        Args:
+            name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            CallToolResult from the MCP server.
+        """
+        if not self._persistent:
+            return await self._call_per_request(name, arguments)
+        return await self._call_persistent(name, arguments)
+
+    async def list_tools(self):
+        """List available tools using a temporary connection.
+
+        Returns:
+            List of ToolSpec objects.
+        """
+        async with MCPClient(self._transport, self._headers) as client:
+            return await client.list_tools()
+
+    async def _ensure_connected(self) -> None:
+        """Connect if not already connected. Must be called under lock."""
+        if self._client is None or not self._client.is_connected:
+            await self._connect()
+
+    async def _connect(self) -> None:
+        """Establish (or re-establish) connection."""
+        if self._client is not None:
+            try:
+                await self._client.__aexit__(None, None, None)
+            except Exception:
+                pass
+        self._client = MCPClient(self._transport, self._headers)
+        await self._client.__aenter__()
+
+    async def _call_persistent(
+        self, name: str, arguments: dict[str, Any]
+    ) -> CallToolResult:
+        """Call tool using a persistent connection with auto-reconnect."""
+        async with self._lock:
+            await self._ensure_connected()
+        try:
+            assert self._client is not None
+            return await self._client.call_tool(name, arguments)
+        except Exception:
+            logger.warning(f"MCP call to '{name}' failed, reconnecting and retrying")
+            async with self._lock:
+                await self._connect()
+            assert self._client is not None
+            return await self._client.call_tool(name, arguments)
+
+    async def _call_per_request(
+        self, name: str, arguments: dict[str, Any]
+    ) -> CallToolResult:
+        """Call tool using a fresh connection (original behavior)."""
+        async with MCPClient(self._transport, self._headers) as client:
+            return await client.call_tool(name, arguments)
+
+    async def close(self) -> None:
+        """Close the persistent connection."""
+        async with self._lock:
+            if self._client is not None:
+                try:
+                    await self._client.__aexit__(None, None, None)
+                except Exception:
+                    pass
+                self._client = None

--- a/src/toolregistry/mcp/integration.py
+++ b/src/toolregistry/mcp/integration.py
@@ -19,32 +19,37 @@ from ..tool_registry import ToolRegistry
 from ..tool_wrapper import BaseToolWrapper
 from ..utils import normalize_tool_name
 from .client import MCPClient
+from .connection import MCPConnectionManager
 
 
 class MCPToolWrapper(BaseToolWrapper):
     """Wrapper class providing both async and sync versions of MCP tool calls.
 
     Attributes:
-        transport (Union[str, dict, Path]): MCP server source for communication.
         name (str): Name of the tool/operation.
         params (Optional[List[str]]): List of parameter names.
     """
 
     def __init__(
         self,
-        transport: str | dict | Path,
+        connection: MCPConnectionManager,
         name: str,
         params: list[str] | None,
     ) -> None:
         """Initialize MCP tool wrapper.
 
         Args:
-            transport (Union[str, dict, Path]): MCP server source for communication.
+            connection: Shared connection manager for the MCP server.
             name (str): Name of the tool/operation.
             params (Optional[List[str]]): List of parameter names.
         """
         super().__init__(name=name, params=params)
-        self.transport = transport
+        self._connection = connection
+
+    @property
+    def transport(self) -> str | dict | Path:
+        """Transport source, for backward compatibility."""
+        return self._connection.transport
 
     def call_sync(self, *args: Any, **kwargs: Any) -> Any:
         """Synchronous implementation of MCP tool call.
@@ -79,32 +84,30 @@ class MCPToolWrapper(BaseToolWrapper):
             Any: Result from tool execution.
 
         Raises:
-            ValueError: If URL or name not set.
+            ValueError: If name not set.
             Exception: If tool execution fails.
         """
         try:
-            if not self.transport or not self.name:
-                raise ValueError("Client and name must be set before calling")
+            if not self.name:
+                raise ValueError("Tool name must be set before calling")
 
-            async with MCPClient(self.transport) as client:
-                validated_params = {}
-                kwargs = self._process_args(*args, **kwargs)
-                if self.params:
-                    for param_name in self.params:
-                        if param_name in kwargs:
-                            validated_params[param_name] = kwargs[param_name]
+            validated_params: dict[str, Any] = {}
+            kwargs = self._process_args(*args, **kwargs)
+            if self.params:
+                for param_name in self.params:
+                    if param_name in kwargs:
+                        validated_params[param_name] = kwargs[param_name]
 
-                result = await client.call_tool(self.name, validated_params)
-                return self._post_process_result(result)
+            result = await self._connection.call_tool(self.name, validated_params)
+            return self._post_process_result(result)
 
         except Exception:
-            # record full exception stack
             import traceback
 
             logger.error(
                 f"Original Exception happens at {self.name}:\n{traceback.format_exc()}"
             )
-            raise  # throw to keep the original behavior
+            raise
 
     def _post_process_result(self, result: Any) -> Any:
         """Post-process the result from an MCP tool call.
@@ -183,14 +186,14 @@ class MCPTool(Tool):
     def from_tool_json(
         cls,
         tool_spec: ToolSpec,
-        transport: str | dict | Path,
+        connection: MCPConnectionManager,
         namespace: str | None = None,
     ) -> "MCPTool":
         """Create an MCPTool instance from a JSON representation.
 
         Args:
             tool_spec (ToolSpec): The JSON representation of the tool.
-            transport (Union[str, dict, Path]): MCP server source for communication.
+            connection: Shared connection manager for the MCP server.
             namespace (Optional[str]): An optional namespace to prefix the tool name.
                 If provided, the tool name will be formatted as "{namespace}.{name}".
 
@@ -204,7 +207,7 @@ class MCPTool(Tool):
         )
 
         wrapper = MCPToolWrapper(
-            transport=transport,
+            connection=connection,
             name=name,
             params=(
                 list(input_schema.get("properties", {}).keys()) if input_schema else []
@@ -234,11 +237,13 @@ class MCPIntegration:
 
     def __init__(self, registry: ToolRegistry):
         self.registry = registry
+        self._connections: list[MCPConnectionManager] = []
 
     async def register_mcp_tools_async(
         self,
         transport: str | dict[str, Any] | Path,
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ) -> None:
         """Async implementation to register all tools from an MCP server.
 
@@ -252,10 +257,19 @@ class MCPIntegration:
                 - If `True`, the namespace is derived from the server info name.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            persistent (bool): If True (default), keep the connection open
+                across tool calls. If False, create a new connection per call.
 
         Raises:
             RuntimeError: If connection to server fails.
         """
+        connection = MCPConnectionManager(
+            transport=transport,
+            persistent=persistent,
+        )
+        self._connections.append(connection)
+
+        # Use a temporary connection for tool discovery
         async with MCPClient(transport) as client:
             server_info: Implementation | None = client.server_info
 
@@ -269,21 +283,21 @@ class MCPIntegration:
             # Get available tools from server
             tools_response: list[ToolSpec] = await client.list_tools()
 
-            # Register each tool with a wrapper function
+            # Register each tool with the shared connection manager
             for tool_spec in tools_response:
-                mcp_sse_tool = MCPTool.from_tool_json(
+                mcp_tool = MCPTool.from_tool_json(
                     tool_spec=tool_spec,
-                    transport=transport,
+                    connection=connection,
                     namespace=namespace,
                 )
 
-                # Register the tool wrapper function
-                self.registry.register(mcp_sse_tool, namespace=namespace)
+                self.registry.register(mcp_tool, namespace=namespace)
 
     def register_mcp_tools(
         self,
         transport: str | dict[str, Any] | Path,
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ) -> None:
         """Register all tools from an MCP server (synchronous entry point).
 
@@ -297,11 +311,19 @@ class MCPIntegration:
                 - If `True`, the namespace is derived from the server info name.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            persistent (bool): If True (default), keep the connection open
+                across tool calls. If False, create a new connection per call.
         """
         loop = asyncio.new_event_loop()
         try:
             loop.run_until_complete(
-                self.register_mcp_tools_async(transport, with_namespace)
+                self.register_mcp_tools_async(transport, with_namespace, persistent)
             )
         finally:
             loop.close()
+
+    async def close(self) -> None:
+        """Close all persistent connections."""
+        for connection in self._connections:
+            await connection.close()
+        self._connections.clear()

--- a/src/toolregistry/openapi/integration.py
+++ b/src/toolregistry/openapi/integration.py
@@ -16,6 +16,7 @@ class OpenAPIToolWrapper(BaseToolWrapper):
         method (str): The HTTP method (e.g., "get", "post").
         path (str): The API endpoint path.
         params (Optional[List[str]]): List of parameter names for the API call.
+        persistent (bool): If True, reuse a persistent HTTP client.
     """
 
     def __init__(
@@ -25,11 +26,13 @@ class OpenAPIToolWrapper(BaseToolWrapper):
         method: str,
         path: str,
         params: list[str] | None,
+        persistent: bool = True,
     ) -> None:
         super().__init__(name=name, params=params)
         self.client_config = client_config
         self.method = method.lower()
         self.path = path
+        self._persistent = persistent
 
     def call_sync(self, *args: Any, **kwargs: Any) -> Any:
         """Synchronously call the API using the client configuration.
@@ -50,13 +53,21 @@ class OpenAPIToolWrapper(BaseToolWrapper):
         if not self.name:
             raise ValueError("Tool name must be set before calling")
 
-        with self.client_config.to_client(use_async=False) as client:
-            if self.method == "get":
-                response = client.get(self.path, params=kwargs)
-            else:
-                response = client.request(self.method, self.path, json=kwargs)
-            response.raise_for_status()
-            return response.json()
+        if self._persistent:
+            client = self.client_config.get_persistent_client(use_async=False)
+            return self._do_sync_request(client, kwargs)
+        else:
+            with self.client_config.to_client(use_async=False) as client:
+                return self._do_sync_request(client, kwargs)
+
+    def _do_sync_request(self, client: Any, kwargs: dict[str, Any]) -> Any:
+        """Execute the sync HTTP request."""
+        if self.method == "get":
+            response = client.get(self.path, params=kwargs)
+        else:
+            response = client.request(self.method, self.path, json=kwargs)
+        response.raise_for_status()
+        return response.json()
 
     async def call_async(self, *args: Any, **kwargs: Any) -> Any:
         """Asynchronously call the API using the client configuration.
@@ -77,15 +88,21 @@ class OpenAPIToolWrapper(BaseToolWrapper):
         if not self.name:
             raise ValueError("Tool name must be set before calling")
 
-        async with self.client_config.to_client(use_async=True) as async_client:
-            if self.method == "get":
-                response = await async_client.get(self.path, params=kwargs)
-            else:
-                response = await async_client.request(
-                    self.method, self.path, json=kwargs
-                )
-            response.raise_for_status()
-            return response.json()
+        if self._persistent:
+            client = self.client_config.get_persistent_client(use_async=True)
+            return await self._do_async_request(client, kwargs)
+        else:
+            async with self.client_config.to_client(use_async=True) as client:
+                return await self._do_async_request(client, kwargs)
+
+    async def _do_async_request(self, client: Any, kwargs: dict[str, Any]) -> Any:
+        """Execute the async HTTP request."""
+        if self.method == "get":
+            response = await client.get(self.path, params=kwargs)
+        else:
+            response = await client.request(self.method, self.path, json=kwargs)
+        response.raise_for_status()
+        return response.json()
 
 
 class OpenAPITool(Tool):
@@ -99,6 +116,7 @@ class OpenAPITool(Tool):
         method: str,
         spec: dict[str, Any],
         namespace: str | None = None,
+        persistent: bool = True,
     ) -> "OpenAPITool":
         """Create an OpenAPITool instance from an OpenAPI specification.
 
@@ -154,6 +172,7 @@ class OpenAPITool(Tool):
             method=method,
             path=path,
             params=param_names,
+            persistent=persistent,
         )
 
         tool = cls(
@@ -179,12 +198,14 @@ class OpenAPIIntegration:
 
     def __init__(self, registry: ToolRegistry) -> None:
         self.registry: ToolRegistry = registry
+        self._client_configs: list[HttpxClientConfig] = []
 
     async def register_openapi_tools_async(
         self,
         client_config: HttpxClientConfig,
         openapi_spec: dict[str, Any],
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ) -> None:
         """Asynchronously register all tools defined in an OpenAPI specification.
 
@@ -196,11 +217,15 @@ class OpenAPIIntegration:
                 - If `True`, the namespace is derived from the OpenAPI info.title.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            persistent (bool): If True (default), reuse a persistent HTTP
+                client for connection pooling.
 
         Returns:
             None
         """
         try:
+            self._client_configs.append(client_config)
+
             namespace = (
                 with_namespace
                 if isinstance(with_namespace, str)
@@ -221,6 +246,7 @@ class OpenAPIIntegration:
                         method=method,
                         spec=spec,
                         namespace=namespace,
+                        persistent=persistent,
                     )
                     self.registry.register(open_api_tool, namespace=namespace)
         except Exception as e:
@@ -231,6 +257,7 @@ class OpenAPIIntegration:
         client_config: HttpxClientConfig,
         openapi_spec: dict[str, Any],
         with_namespace: bool | str = False,
+        persistent: bool = True,
     ) -> None:
         """Synchronously register all tools defined in an OpenAPI specification.
 
@@ -242,6 +269,8 @@ class OpenAPIIntegration:
                 - If `True`, the namespace is derived from the OpenAPI info.title.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            persistent (bool): If True (default), reuse a persistent HTTP
+                client for connection pooling.
 
         Returns:
             None
@@ -252,9 +281,20 @@ class OpenAPIIntegration:
             asyncio.set_event_loop(loop)
             loop.run_until_complete(
                 self.register_openapi_tools_async(
-                    client_config, openapi_spec, with_namespace
+                    client_config, openapi_spec, with_namespace, persistent
                 )
             )
         finally:
             if loop is not None:
                 loop.close()
+
+    def close(self) -> None:
+        """Close all persistent HTTP clients (sync)."""
+        for config in self._client_configs:
+            config.close()
+
+    async def close_async(self) -> None:
+        """Close all persistent HTTP clients (async)."""
+        for config in self._client_configs:
+            await config.close_async()
+        self._client_configs.clear()

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import random
@@ -114,6 +115,40 @@ class ToolRegistry(
             Optional[Callable[..., Any]]: The function to call, or None if not found.
         """
         return self.get_callable(key)
+
+    # ============== Lifecycle ==============
+    async def close_async(self) -> None:
+        """Close all persistent connections (async).
+
+        Closes MCP and OpenAPI integrations that hold persistent
+        connections or HTTP clients.
+        """
+        for integration in self._mcp_integrations:
+            await integration.close()
+        for integration in self._openapi_integrations:
+            await integration.close_async()
+        self._mcp_integrations.clear()
+        self._openapi_integrations.clear()
+
+    def close(self) -> None:
+        """Close all persistent connections (sync)."""
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(self.close_async())
+        finally:
+            loop.close()
+
+    async def __aenter__(self) -> "ToolRegistry":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.close_async()
+
+    def __enter__(self) -> "ToolRegistry":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
 
     # ============== Execution ==============
     def set_execution_mode(self, mode: Literal["thread", "process"]) -> None:

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -28,6 +28,8 @@ class HttpxClientConfig:
         self.timeout = timeout
         self.auth = auth
         self.extra_options = extra_options
+        self._sync_client: httpx.Client | None = None
+        self._async_client: httpx.AsyncClient | None = None
 
     @overload
     def to_client(self, use_async: Literal[False]) -> httpx.Client: ...
@@ -45,6 +47,17 @@ class HttpxClientConfig:
         Returns:
             Union[httpx.Client, httpx.AsyncClient]: An instance of httpx.Client or httpx.AsyncClient.
         """
+        return self._make_client(use_async=use_async)
+
+    def _make_client(self, use_async: bool = False):
+        """Create a new httpx client instance.
+
+        Args:
+            use_async (bool): Whether to create an asynchronous client.
+
+        Returns:
+            Union[httpx.Client, httpx.AsyncClient]: A new client instance.
+        """
         client_class = httpx.AsyncClient if use_async else httpx.Client
         return client_class(
             base_url=self.base_url,
@@ -53,6 +66,56 @@ class HttpxClientConfig:
             auth=self.auth,
             **self.extra_options,
         )
+
+    @overload
+    def get_persistent_client(
+        self, use_async: Literal[False] = False
+    ) -> httpx.Client: ...
+
+    @overload
+    def get_persistent_client(
+        self, use_async: Literal[True] = ...
+    ) -> httpx.AsyncClient: ...
+
+    def get_persistent_client(self, use_async: bool = False):
+        """Get or create a persistent client instance.
+
+        Unlike ``to_client()``, this method reuses the same client across
+        multiple calls, enabling HTTP connection pooling.
+
+        Args:
+            use_async (bool): Whether to return an async client.
+
+        Returns:
+            Union[httpx.Client, httpx.AsyncClient]: A persistent client instance.
+        """
+        if use_async:
+            if self._async_client is None:
+                self._async_client = self._make_client(use_async=True)
+            return self._async_client
+        else:
+            if self._sync_client is None:
+                self._sync_client = self._make_client(use_async=False)
+            return self._sync_client
+
+    def close(self):
+        """Close persistent clients (sync).
+
+        Only closes the sync client. Use ``close_async()`` to properly
+        close the async client.
+        """
+        if self._sync_client:
+            self._sync_client.close()
+            self._sync_client = None
+
+    async def close_async(self):
+        """Close all persistent clients."""
+        if self._async_client:
+            await self._async_client.aclose()
+            self._async_client = None
+        if self._sync_client:
+            self._sync_client.close()
+            self._sync_client = None
 
 
 def normalize_tool_name(name: str) -> str:

--- a/tests/test_persistent_connection.py
+++ b/tests/test_persistent_connection.py
@@ -1,0 +1,295 @@
+"""Tests for persistent connection support in MCP and OpenAPI integrations.
+
+Covers MCPConnectionManager, HttpxClientConfig persistent clients,
+ToolRegistry lifecycle (close / context manager), and backward compat.
+"""
+
+import asyncio
+import json
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from toolregistry import ToolRegistry
+from toolregistry.mcp.client import MCPClient
+from toolregistry.mcp.connection import MCPConnectionManager
+from toolregistry.utils import HttpxClientConfig
+
+_SERVER_SCRIPT = str(Path(__file__).parent / "_mcp_test_server.py")
+
+
+def _get_free_port() -> int:
+    """Find and return a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _wait_for_port(port: int, timeout: float = 30.0) -> None:
+    """Block until *port* on localhost accepts connections."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.5)
+            s.connect(("127.0.0.1", port))
+            s.close()
+            await asyncio.sleep(0.5)
+            return
+        except (ConnectionRefusedError, OSError):
+            await asyncio.sleep(0.5)
+    raise TimeoutError(f"Port {port} did not open within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# MCPConnectionManager unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCPConnectionManager:
+    """Tests for MCPConnectionManager."""
+
+    def test_initial_state(self):
+        mgr = MCPConnectionManager("http://localhost:9999/mcp")
+        assert not mgr.is_connected
+        assert mgr.transport == "http://localhost:9999/mcp"
+
+    def test_persistent_default_true(self):
+        mgr = MCPConnectionManager("http://localhost:9999/mcp")
+        assert mgr._persistent is True
+
+    def test_persistent_false(self):
+        mgr = MCPConnectionManager("http://localhost:9999/mcp", persistent=False)
+        assert mgr._persistent is False
+
+    @pytest.mark.asyncio
+    async def test_close_when_not_connected(self):
+        """close() should be safe to call when not connected."""
+        mgr = MCPConnectionManager("http://localhost:9999/mcp")
+        await mgr.close()
+        assert not mgr.is_connected
+
+
+class TestMCPConnectionManagerStdio:
+    """Integration tests for MCPConnectionManager with stdio transport."""
+
+    @pytest.mark.asyncio
+    async def test_persistent_multiple_calls(self):
+        """Multiple tool calls should reuse the same persistent connection."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        mgr = MCPConnectionManager(config, persistent=True)
+        try:
+            result1 = await mgr.call_tool("add", {"a": 1, "b": 2})
+            assert mgr.is_connected
+            result2 = await mgr.call_tool("add", {"a": 3, "b": 4})
+            assert mgr.is_connected
+
+            text1 = result1.content[0].text
+            text2 = result2.content[0].text
+            assert json.loads(text1) == {"result": 3}
+            assert json.loads(text2) == {"result": 7}
+        finally:
+            await mgr.close()
+
+        assert not mgr.is_connected
+
+    @pytest.mark.asyncio
+    async def test_non_persistent_creates_new_connection(self):
+        """With persistent=False, each call uses a fresh connection."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        mgr = MCPConnectionManager(config, persistent=False)
+        try:
+            result = await mgr.call_tool("echo", {"message": "test"})
+            assert result.content[0].text == "test"
+            # Non-persistent manager should not hold a connection
+            assert not mgr.is_connected
+        finally:
+            await mgr.close()
+
+    @pytest.mark.asyncio
+    async def test_list_tools(self):
+        """list_tools() uses a temporary connection for discovery."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        mgr = MCPConnectionManager(config)
+        tools = await mgr.list_tools()
+        names = {t.name for t in tools}
+        assert "add" in names
+        assert "echo" in names
+        # list_tools uses temp connection, persistent state unchanged
+        assert not mgr.is_connected
+        await mgr.close()
+
+
+class TestMCPConnectionManagerHttp:
+    """Integration tests for MCPConnectionManager with HTTP transport."""
+
+    @pytest.fixture()
+    def http_server(self):
+        port = _get_free_port()
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                _SERVER_SCRIPT,
+                "--transport",
+                "streamable-http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        yield port, proc
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_persistent_connection_http(self, http_server):
+        port, _ = http_server
+        await _wait_for_port(port)
+        mgr = MCPConnectionManager(f"http://127.0.0.1:{port}/mcp", persistent=True)
+        try:
+            r1 = await mgr.call_tool("add", {"a": 10, "b": 20})
+            assert mgr.is_connected
+            r2 = await mgr.call_tool("echo", {"message": "persistent"})
+            assert mgr.is_connected
+
+            assert json.loads(r1.content[0].text) == {"result": 30}
+            assert r2.content[0].text == "persistent"
+        finally:
+            await mgr.close()
+
+
+# ---------------------------------------------------------------------------
+# HttpxClientConfig persistent client tests
+# ---------------------------------------------------------------------------
+
+
+class TestHttpxClientConfigPersistent:
+    """Tests for HttpxClientConfig persistent client methods."""
+
+    def test_get_persistent_client_sync(self):
+        config = HttpxClientConfig(base_url="http://localhost:9999")
+        client1 = config.get_persistent_client(use_async=False)
+        client2 = config.get_persistent_client(use_async=False)
+        assert client1 is client2
+        config.close()
+
+    @pytest.mark.asyncio
+    async def test_get_persistent_client_async(self):
+        config = HttpxClientConfig(base_url="http://localhost:9999")
+        client1 = config.get_persistent_client(use_async=True)
+        client2 = config.get_persistent_client(use_async=True)
+        assert client1 is client2
+        await config.close_async()
+
+    def test_close_sync(self):
+        config = HttpxClientConfig(base_url="http://localhost:9999")
+        _ = config.get_persistent_client(use_async=False)
+        assert config._sync_client is not None
+        config.close()
+        assert config._sync_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        config = HttpxClientConfig(base_url="http://localhost:9999")
+        _ = config.get_persistent_client(use_async=True)
+        _ = config.get_persistent_client(use_async=False)
+        assert config._async_client is not None
+        assert config._sync_client is not None
+        await config.close_async()
+        assert config._async_client is None
+        assert config._sync_client is None
+
+    def test_to_client_still_works(self):
+        """to_client() should still create fresh clients (backward compat)."""
+        config = HttpxClientConfig(base_url="http://localhost:9999")
+        client1 = config.to_client(use_async=False)
+        client2 = config.to_client(use_async=False)
+        assert client1 is not client2
+        client1.close()
+        client2.close()
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistryLifecycle:
+    """Tests for ToolRegistry close() and context manager."""
+
+    def test_sync_context_manager(self):
+        with ToolRegistry() as reg:
+            assert isinstance(reg, ToolRegistry)
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self):
+        async with ToolRegistry() as reg:
+            assert isinstance(reg, ToolRegistry)
+
+    def test_close_without_integrations(self):
+        """close() should be safe even with no integrations."""
+        reg = ToolRegistry()
+        reg.close()
+
+    @pytest.mark.asyncio
+    async def test_close_async_without_integrations(self):
+        reg = ToolRegistry()
+        await reg.close_async()
+
+
+class TestToolRegistryMCPIntegration:
+    """Integration test: register_from_mcp with persistent connections."""
+
+    @pytest.mark.asyncio
+    async def test_register_and_call_persistent(self):
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(config, persistent=True)
+            assert "add" in reg
+            assert "echo" in reg
+            assert len(reg._mcp_integrations) == 1
+
+    @pytest.mark.asyncio
+    async def test_register_non_persistent(self):
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(config, persistent=False)
+            assert "add" in reg
+
+    @pytest.mark.asyncio
+    async def test_close_cleans_up_integrations(self):
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        reg = ToolRegistry()
+        await reg.register_from_mcp_async(config, persistent=True)
+        assert len(reg._mcp_integrations) == 1
+        await reg.close_async()
+        assert len(reg._mcp_integrations) == 0


### PR DESCRIPTION
## Summary

- **MCP**: Add `MCPConnectionManager` (`mcp/connection.py`) — all tools from the same server share one persistent connection with lazy connect + auto-reconnect via `asyncio.Lock`
- **OpenAPI**: `HttpxClientConfig` gains `get_persistent_client()` for HTTP connection pooling; `OpenAPIToolWrapper` reuses the client across calls
- **Lifecycle**: `ToolRegistry` now supports `close()` / `close_async()` and context managers (`with` / `async with`) for proper cleanup
- All registration methods (`register_from_mcp`, `register_from_openapi` + async variants) accept `persistent` parameter (default `True`)
- Fully backward compatible — existing API unchanged, `persistent=False` falls back to per-call behavior

Closes #90, closes #73

## Files changed

| File | Change |
|------|--------|
| `mcp/connection.py` | **New** — `MCPConnectionManager` |
| `mcp/client.py` | Add `is_connected` property |
| `mcp/integration.py` | `MCPToolWrapper` uses `MCPConnectionManager`; `MCPIntegration` gains `persistent` + `close()` |
| `mcp/__init__.py` | Export `MCPConnectionManager` |
| `utils.py` | `HttpxClientConfig` adds `get_persistent_client()`, `close()`, `close_async()` |
| `openapi/integration.py` | `OpenAPIToolWrapper` adds `persistent` flag; `OpenAPIIntegration` gains `close()`/`close_async()` |
| `_registration.py` | `persistent` param on all registration methods; store integration instances |
| `tool_registry.py` | `close()`, `close_async()`, `__enter__`/`__exit__`/`__aenter__`/`__aexit__` |
| `tests/test_persistent_connection.py` | **New** — 20 test cases |

## Test plan

- [x] 20 new persistent connection tests pass (MCPConnectionManager unit + integration, HttpxClientConfig, ToolRegistry lifecycle)
- [x] 25 existing MCP client tests pass (backward compat)
- [x] Full suite: 352/352 tests pass
- [x] ruff check + format clean