### PR TITLE
feat: add think-augmented function calling

### DIFF
--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -26,6 +26,19 @@ class ToolTag(str, Enum):
     PRIVILEGED = "privileged"
 
 
+THINK_PROPERTY: dict[str, str] = {
+    "type": "string",
+    "description": (
+        "Your step-by-step reasoning about why you chose this tool and how to use it."
+    ),
+}
+"""Schema snippet injected into every tool's ``parameters.properties``
+so that LLMs can include chain-of-thought reasoning when calling a tool.
+
+Reference: https://arxiv.org/abs/2601.18282
+"""
+
+
 class ToolMetadata(BaseModel):
     """Behavioral and classification metadata for a Tool.
 
@@ -154,6 +167,28 @@ class Tool(BaseModel):
             elif isinstance(data["metadata"], dict):
                 data["metadata"].setdefault("is_async", is_async)
         return data
+
+    def model_post_init(self, __context: Any) -> None:
+        """Inject ``thought`` property into the tool's parameter schema.
+
+        Runs after every ``Tool`` (and subclass) construction, regardless
+        of whether the instance was created via ``from_function()``, or
+        directly (MCP, OpenAPI, LangChain integrations).
+
+        The ``thought`` field is only added when ``parameters`` already
+        contains a ``properties`` mapping and does not already define a
+        ``thought`` key (i.e. native ``thought`` parameters are preserved).
+        """
+        props = self.parameters.get("properties")
+        if props is not None and "thought" not in props:
+            props["thought"] = THINK_PROPERTY
+
+    def _has_native_thought_param(self) -> bool:
+        """Return True if the wrapped function natively declares a ``thought`` parameter."""
+        return (
+            self.parameters_model is not None
+            and "thought" in self.parameters_model.model_fields
+        )
 
     @property
     def is_async(self) -> bool:
@@ -336,6 +371,8 @@ class Tool(BaseModel):
             return raw results without truncation.
         """
         try:
+            if not self._has_native_thought_param():
+                parameters = {k: v for k, v in parameters.items() if k != "thought"}
             validated_params = self._validate_parameters(parameters)
             return self.callable(**validated_params)
         except Exception as e:
@@ -361,6 +398,8 @@ class Tool(BaseModel):
             return raw results without truncation.
         """
         try:
+            if not self._has_native_thought_param():
+                parameters = {k: v for k, v in parameters.items() if k != "thought"}
             validated_params = self._validate_parameters(parameters)
 
             if inspect.iscoroutinefunction(self.callable):

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -304,6 +304,8 @@ class ToolRegistry(
                 function_name = tc.name
                 function_args = call_arguments.get(tc.id, {})
                 tool_obj = self.get_tool(function_name)
+                if tool_obj and not tool_obj._has_native_thought_param():
+                    function_args.pop("thought", None)
                 callable_func = tool_obj.callable if tool_obj else None
 
                 if callable_func is None:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -278,6 +278,87 @@ class TestTool:
         assert "parameters" in model_dict
 
 
+class TestThinkAugmented:
+    """Test cases for think-augmented function calling."""
+
+    def test_think_property_in_schema(self, sample_tool):
+        """Test that thought property is injected into tool schema."""
+        assert "thought" in sample_tool.parameters["properties"]
+        thought = sample_tool.parameters["properties"]["thought"]
+        assert thought["type"] == "string"
+        assert "reasoning" in thought["description"]
+
+    def test_think_property_in_openai_format(self, sample_tool):
+        """Test that thought appears in OpenAI format schema."""
+        schema = sample_tool.get_json_schema("openai")
+        params = schema["function"]["parameters"]
+        assert "thought" in params["properties"]
+
+    def test_think_property_in_anthropic_format(self, sample_tool):
+        """Test that thought appears in Anthropic format schema."""
+        schema = sample_tool.get_json_schema("anthropic")
+        assert "thought" in schema["input_schema"]["properties"]
+
+    def test_think_property_in_gemini_format(self, sample_tool):
+        """Test that thought appears in Gemini format schema."""
+        schema = sample_tool.get_json_schema("gemini")
+        assert "thought" in schema["parameters"]["properties"]
+
+    def test_think_stripped_on_run(self, sample_tool):
+        """Test that thought is stripped before execution in run()."""
+        result = sample_tool.run(
+            {"a": 5, "b": 3, "thought": "I need to add these numbers"}
+        )
+        assert result == 8
+
+    @pytest.mark.asyncio
+    async def test_think_stripped_on_arun(self, async_sample_function):
+        """Test that thought is stripped before execution in arun()."""
+        tool = Tool.from_function(async_sample_function)
+        result = await tool.arun({"a": 10, "b": 20, "thought": "Adding asynchronously"})
+        assert result == 30
+
+    def test_think_no_override_existing(self):
+        """Test that native thought parameter is not overridden."""
+
+        def func_with_thought(thought: str, value: int) -> str:
+            """A function that uses thought as a real parameter."""
+            return f"{thought}: {value}"
+
+        tool = Tool.from_function(func_with_thought)
+        # thought should still be in schema (native)
+        assert "thought" in tool.parameters["properties"]
+        # Should NOT be stripped during execution
+        result = tool.run({"thought": "hello", "value": 42})
+        assert result == "hello: 42"
+
+    def test_think_manual_tool_creation(self):
+        """Test that manually created Tool also gets thought injected."""
+        tool = Tool(
+            name="manual_tool",
+            description="A manually created tool",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                },
+                "required": ["x"],
+            },
+            callable=lambda x: x * 2,
+        )
+        assert "thought" in tool.parameters["properties"]
+
+    def test_think_empty_schema_no_inject(self):
+        """Test that thought is not injected when schema has no properties."""
+        tool = Tool(
+            name="empty_tool",
+            description="Tool with empty schema",
+            parameters={},
+            callable=lambda: "ok",
+        )
+        assert "properties" not in tool.parameters
+
+
 class TestToolMetadataFields:
     """Test cases for ToolMetadata and ToolTag."""
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -591,3 +591,34 @@ class TestToolRegistryResultTruncation:
 
         # 50 chars < 1000 limit, so no truncation
         assert "Truncated" not in results["call_override"]
+
+
+class TestThinkAugmentedExecution:
+    """Test think-augmented calling in execute_tool_calls path."""
+
+    def test_execute_tool_calls_strips_thought(self):
+        """Test that thought is stripped in execute_tool_calls."""
+        from openai.types.chat.chat_completion_message_tool_call import (
+            ChatCompletionMessageToolCall as ChatCompletionMessageFunctionToolCall,
+            Function,
+        )
+
+        def greet(name: str) -> str:
+            """Greet someone."""
+            return f"Hello, {name}!"
+
+        registry = ToolRegistry()
+        registry.register(greet)
+
+        tool_calls = [
+            ChatCompletionMessageFunctionToolCall(
+                id="call_think",
+                type="function",
+                function=Function(
+                    name="greet",
+                    arguments='{"name": "World", "thought": "I should greet the world"}',
+                ),
+            )
+        ]
+        results = registry.execute_tool_calls(tool_calls)
+        assert results["call_think"] == "Hello, World!"


### PR DESCRIPTION
## Summary

Closes #49

Inject a `thought` string property into every tool's parameter schema so LLMs can include chain-of-thought reasoning when calling tools (ref: [arxiv 2601.18282](https://arxiv.org/abs/2601.18282)). The property is automatically stripped before execution.

- `Tool.model_post_init` injects `thought` via `THINK_PROPERTY` constant — covers **all** creation paths (native, MCP, OpenAPI, LangChain, manual)
- `Tool.run()`/`arun()` and `ToolRegistry.execute_tool_calls()` strip `thought` before passing args to the callable
- Functions that natively declare a `thought` parameter are preserved (not overridden or stripped)

## Test plan

- [x] 9 new unit tests in `TestThinkAugmented` (schema injection, OpenAI/Anthropic/Gemini format, run/arun stripping, native thought preservation, manual creation, empty schema)
- [x] 1 new integration test in `TestThinkAugmentedExecution` (execute_tool_calls path)
- [x] All 93 existing tests pass
- [x] `ruff check` and `ruff format` clean