### PR TITLE
feat: result size management with truncation and persistence

### DIFF
--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -37,6 +37,11 @@ class ToolMetadata(BaseModel):
             must run on the user's machine (e.g. file-system, shell),
             ``"remote"`` for tools best served by a remote server
             (e.g. web search), ``"any"`` (default) for location-agnostic tools.
+        max_result_size: Maximum result size in characters. When a tool's
+            result exceeds this limit, it is automatically truncated and
+            the full output is persisted to a temporary file. Only
+            effective when executed through
+            ``ToolRegistry.execute_tool_calls()``. None means no limit.
         tags: Predefined tags from ToolTag enum.
         custom_tags: User-defined free-form string tags.
         extra: Arbitrary key-value pairs for application-specific use.
@@ -46,6 +51,7 @@ class ToolMetadata(BaseModel):
     is_concurrency_safe: bool = True
     timeout: float | None = None
     locality: Literal["local", "remote", "any"] = "any"
+    max_result_size: int | None = None
 
     tags: set[ToolTag] = Field(default_factory=set)
     custom_tags: set[str] = Field(default_factory=set)
@@ -322,6 +328,12 @@ class Tool(BaseModel):
 
         Raises:
             Exception: On execution failure.
+
+        Note:
+            Result size truncation (via ``max_result_size``) is only applied
+            when tools are executed through
+            ``ToolRegistry.execute_tool_calls()``. Direct calls to ``run()``
+            return raw results without truncation.
         """
         try:
             validated_params = self._validate_parameters(parameters)
@@ -341,6 +353,12 @@ class Tool(BaseModel):
         Raises:
             NotImplementedError: If async execution unsupported.
             Exception: On execution failure.
+
+        Note:
+            Result size truncation (via ``max_result_size``) is only applied
+            when tools are executed through
+            ``ToolRegistry.execute_tool_calls()``. Direct calls to ``arun()``
+            return raw results without truncation.
         """
         try:
             validated_params = self._validate_parameters(parameters)

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 
 from .executor import ProcessPoolBackend, ThreadBackend
 from .tool import ToolTag
+from .truncation import truncate_result
 from .permissions import (
     PermissionResult,
 )
@@ -54,17 +55,23 @@ class ToolRegistry(
     """
 
     # ============== dunder methods ==============
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        default_max_result_size: int | None = None,
+    ) -> None:
         """Initialize an empty ToolRegistry.
 
         This method initializes an empty ToolRegistry with a name and internal
         structures for storing tools and sub-registries.
 
         Args:
-            name (Optional[str]): Name of the tool registry. Defaults to a random "reg_<4-char>" string. For instance, "reg_1a3c".
-
-        Attributes:
-            name (str): Name of the tool registry.
+            name: Name of the tool registry. Defaults to a random
+                "reg_<4-char>" string. For instance, "reg_1a3c".
+            default_max_result_size: Default maximum result size in characters
+                for all tools. Individual tools can override this via
+                ``ToolMetadata.max_result_size``. None means no limit.
 
         Notes:
             This class uses private attributes `_tools` and `_sub_registries` internally
@@ -78,6 +85,7 @@ class ToolRegistry(
         self._thread_backend = ThreadBackend()
         self._process_backend = ProcessPoolBackend()
         self._execution_mode: Literal["process", "thread"] = "process"
+        self._default_max_result_size = default_max_result_size
 
     def __contains__(self, name: str) -> bool:
         """Check if a tool with the given name is registered.
@@ -152,6 +160,36 @@ class ToolRegistry(
         self.close()
 
     # ============== Execution ==============
+    def _finalize_result(self, result: Any, tool_name: str) -> str:
+        """Convert a raw tool result to a string, applying truncation if configured.
+
+        Args:
+            result: Raw result from tool execution.
+            tool_name: Name of the tool (used to look up ``max_result_size``).
+
+        Returns:
+            The result as a string, possibly truncated.
+        """
+        # Serialize to string
+        try:
+            json.dumps(result)
+        except (TypeError, ValueError):
+            result = str(result)
+        result_str: str = result if isinstance(result, str) else json.dumps(result)
+
+        # Determine effective max size
+        tool_obj = self._tools.get(tool_name)
+        max_size = None
+        if tool_obj and tool_obj.metadata.max_result_size is not None:
+            max_size = tool_obj.metadata.max_result_size
+        elif self._default_max_result_size is not None:
+            max_size = self._default_max_result_size
+
+        if max_size is not None:
+            tr = truncate_result(result_str, max_size, tool_name=tool_name)
+            return str(tr)
+        return result_str
+
     def set_execution_mode(self, mode: Literal["thread", "process"]) -> None:
         """Set the execution mode for parallel tasks.
 
@@ -312,12 +350,8 @@ class ToolRegistry(
                     # Sequential execution: wait for result immediately
                     try:
                         result = handle.result()
-                        try:
-                            json.dumps(result)
-                        except (TypeError, ValueError):
-                            result = str(result)
-                        tool_responses[tc.id] = (
-                            result if isinstance(result, str) else json.dumps(result)
+                        tool_responses[tc.id] = self._finalize_result(
+                            result, function_name
                         )
                     except TimeoutError:
                         tool_responses[tc.id] = (
@@ -334,13 +368,7 @@ class ToolRegistry(
             for tc, handle in handles:
                 try:
                     result = handle.result()
-                    try:
-                        json.dumps(result)
-                    except (TypeError, ValueError):
-                        result = str(result)
-                    tool_responses[tc.id] = (
-                        result if isinstance(result, str) else json.dumps(result)
-                    )
+                    tool_responses[tc.id] = self._finalize_result(result, tc.name)
                 except TimeoutError:
                     tool_responses[tc.id] = f"Error: Tool '{tc.name}' timed out"
                 except Exception as e:

--- a/src/toolregistry/truncation.py
+++ b/src/toolregistry/truncation.py
@@ -1,0 +1,131 @@
+"""Result size management: truncation and persistence for large tool outputs."""
+
+import hashlib
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from enum import Enum
+
+
+class TruncationStrategy(str, Enum):
+    """Strategy for truncating large results.
+
+    Attributes:
+        HEAD: Keep only the first ``max_size`` characters.
+        HEAD_TAIL: Keep the first and last portions, with a marker in the
+            middle indicating how many characters were omitted.
+    """
+
+    HEAD = "head"
+    HEAD_TAIL = "head_tail"
+
+
+@dataclass
+class TruncatedResult:
+    """Container for a possibly-truncated tool result.
+
+    Attributes:
+        content: The (possibly truncated) text content.
+        original_size: Original result size in characters.
+        truncated: Whether truncation was applied.
+        full_path: Path to the persisted full result, or None.
+    """
+
+    content: str
+    original_size: int
+    truncated: bool = False
+    full_path: str | None = None
+
+    def __str__(self) -> str:
+        if not self.truncated:
+            return self.content
+        header_parts = [
+            f"Truncated: {self.original_size} chars -> {len(self.content)} chars"
+        ]
+        if self.full_path:
+            header_parts.append(f"full output: {self.full_path}")
+        header = " | ".join(header_parts)
+        return f"[{header}]\n{self.content}"
+
+
+def _get_results_dir() -> str:
+    """Return (and create) the directory for persisted full results."""
+    results_dir = os.path.join(tempfile.gettempdir(), "toolregistry_results")
+    os.makedirs(results_dir, exist_ok=True)
+    return results_dir
+
+
+def _persist_full_result(result_str: str, tool_name: str) -> str:
+    """Write the full result to a temporary file and return its path.
+
+    Args:
+        result_str: The complete result string.
+        tool_name: Name of the tool (used in the filename).
+
+    Returns:
+        Absolute path to the persisted file.
+    """
+    results_dir = _get_results_dir()
+    content_hash = hashlib.sha256(result_str.encode()).hexdigest()[:12]
+    timestamp = int(time.time())
+    safe_name = tool_name.replace("/", "_").replace("\\", "_")
+    filename = f"{safe_name}_{timestamp}_{content_hash}.txt"
+    filepath = os.path.join(results_dir, filename)
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(result_str)
+    return filepath
+
+
+def truncate_result(
+    result_str: str,
+    max_size: int,
+    *,
+    strategy: TruncationStrategy = TruncationStrategy.HEAD_TAIL,
+    tool_name: str = "",
+    persist: bool = True,
+) -> TruncatedResult:
+    """Truncate a string result if it exceeds ``max_size`` characters.
+
+    Args:
+        result_str: The full result string.
+        max_size: Maximum allowed size in characters.
+        strategy: Truncation strategy to apply.
+        tool_name: Tool name, used for the persisted filename.
+        persist: Whether to write the full result to a temporary file.
+
+    Returns:
+        A ``TruncatedResult`` with the (possibly truncated) content and
+        metadata about the operation.
+    """
+    if len(result_str) <= max_size:
+        return TruncatedResult(
+            content=result_str,
+            original_size=len(result_str),
+            truncated=False,
+        )
+
+    full_path = None
+    if persist:
+        full_path = _persist_full_result(result_str, tool_name)
+
+    if strategy == TruncationStrategy.HEAD:
+        content = result_str[:max_size]
+    else:
+        # HEAD_TAIL: split budget between head and tail with a marker
+        marker = f"\n... (truncated {len(result_str) - max_size} chars) ...\n"
+        available = max_size - len(marker)
+        if available <= 0:
+            # max_size too small for marker; fall back to pure head
+            content = result_str[:max_size]
+        else:
+            head_size = available // 2
+            tail_size = available - head_size
+            content = result_str[:head_size] + marker + result_str[-tail_size:]
+
+    return TruncatedResult(
+        content=content,
+        original_size=len(result_str),
+        truncated=True,
+        full_path=full_path,
+    )

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -494,3 +494,100 @@ class TestToolRegistryTagFiltering:
 
         assert len(result) == 1
         assert result[0]["function"]["name"] == "compute"
+
+
+class TestToolRegistryResultTruncation:
+    """Test cases for result truncation in execute_tool_calls."""
+
+    def test_execute_tool_calls_truncates_large_result(self):
+        """Test that large results are truncated when max_result_size is set."""
+        registry = ToolRegistry(name="trunc_test")
+
+        def big_output(n: int) -> str:
+            """Return a large string."""
+            return "x" * n
+
+        registry.register(
+            Tool.from_function(big_output, metadata=ToolMetadata(max_result_size=50))
+        )
+
+        tool_calls = [
+            ChatCompletionMessageFunctionToolCall(
+                id="call_big",
+                function=Function(name="big_output", arguments='{"n": 500}'),
+            )
+        ]
+        results = registry.execute_tool_calls(tool_calls)
+
+        assert "call_big" in results
+        assert "Truncated" in results["call_big"]
+        assert "500 chars" in results["call_big"]
+        # The truncated content should be much shorter than 500
+        assert len(results["call_big"]) < 500
+
+    def test_execute_tool_calls_no_truncation_when_under_limit(self):
+        """Test that small results are not truncated."""
+        registry = ToolRegistry(name="no_trunc_test")
+
+        def small_output() -> str:
+            """Return a small string."""
+            return "hello"
+
+        registry.register(
+            Tool.from_function(
+                small_output, metadata=ToolMetadata(max_result_size=1000)
+            )
+        )
+
+        tool_calls = [
+            ChatCompletionMessageFunctionToolCall(
+                id="call_small",
+                function=Function(name="small_output", arguments="{}"),
+            )
+        ]
+        results = registry.execute_tool_calls(tool_calls)
+
+        assert results["call_small"] == "hello"
+
+    def test_execute_tool_calls_default_max_result_size(self):
+        """Test that registry-level default_max_result_size is applied."""
+        registry = ToolRegistry(name="default_trunc", default_max_result_size=30)
+
+        def verbose_output() -> str:
+            """Return a verbose string."""
+            return "a" * 200
+
+        registry.register(verbose_output)
+
+        tool_calls = [
+            ChatCompletionMessageFunctionToolCall(
+                id="call_verbose",
+                function=Function(name="verbose_output", arguments="{}"),
+            )
+        ]
+        results = registry.execute_tool_calls(tool_calls)
+
+        assert "Truncated" in results["call_verbose"]
+
+    def test_execute_tool_calls_tool_level_overrides_default(self):
+        """Test that tool-level max_result_size takes precedence over default."""
+        registry = ToolRegistry(name="override_test", default_max_result_size=10)
+
+        def output() -> str:
+            """Return a medium string."""
+            return "b" * 50
+
+        registry.register(
+            Tool.from_function(output, metadata=ToolMetadata(max_result_size=1000))
+        )
+
+        tool_calls = [
+            ChatCompletionMessageFunctionToolCall(
+                id="call_override",
+                function=Function(name="output", arguments="{}"),
+            )
+        ]
+        results = registry.execute_tool_calls(tool_calls)
+
+        # 50 chars < 1000 limit, so no truncation
+        assert "Truncated" not in results["call_override"]

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,151 @@
+"""Unit tests for the truncation module."""
+
+import os
+
+from toolregistry.truncation import (
+    TruncatedResult,
+    TruncationStrategy,
+    truncate_result,
+)
+
+
+class TestTruncatedResult:
+    """Test cases for the TruncatedResult dataclass."""
+
+    def test_str_not_truncated(self):
+        """Test __str__ for a non-truncated result."""
+        tr = TruncatedResult(content="hello", original_size=5, truncated=False)
+
+        assert str(tr) == "hello"
+
+    def test_str_truncated_with_path(self):
+        """Test __str__ for a truncated result with a persisted file."""
+        tr = TruncatedResult(
+            content="hel...",
+            original_size=100,
+            truncated=True,
+            full_path="/tmp/toolregistry_results/test.txt",
+        )
+        result = str(tr)
+
+        assert "Truncated: 100 chars -> 6 chars" in result
+        assert "/tmp/toolregistry_results/test.txt" in result
+        assert "hel..." in result
+
+    def test_str_truncated_without_path(self):
+        """Test __str__ for a truncated result without persistence."""
+        tr = TruncatedResult(
+            content="hel...",
+            original_size=100,
+            truncated=True,
+            full_path=None,
+        )
+        result = str(tr)
+
+        assert "Truncated: 100 chars -> 6 chars" in result
+        assert "full output" not in result
+
+
+class TestTruncateResult:
+    """Test cases for the truncate_result function."""
+
+    def test_no_truncation_when_under_limit(self):
+        """Test that results under max_size are not truncated."""
+        text = "short result"
+        tr = truncate_result(text, max_size=100, persist=False)
+
+        assert tr.truncated is False
+        assert tr.content == text
+        assert tr.original_size == len(text)
+        assert tr.full_path is None
+
+    def test_no_truncation_when_at_limit(self):
+        """Test that results exactly at max_size are not truncated."""
+        text = "x" * 50
+        tr = truncate_result(text, max_size=50, persist=False)
+
+        assert tr.truncated is False
+        assert tr.content == text
+
+    def test_head_truncation(self):
+        """Test head truncation strategy."""
+        text = "a" * 200
+        tr = truncate_result(
+            text, max_size=50, strategy=TruncationStrategy.HEAD, persist=False
+        )
+
+        assert tr.truncated is True
+        assert len(tr.content) == 50
+        assert tr.content == "a" * 50
+        assert tr.original_size == 200
+
+    def test_head_tail_truncation(self):
+        """Test head+tail truncation strategy with marker."""
+        text = "A" * 100 + "B" * 100
+        tr = truncate_result(
+            text, max_size=80, strategy=TruncationStrategy.HEAD_TAIL, persist=False
+        )
+
+        assert tr.truncated is True
+        assert tr.original_size == 200
+        assert "truncated 120 chars" in tr.content
+        assert tr.content.startswith("A")
+        assert tr.content.endswith("B")
+
+    def test_head_tail_preserves_head_and_tail(self):
+        """Test that head+tail keeps recognizable head and tail portions."""
+        head = "HEAD_CONTENT_"
+        tail = "_TAIL_CONTENT"
+        middle = "x" * 200
+        text = head + middle + tail
+        tr = truncate_result(
+            text, max_size=100, strategy=TruncationStrategy.HEAD_TAIL, persist=False
+        )
+
+        assert tr.truncated is True
+        assert tr.content.startswith("HEAD_CONTENT_")
+        assert tr.content.endswith("_TAIL_CONTENT")
+
+    def test_head_tail_very_small_max_size_falls_back_to_head(self):
+        """Test that very small max_size falls back to head truncation."""
+        text = "a" * 200
+        tr = truncate_result(
+            text, max_size=5, strategy=TruncationStrategy.HEAD_TAIL, persist=False
+        )
+
+        assert tr.truncated is True
+        assert len(tr.content) == 5
+
+    def test_persist_full_result(self):
+        """Test that persistence writes the full result to a temp file."""
+        text = "x" * 200
+        tr = truncate_result(text, max_size=50, tool_name="test_tool", persist=True)
+
+        assert tr.truncated is True
+        assert tr.full_path is not None
+        assert os.path.exists(tr.full_path)
+
+        with open(tr.full_path, encoding="utf-8") as f:
+            persisted = f.read()
+        assert persisted == text
+
+        # Cleanup
+        os.remove(tr.full_path)
+
+    def test_no_persist(self):
+        """Test that persist=False skips file writing."""
+        text = "x" * 200
+        tr = truncate_result(text, max_size=50, persist=False)
+
+        assert tr.truncated is True
+        assert tr.full_path is None
+
+    def test_default_strategy_is_head_tail(self):
+        """Test that the default strategy is HEAD_TAIL."""
+        text = "A" * 100 + "B" * 100
+        tr = truncate_result(text, max_size=80, persist=False)
+
+        # HEAD_TAIL produces a marker in the middle
+        assert "truncated" in tr.content
+        assert tr.content.startswith("A")
+        assert tr.content.endswith("B")


### PR DESCRIPTION
## Summary

Closes #92

- Add `max_result_size` field to `ToolMetadata` for per-tool result size limits (in characters)
- Add `default_max_result_size` parameter to `ToolRegistry.__init__()` as a registry-level fallback
- New `truncation.py` module with `TruncationStrategy` (HEAD, HEAD_TAIL), `TruncatedResult` dataclass, and `truncate_result()` function
- HEAD_TAIL strategy (default) keeps first and last portions with a `... (truncated N chars) ...` marker
- Full results optionally persisted to `{tempdir}/toolregistry_results/` for later retrieval
- Extract `_finalize_result()` helper in `ToolRegistry` to eliminate duplicate result-serialization logic
- Truncation only applies through `execute_tool_calls()` — direct `Tool.run()`/`arun()` calls return raw results (documented in docstrings)

## Test plan

- [x] Unit tests for `TruncatedResult` string representations (truncated/non-truncated/with-path/without-path)
- [x] Unit tests for `truncate_result()` (under limit, at limit, head strategy, head_tail strategy, small max_size fallback, persistence, no-persist)
- [x] Integration tests for truncation through `execute_tool_calls()` (large result truncated, normal result unchanged, registry default, tool-level override)
- [x] All 552 tests pass
- [x] ruff check + format clean