### PR TITLE
test: add integration tests for OpenAPI, LangChain, MCP and tool_wrapper

### DIFF
--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -1,0 +1,314 @@
+"""Tests for LangChain integration module."""
+
+from typing import Any
+
+import pytest
+
+langchain_core = pytest.importorskip("langchain_core")
+
+from langchain_core.tools import BaseTool as LCBaseTool  # noqa: E402
+from pydantic import BaseModel, Field  # noqa: E402
+
+from toolregistry import ToolRegistry  # noqa: E402
+from toolregistry.langchain.integration import (  # noqa: E402
+    LangChainIntegration,
+    LangChainTool,
+    LangChainToolWrapper,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock LangChain tools
+# ---------------------------------------------------------------------------
+
+
+class AddInput(BaseModel):
+    """Input for adding two numbers."""
+
+    a: int = Field(description="First number")
+    b: int = Field(description="Second number")
+
+
+class MockAddTool(LCBaseTool):
+    """A mock tool that adds two numbers."""
+
+    name: str = "add_numbers"
+    description: str = "Add two numbers together"
+    args_schema: type[BaseModel] = AddInput
+
+    def _run(self, a: int, b: int) -> int:
+        return a + b
+
+    async def _arun(self, a: int, b: int) -> int:
+        return a + b
+
+
+class MockUpperTool(LCBaseTool):
+    """A mock tool that uppercases a string."""
+
+    name: str = "upper_case"
+    description: str = "Convert text to uppercase"
+
+    def _run(self, text: str) -> str:
+        return text.upper()
+
+    async def _arun(self, text: str) -> str:
+        return text.upper()
+
+
+class MockFailTool(LCBaseTool):
+    """A mock tool that always fails."""
+
+    name: str = "fail_tool"
+    description: str = "Always fails"
+
+    def _run(self, **kwargs: Any) -> str:
+        raise RuntimeError("Intentional failure")
+
+    async def _arun(self, **kwargs: Any) -> str:
+        raise RuntimeError("Intentional async failure")
+
+
+class MockNoArgsTool(LCBaseTool):
+    """A mock tool with no arguments."""
+
+    name: str = "no_args_tool"
+    description: str = "A tool that takes no arguments"
+
+    def _run(self) -> str:
+        return "done"
+
+    async def _arun(self) -> str:
+        return "done"
+
+
+# ===========================================================================
+# TestLangChainToolWrapper
+# ===========================================================================
+
+
+class TestLangChainToolWrapper:
+    """Tests for LangChainToolWrapper."""
+
+    def test_call_sync(self):
+        """Sync call delegates to tool._run()."""
+        lc_tool = MockAddTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        result = wrapper.call_sync(a=3, b=4)
+        assert result == 7
+
+    @pytest.mark.asyncio
+    async def test_call_async(self):
+        """Async call delegates to tool._arun()."""
+        lc_tool = MockAddTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        result = await wrapper.call_async(a=10, b=20)
+        assert result == 30
+
+    def test_name_normalization(self):
+        """Tool name is normalized."""
+        lc_tool = MockAddTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        assert wrapper.name == "add_numbers"
+
+    def test_params_extracted(self):
+        """Parameter names are extracted from tool.args."""
+        lc_tool = MockAddTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        assert set(wrapper.params) == {"a", "b"}
+
+    def test_call_sync_exception_propagates(self):
+        """Exceptions from tool._run() propagate."""
+        lc_tool = MockFailTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        with pytest.raises(RuntimeError, match="Intentional failure"):
+            wrapper.call_sync()
+
+    @pytest.mark.asyncio
+    async def test_call_async_exception_propagates(self):
+        """Exceptions from tool._arun() propagate."""
+        lc_tool = MockFailTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        with pytest.raises(RuntimeError, match="Intentional async failure"):
+            await wrapper.call_async()
+
+    def test_string_tool(self):
+        """Wrapper works with string-based tools."""
+        lc_tool = MockUpperTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        result = wrapper.call_sync(text="hello")
+        assert result == "HELLO"
+
+    @pytest.mark.asyncio
+    async def test_string_tool_async(self):
+        """Async wrapper works with string-based tools."""
+        lc_tool = MockUpperTool()
+        wrapper = LangChainToolWrapper(lc_tool)
+        result = await wrapper.call_async(text="world")
+        assert result == "WORLD"
+
+
+# ===========================================================================
+# TestLangChainTool
+# ===========================================================================
+
+
+class TestLangChainTool:
+    """Tests for LangChainTool.from_langchain_tool()."""
+
+    def test_basic_creation(self):
+        """Creates a LangChainTool from a LangChain tool."""
+        lc_tool = MockAddTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool)
+        assert tool.name == "add_numbers"
+        assert tool.description == "Add two numbers together"
+
+    def test_parameters_schema(self):
+        """Parameter schema is correctly extracted."""
+        lc_tool = MockAddTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool)
+        props = tool.parameters.get("properties", {})
+        assert "a" in props
+        assert "b" in props
+
+    def test_with_namespace(self):
+        """Namespace is applied to tool name."""
+        lc_tool = MockAddTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool, namespace="math")
+        assert "math" in tool.name
+
+    def test_without_namespace(self):
+        """Without namespace, name is plain."""
+        lc_tool = MockAddTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool)
+        assert tool.name == "add_numbers"
+
+    def test_description_preserved(self):
+        """Description from LangChain tool is preserved."""
+        lc_tool = MockUpperTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool)
+        assert tool.description == "Convert text to uppercase"
+
+    def test_tool_is_callable(self):
+        """Created tool has a callable wrapper."""
+        lc_tool = MockAddTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool)
+        assert tool.callable is not None
+        result = tool.callable.call_sync(a=5, b=6)
+        assert result == 11
+
+    def test_no_args_tool(self):
+        """Tool with no args_schema works."""
+        lc_tool = MockNoArgsTool()
+        tool = LangChainTool.from_langchain_tool(lc_tool)
+        assert tool.name == "no_args_tool"
+
+
+# ===========================================================================
+# TestLangChainIntegration
+# ===========================================================================
+
+
+class TestLangChainIntegration:
+    """Tests for LangChainIntegration."""
+
+    def test_register_single_tool(self):
+        """Register a single LangChain tool."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockAddTool())
+        assert registry.get_tool("add_numbers") is not None
+
+    def test_register_with_namespace_string(self):
+        """Register with a string namespace."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockAddTool(), namespace="math")
+        tool_names = [t.name for t in registry._tools.values()]
+        assert any("math" in name for name in tool_names)
+
+    def test_register_with_namespace_true(self):
+        """Register with namespace=True uses default ns."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockAddTool(), namespace=True)
+        tool_names = [t.name for t in registry._tools.values()]
+        assert any("langchain" in name.lower() for name in tool_names)
+
+    def test_register_with_namespace_false(self):
+        """Register with namespace=False uses no prefix."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockUpperTool(), namespace=False)
+        assert registry.get_tool("upper_case") is not None
+
+    def test_register_multiple_tools(self):
+        """Register multiple different tools."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockAddTool())
+        integration.register_langchain_tools(MockUpperTool())
+        assert registry.get_tool("add_numbers") is not None
+        assert registry.get_tool("upper_case") is not None
+
+    @pytest.mark.asyncio
+    async def test_register_async(self):
+        """Async registration works."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        await integration.register_langchain_tools_async(MockAddTool())
+        assert registry.get_tool("add_numbers") is not None
+
+
+# ===========================================================================
+# TestLangChainEndToEnd
+# ===========================================================================
+
+
+class TestLangChainEndToEnd:
+    """End-to-end: register LangChain tools, call through registry."""
+
+    def test_sync_end_to_end(self):
+        """Register and call synchronously through the registry."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockAddTool())
+
+        fn = registry.get_callable("add_numbers")
+        assert fn is not None
+        result = fn(a=100, b=200)
+        assert result == 300
+
+    def test_sync_string_tool_end_to_end(self):
+        """Register and call a string tool through the registry."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockUpperTool())
+
+        fn = registry.get_callable("upper_case")
+        assert fn is not None
+        result = fn(text="hello world")
+        assert result == "HELLO WORLD"
+
+    @pytest.mark.asyncio
+    async def test_async_end_to_end(self):
+        """Register and call asynchronously through the registry."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        await integration.register_langchain_tools_async(MockAddTool())
+
+        fn = registry.get_callable("add_numbers")
+        assert fn is not None
+        result = await fn.call_async(a=7, b=8)
+        assert result == 15
+
+    def test_error_propagation_end_to_end(self):
+        """Errors from tool execution propagate through the registry."""
+        registry = ToolRegistry(name="test")
+        integration = LangChainIntegration(registry)
+        integration.register_langchain_tools(MockFailTool())
+
+        fn = registry.get_callable("fail_tool")
+        assert fn is not None
+        with pytest.raises(RuntimeError, match="Intentional failure"):
+            fn()

--- a/tests/test_mcp_post_processing.py
+++ b/tests/test_mcp_post_processing.py
@@ -1,0 +1,305 @@
+"""Tests for MCP post-processing and tool creation logic."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+mcp_types = pytest.importorskip("mcp.types")
+
+from mcp.types import (  # noqa: E402
+    BlobResourceContents,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+)
+from mcp.types import Tool as MCPToolSpec  # noqa: E402
+
+from toolregistry.mcp.integration import MCPTool, MCPToolWrapper  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_wrapper(name="test_tool", params=None):
+    """Create an MCPToolWrapper with a mock connection."""
+    mock_connection = MagicMock()
+    return MCPToolWrapper(connection=mock_connection, name=name, params=params)
+
+
+class FakeResult:
+    """Mimics a CallToolResult without importing the exact class."""
+
+    def __init__(self, content, is_error=False):
+        self.content = content
+        self.isError = is_error
+        self.is_error = is_error
+
+
+# ===========================================================================
+# TestMCPPostProcessResult
+# ===========================================================================
+
+
+class TestMCPPostProcessResult:
+    """Tests for MCPToolWrapper._post_process_result()."""
+
+    def test_single_text_content(self):
+        """Single TextContent returns a plain string."""
+        wrapper = _make_wrapper()
+        result = FakeResult(content=[TextContent(type="text", text="hello world")])
+        output = wrapper._post_process_result(result)
+        assert output == "hello world"
+
+    def test_multiple_text_content(self):
+        """Multiple TextContent items return a list of content blocks."""
+        wrapper = _make_wrapper()
+        result = FakeResult(
+            content=[
+                TextContent(type="text", text="first"),
+                TextContent(type="text", text="second"),
+            ]
+        )
+        output = wrapper._post_process_result(result)
+        assert isinstance(output, list)
+        assert len(output) == 2
+        assert output[0] == {"type": "text", "text": "first"}
+        assert output[1] == {"type": "text", "text": "second"}
+
+    def test_image_content(self):
+        """ImageContent is converted to base64 block."""
+        wrapper = _make_wrapper()
+        result = FakeResult(
+            content=[
+                ImageContent(
+                    type="image", data="abc123base64data", mimeType="image/png"
+                )
+            ]
+        )
+        output = wrapper._post_process_result(result)
+        assert isinstance(output, list)
+        assert output[0]["type"] == "image"
+        assert output[0]["source"]["type"] == "base64"
+        assert output[0]["source"]["media_type"] == "image/png"
+        assert output[0]["source"]["data"] == "abc123base64data"
+
+    def test_mixed_text_and_image(self):
+        """Mixed TextContent + ImageContent returns list."""
+        wrapper = _make_wrapper()
+        result = FakeResult(
+            content=[
+                TextContent(type="text", text="A caption"),
+                ImageContent(type="image", data="imgdata", mimeType="image/jpeg"),
+            ]
+        )
+        output = wrapper._post_process_result(result)
+        assert isinstance(output, list)
+        assert len(output) == 2
+        assert output[0]["type"] == "text"
+        assert output[1]["type"] == "image"
+
+    def test_embedded_text_resource(self):
+        """EmbeddedResource with TextResourceContents extracts text."""
+        wrapper = _make_wrapper()
+        text_resource = TextResourceContents(
+            uri="file:///test.txt", text="embedded text", mimeType="text/plain"
+        )
+        result = FakeResult(
+            content=[EmbeddedResource(type="resource", resource=text_resource)]
+        )
+        output = wrapper._post_process_result(result)
+        assert output == "embedded text"
+
+    def test_embedded_blob_image_resource(self):
+        """EmbeddedResource with BlobResourceContents (image) returns image block."""
+        wrapper = _make_wrapper()
+        blob_resource = BlobResourceContents(
+            uri="file:///test.png",
+            blob="blobdata123",
+            mimeType="image/png",
+        )
+        result = FakeResult(
+            content=[EmbeddedResource(type="resource", resource=blob_resource)]
+        )
+        output = wrapper._post_process_result(result)
+        assert isinstance(output, list)
+        assert output[0]["type"] == "image"
+        assert output[0]["source"]["data"] == "blobdata123"
+
+    def test_embedded_blob_non_image_resource(self):
+        """EmbeddedResource with non-image BlobResourceContents returns text summary."""
+        wrapper = _make_wrapper()
+        blob_resource = BlobResourceContents(
+            uri="file:///test.bin",
+            blob="binarydata",
+            mimeType="application/octet-stream",
+        )
+        result = FakeResult(
+            content=[EmbeddedResource(type="resource", resource=blob_resource)]
+        )
+        output = wrapper._post_process_result(result)
+        assert "Blob" in output
+        assert "application/octet-stream" in output
+
+    def test_is_error_returns_raw(self):
+        """isError=True returns the raw result unchanged."""
+        wrapper = _make_wrapper()
+        result = FakeResult(content=[], is_error=True)
+        output = wrapper._post_process_result(result)
+        assert output is result
+
+    def test_empty_content_returns_raw(self):
+        """Empty content list returns the raw result."""
+        wrapper = _make_wrapper()
+        result = FakeResult(content=[], is_error=False)
+        output = wrapper._post_process_result(result)
+        assert output is result
+
+    def test_list_input_bypasses_result_check(self):
+        """When input is a plain list, processes directly."""
+        wrapper = _make_wrapper()
+        contents = [TextContent(type="text", text="direct")]
+        output = wrapper._post_process_result(contents)
+        assert output == "direct"
+
+    def test_unsupported_content_type_raises(self):
+        """Unsupported content type raises NotImplementedError."""
+        wrapper = _make_wrapper()
+
+        class UnknownContent:
+            pass
+
+        result = FakeResult(content=[UnknownContent()])
+        with pytest.raises(NotImplementedError, match="No handler"):
+            wrapper._post_process_result(result)
+
+    def test_multiple_embedded_resources(self):
+        """Multiple EmbeddedResources are processed correctly."""
+        wrapper = _make_wrapper()
+        text_res = TextResourceContents(
+            uri="file:///a.txt", text="text A", mimeType="text/plain"
+        )
+        blob_res = BlobResourceContents(
+            uri="file:///b.png", blob="imgblob", mimeType="image/png"
+        )
+        result = FakeResult(
+            content=[
+                EmbeddedResource(type="resource", resource=text_res),
+                EmbeddedResource(type="resource", resource=blob_res),
+            ]
+        )
+        output = wrapper._post_process_result(result)
+        assert isinstance(output, list)
+        assert len(output) == 2
+        assert output[0]["type"] == "text"
+        assert output[1]["type"] == "image"
+
+    def test_single_image_returns_list(self):
+        """Single image content returns a list (not string)."""
+        wrapper = _make_wrapper()
+        result = FakeResult(
+            content=[ImageContent(type="image", data="data", mimeType="image/gif")]
+        )
+        output = wrapper._post_process_result(result)
+        assert isinstance(output, list)
+        assert len(output) == 1
+
+
+# ===========================================================================
+# TestMCPToolFromJson
+# ===========================================================================
+
+
+class TestMCPToolFromJson:
+    """Tests for MCPTool.from_tool_json()."""
+
+    def _make_tool_spec(
+        self, name="test_tool", description="A test", input_schema=None
+    ):
+        if input_schema is None:
+            input_schema = {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query"}
+                },
+            }
+        return MCPToolSpec(
+            name=name,
+            description=description,
+            inputSchema=input_schema,
+        )
+
+    def test_basic_creation(self):
+        """Creates an MCPTool from a tool spec."""
+        spec = self._make_tool_spec()
+        mock_conn = MagicMock()
+        tool = MCPTool.from_tool_json(spec, mock_conn)
+        assert tool.name == "test_tool"
+        assert tool.description == "A test"
+
+    def test_params_extracted(self):
+        """Parameter names are extracted from input schema properties."""
+        spec = self._make_tool_spec()
+        mock_conn = MagicMock()
+        tool = MCPTool.from_tool_json(spec, mock_conn)
+        assert tool.callable.params == ["query"]
+
+    def test_with_namespace(self):
+        """Namespace is applied to tool name."""
+        spec = self._make_tool_spec()
+        mock_conn = MagicMock()
+        tool = MCPTool.from_tool_json(spec, mock_conn, namespace="myserver")
+        assert "myserver" in tool.name
+
+    def test_empty_description(self):
+        """Empty description defaults to empty string."""
+        spec = MCPToolSpec(
+            name="no_desc",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        mock_conn = MagicMock()
+        tool = MCPTool.from_tool_json(spec, mock_conn)
+        assert tool.description == ""
+
+    def test_empty_input_schema(self):
+        """Tool with empty input schema creates wrapper with empty params."""
+        spec = MCPToolSpec(
+            name="bare_tool",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        mock_conn = MagicMock()
+        tool = MCPTool.from_tool_json(spec, mock_conn)
+        assert tool.callable.params == []
+
+
+# ===========================================================================
+# TestMCPToolWrapperEdgeCases
+# ===========================================================================
+
+
+class TestMCPToolWrapperEdgeCases:
+    """Edge case tests for MCPToolWrapper."""
+
+    def test_transport_property(self):
+        """transport property returns connection transport."""
+        mock_conn = MagicMock()
+        mock_conn.transport = "http://example.com"
+        wrapper = MCPToolWrapper(connection=mock_conn, name="t", params=[])
+        assert wrapper.transport == "http://example.com"
+
+    def test_name_and_params(self):
+        """Name and params are correctly stored."""
+        mock_conn = MagicMock()
+        wrapper = MCPToolWrapper(
+            connection=mock_conn, name="my_tool", params=["a", "b"]
+        )
+        assert wrapper.name == "my_tool"
+        assert wrapper.params == ["a", "b"]
+
+    def test_no_params(self):
+        """Wrapper with no params."""
+        mock_conn = MagicMock()
+        wrapper = MCPToolWrapper(connection=mock_conn, name="t", params=None)
+        assert wrapper.params is None

--- a/tests/test_openapi_integration.py
+++ b/tests/test_openapi_integration.py
@@ -5,19 +5,21 @@ import json
 import httpx
 import pytest
 
-from toolregistry import ToolRegistry
-from toolregistry.openapi.integration import (
+pytest.importorskip("jsonref")
+
+from toolregistry import ToolRegistry  # noqa: E402
+from toolregistry.openapi.integration import (  # noqa: E402
     OpenAPIIntegration,
     OpenAPITool,
     OpenAPIToolWrapper,
 )
-from toolregistry.openapi.utils import (
+from toolregistry.openapi.utils import (  # noqa: E402
     determine_urls,
     extract_base_url_from_specs,
     load_openapi_spec,
     load_openapi_spec_async,
 )
-from toolregistry.utils import HttpxClientConfig
+from toolregistry.utils import HttpxClientConfig  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_openapi_integration.py
+++ b/tests/test_openapi_integration.py
@@ -1,0 +1,768 @@
+"""Tests for OpenAPI integration module."""
+
+import json
+
+import httpx
+import pytest
+
+from toolregistry import ToolRegistry
+from toolregistry.openapi.integration import (
+    OpenAPIIntegration,
+    OpenAPITool,
+    OpenAPIToolWrapper,
+)
+from toolregistry.openapi.utils import (
+    determine_urls,
+    extract_base_url_from_specs,
+    load_openapi_spec,
+    load_openapi_spec_async,
+)
+from toolregistry.utils import HttpxClientConfig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+PETSTORE_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "Petstore", "version": "1.0.0"},
+    "servers": [{"url": "http://petstore.example.com/v1"}],
+    "paths": {
+        "/pets": {
+            "get": {
+                "operationId": "listPets",
+                "summary": "List all pets",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer"},
+                        "description": "How many items to return",
+                    }
+                ],
+            },
+            "post": {
+                "operationId": "createPet",
+                "summary": "Create a pet",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Pet name",
+                                    },
+                                    "tag": {
+                                        "type": "string",
+                                        "description": "Pet tag",
+                                    },
+                                },
+                                "required": ["name"],
+                            }
+                        }
+                    }
+                },
+            },
+        },
+        "/pets/{petId}": {
+            "get": {
+                "operationId": "showPetById",
+                "summary": "Info for a specific pet",
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                        "description": "The id of the pet to retrieve",
+                    }
+                ],
+            },
+            "delete": {
+                "operationId": "deletePet",
+                "summary": "Delete a pet",
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+            },
+            "put": {
+                "operationId": "updatePet",
+                "summary": "Update a pet",
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "tag": {"type": "string"},
+                                },
+                            }
+                        }
+                    }
+                },
+            },
+        },
+    },
+}
+
+
+def _make_mock_transport(handler):
+    """Create a mock transport from a handler function."""
+    return httpx.MockTransport(handler)
+
+
+def _make_config_with_mock(handler, base_url="http://test"):
+    """Create an HttpxClientConfig backed by a mock transport."""
+    transport = _make_mock_transport(handler)
+    return HttpxClientConfig(
+        base_url=base_url,
+        transport=transport,
+    )
+
+
+# ===========================================================================
+# TestOpenAPIToolWrapper
+# ===========================================================================
+
+
+class TestOpenAPIToolWrapper:
+    """Tests for OpenAPIToolWrapper."""
+
+    def test_call_sync_get(self):
+        """GET request returns JSON."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "GET"
+            return httpx.Response(200, json={"pets": []})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="list_pets",
+            method="get",
+            path="/pets",
+            params=["limit"],
+            persistent=True,
+        )
+        result = wrapper.call_sync(limit=10)
+        assert result == {"pets": []}
+
+    def test_call_sync_post(self):
+        """POST request sends JSON body."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            body = json.loads(request.content)
+            assert body["name"] == "Fido"
+            return httpx.Response(201, json={"id": 1, "name": "Fido"})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="create_pet",
+            method="post",
+            path="/pets",
+            params=["name", "tag"],
+            persistent=True,
+        )
+        result = wrapper.call_sync(name="Fido")
+        assert result["id"] == 1
+
+    def test_call_sync_put(self):
+        """PUT request sends JSON body."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PUT"
+            return httpx.Response(200, json={"updated": True})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="update_pet",
+            method="put",
+            path="/pets/1",
+            params=["name"],
+            persistent=True,
+        )
+        result = wrapper.call_sync(name="Rex")
+        assert result["updated"] is True
+
+    def test_call_sync_delete(self):
+        """DELETE request works."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "DELETE"
+            return httpx.Response(200, json={"deleted": True})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="delete_pet",
+            method="delete",
+            path="/pets/1",
+            params=None,
+            persistent=True,
+        )
+        result = wrapper.call_sync()
+        assert result["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_call_async_get(self):
+        """Async GET request works."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"async": True})
+
+        transport = httpx.MockTransport(handler)
+        config = HttpxClientConfig(base_url="http://test", transport=transport)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="list_pets",
+            method="get",
+            path="/pets",
+            params=["limit"],
+            persistent=True,
+        )
+        result = await wrapper.call_async(limit=5)
+        assert result["async"] is True
+
+    @pytest.mark.asyncio
+    async def test_call_async_post(self):
+        """Async POST request sends JSON body."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            return httpx.Response(201, json={"name": body["name"]})
+
+        transport = httpx.MockTransport(handler)
+        config = HttpxClientConfig(base_url="http://test", transport=transport)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="create_pet",
+            method="post",
+            path="/pets",
+            params=["name"],
+            persistent=True,
+        )
+        result = await wrapper.call_async(name="Buddy")
+        assert result["name"] == "Buddy"
+
+    def test_call_sync_http_error(self):
+        """HTTP error raises HTTPStatusError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"error": "not found"})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="show_pet",
+            method="get",
+            path="/pets/999",
+            params=None,
+            persistent=True,
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            wrapper.call_sync()
+
+    def test_call_sync_server_error(self):
+        """500 error raises HTTPStatusError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": "internal"})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="list_pets",
+            method="get",
+            path="/pets",
+            params=None,
+            persistent=True,
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            wrapper.call_sync()
+
+    def test_call_sync_no_name_raises(self):
+        """Calling with empty name raises ValueError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="",
+            method="get",
+            path="/pets",
+            params=None,
+            persistent=True,
+        )
+        with pytest.raises(ValueError, match="Tool name must be set"):
+            wrapper.call_sync()
+
+    def test_non_persistent_client(self):
+        """Non-persistent mode creates a new client per call."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="list_pets",
+            method="get",
+            path="/pets",
+            params=None,
+            persistent=False,
+        )
+        result = wrapper.call_sync()
+        assert result["ok"] is True
+
+    def test_get_query_params_passed(self):
+        """GET request passes kwargs as query params."""
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"ok": True})
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="list_pets",
+            method="get",
+            path="/pets",
+            params=["limit", "offset"],
+            persistent=True,
+        )
+        wrapper.call_sync(limit=10, offset=20)
+        assert captured["params"]["limit"] == "10"
+        assert captured["params"]["offset"] == "20"
+
+    def test_process_args_positional(self):
+        """Positional args are mapped to param names."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=dict(request.url.params))
+
+        config = _make_config_with_mock(handler)
+        wrapper = OpenAPIToolWrapper(
+            client_config=config,
+            name="list_pets",
+            method="get",
+            path="/pets",
+            params=["limit", "offset"],
+            persistent=True,
+        )
+        result = wrapper.call_sync(10, 20)
+        assert result["limit"] == "10"
+
+
+# ===========================================================================
+# TestOpenAPITool
+# ===========================================================================
+
+
+class TestOpenAPITool:
+    """Tests for OpenAPITool.from_openapi_spec()."""
+
+    def _make_tool(self, path="/pets", method="get", spec=None, **kwargs):
+        config = HttpxClientConfig(base_url="http://test")
+        if spec is None:
+            spec = PETSTORE_SPEC["paths"]["/pets"]["get"]
+        return OpenAPITool.from_openapi_spec(
+            client_config=config,
+            path=path,
+            method=method,
+            spec=spec,
+            **kwargs,
+        )
+
+    def test_basic_get_tool(self):
+        """Creates a tool from a GET operation."""
+        tool = self._make_tool()
+        assert tool.name == "list_pets"
+        assert "List all pets" in tool.description
+
+    def test_post_tool_with_request_body(self):
+        """Creates a tool from a POST operation with requestBody."""
+        spec = PETSTORE_SPEC["paths"]["/pets"]["post"]
+        tool = self._make_tool(method="post", spec=spec)
+        assert tool.name == "create_pet"
+        assert "name" in tool.parameters["properties"]
+        assert "tag" in tool.parameters["properties"]
+        assert "name" in tool.parameters["required"]
+
+    def test_tool_with_path_param(self):
+        """Creates a tool with path parameters."""
+        spec = PETSTORE_SPEC["paths"]["/pets/{petId}"]["get"]
+        tool = self._make_tool(path="/pets/{petId}", spec=spec)
+        assert tool.name == "show_pet_by_id"
+        assert "petId" in tool.parameters["properties"]
+        assert "petId" in tool.parameters["required"]
+
+    def test_auto_naming_without_operation_id(self):
+        """Generates name from method + path when operationId is missing."""
+        spec = {"summary": "Do something", "parameters": []}
+        tool = self._make_tool(path="/items/search", method="get", spec=spec)
+        assert "get" in tool.name.lower() or "items" in tool.name.lower()
+
+    def test_description_from_summary(self):
+        """Uses summary when description is absent."""
+        spec = {"operationId": "test_op", "summary": "A summary", "parameters": []}
+        tool = self._make_tool(spec=spec)
+        assert tool.description == "A summary"
+
+    def test_description_from_description_field(self):
+        """Prefers description over summary."""
+        spec = {
+            "operationId": "test_op",
+            "summary": "A summary",
+            "description": "Full description",
+            "parameters": [],
+        }
+        tool = self._make_tool(spec=spec)
+        assert tool.description == "Full description"
+
+    def test_namespace_applied(self):
+        """Namespace is applied to tool name."""
+        tool = self._make_tool(namespace="petapi")
+        assert "petapi" in tool.name
+
+    def test_no_namespace(self):
+        """Without namespace, tool name has no prefix."""
+        tool = self._make_tool(namespace=None)
+        assert tool.name == "list_pets"
+
+    def test_put_with_params_and_body(self):
+        """PUT with both path params and requestBody."""
+        spec = PETSTORE_SPEC["paths"]["/pets/{petId}"]["put"]
+        tool = self._make_tool(path="/pets/{petId}", method="put", spec=spec)
+        props = tool.parameters["properties"]
+        assert "petId" in props
+        assert "name" in props
+
+    def test_empty_parameters(self):
+        """Operation with no parameters has no user-defined properties."""
+        spec = {"operationId": "health_check", "parameters": []}
+        tool = self._make_tool(spec=spec)
+        # The tool may have injected params (e.g. 'thought' from think_augment)
+        # but should have no user-defined params from the spec
+        assert tool.parameters["required"] == []
+
+
+# ===========================================================================
+# TestOpenAPIIntegration
+# ===========================================================================
+
+
+class TestOpenAPIIntegration:
+    """Tests for OpenAPIIntegration."""
+
+    def test_register_tools_from_spec(self):
+        """Registers all tools from an OpenAPI spec."""
+        registry = ToolRegistry(name="test")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True})
+
+        config = HttpxClientConfig(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC)
+
+        tool_names = [t.name for t in registry._tools.values()]
+        assert "list_pets" in tool_names
+        assert "create_pet" in tool_names
+        assert "show_pet_by_id" in tool_names
+        assert "delete_pet" in tool_names
+        assert "update_pet" in tool_names
+
+    def test_register_with_namespace_string(self):
+        """Namespace string is applied to all tools."""
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC, namespace="pet_api")
+
+        tool_names = [t.name for t in registry._tools.values()]
+        assert all("pet_api" in name for name in tool_names)
+
+    def test_register_with_namespace_true(self):
+        """namespace=True derives from info.title."""
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC, namespace=True)
+
+        tool_names = [t.name for t in registry._tools.values()]
+        # "Petstore" from info.title
+        assert any("petstore" in name.lower() for name in tool_names)
+
+    def test_register_with_namespace_false(self):
+        """namespace=False means no prefix."""
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC, namespace=False)
+
+        tool_names = [t.name for t in registry._tools.values()]
+        assert "list_pets" in tool_names
+
+    def test_skips_non_http_methods(self):
+        """Skips methods like 'options', 'head', 'parameters'."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/test": {
+                    "options": {"operationId": "opts", "parameters": []},
+                    "head": {"operationId": "hd", "parameters": []},
+                    "get": {"operationId": "testGet", "parameters": []},
+                }
+            },
+        }
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, spec)
+
+        tool_names = [t.name for t in registry._tools.values()]
+        assert "test_get" in tool_names
+        assert "opts" not in tool_names
+        assert "hd" not in tool_names
+
+    def test_close_cleans_up(self):
+        """close() clears client configs."""
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC)
+        assert len(integration._client_configs) == 1
+        integration.close()
+
+    @pytest.mark.asyncio
+    async def test_register_async(self):
+        """Async registration works."""
+        registry = ToolRegistry(name="test")
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True})
+
+        config = HttpxClientConfig(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+        integration = OpenAPIIntegration(registry)
+        await integration.register_openapi_tools_async(config, PETSTORE_SPEC)
+
+        tool_names = [t.name for t in registry._tools.values()]
+        assert len(tool_names) == 5
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        """Async close works."""
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test",
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        )
+        integration = OpenAPIIntegration(registry)
+        await integration.register_openapi_tools_async(config, PETSTORE_SPEC)
+        await integration.close_async()
+        assert len(integration._client_configs) == 0
+
+
+# ===========================================================================
+# TestOpenAPIToolEndToEnd
+# ===========================================================================
+
+
+class TestOpenAPIToolEndToEnd:
+    """End-to-end: register from spec, then call through registry."""
+
+    def test_register_and_call_get(self):
+        """Register tools and call a GET tool through the registry."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/pets":
+                return httpx.Response(200, json=[{"id": 1, "name": "Fido"}])
+            return httpx.Response(404)
+
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC)
+
+        fn = registry.get_callable("list_pets")
+        assert fn is not None
+        result = fn(limit=10)
+        assert isinstance(result, list)
+        assert result[0]["name"] == "Fido"
+
+    def test_register_and_call_post(self):
+        """Register tools and call a POST tool through the registry."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "POST" and request.url.path == "/pets":
+                body = json.loads(request.content)
+                return httpx.Response(201, json={"id": 2, "name": body["name"]})
+            return httpx.Response(404)
+
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+        integration = OpenAPIIntegration(registry)
+        integration.register_openapi_tools(config, PETSTORE_SPEC)
+
+        fn = registry.get_callable("create_pet")
+        assert fn is not None
+        result = fn(name="Buddy")
+        assert result["name"] == "Buddy"
+
+    @pytest.mark.asyncio
+    async def test_register_and_call_async(self):
+        """Register tools and call asynchronously through the registry."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[{"id": 1, "name": "Max"}])
+
+        registry = ToolRegistry(name="test")
+        config = HttpxClientConfig(
+            base_url="http://test", transport=httpx.MockTransport(handler)
+        )
+        integration = OpenAPIIntegration(registry)
+        await integration.register_openapi_tools_async(config, PETSTORE_SPEC)
+
+        fn = registry.get_callable("list_pets")
+        assert fn is not None
+        result = await fn.call_async(limit=5)
+        assert result[0]["name"] == "Max"
+
+
+# ===========================================================================
+# TestOpenAPIUtils
+# ===========================================================================
+
+
+class TestExtractBaseUrl:
+    """Tests for extract_base_url_from_specs()."""
+
+    def test_valid_server_url(self):
+        spec = {"servers": [{"url": "https://api.example.com/v1"}]}
+        assert extract_base_url_from_specs(spec) == "https://api.example.com/v1"
+
+    def test_strips_trailing_slash(self):
+        spec = {"servers": [{"url": "https://api.example.com/"}]}
+        assert extract_base_url_from_specs(spec) == "https://api.example.com"
+
+    def test_no_servers(self):
+        assert extract_base_url_from_specs({}) is None
+
+    def test_empty_servers_list(self):
+        assert extract_base_url_from_specs({"servers": []}) is None
+
+    def test_relative_url(self):
+        """Relative URL without scheme/netloc returns None."""
+        spec = {"servers": [{"url": "/api/v1"}]}
+        assert extract_base_url_from_specs(spec) is None
+
+    def test_first_server_used(self):
+        spec = {
+            "servers": [
+                {"url": "https://primary.example.com"},
+                {"url": "https://secondary.example.com"},
+            ]
+        }
+        assert extract_base_url_from_specs(spec) == "https://primary.example.com"
+
+
+class TestDetermineUrls:
+    """Tests for determine_urls()."""
+
+    def test_direct_endpoint_match(self):
+        """URL ending with known endpoint is recognized."""
+        result = determine_urls("http://api.test/openapi.json")
+        assert result["found"] is True
+        assert result["schema_url"] == "http://api.test/openapi.json"
+
+    def test_swagger_json_match(self):
+        result = determine_urls("http://api.test/swagger.json")
+        assert result["found"] is True
+
+    def test_not_found_returns_base(self):
+        """When no endpoint is found via probing, returns found=False."""
+        # This will fail to connect since no server is running
+        result = determine_urls("http://127.0.0.1:19999")
+        assert result["found"] is False
+        assert result["base_api_url"] == "http://127.0.0.1:19999"
+
+
+class TestLoadOpenapiSpec:
+    """Tests for load_openapi_spec() from file."""
+
+    def test_load_from_json_file(self, tmp_path):
+        """Load spec from a JSON file."""
+        spec_file = tmp_path / "spec.json"
+        spec_file.write_text(json.dumps(PETSTORE_SPEC))
+        result = load_openapi_spec(str(spec_file))
+        assert result["info"]["title"] == "Petstore"
+
+    def test_load_from_yaml_file(self, tmp_path):
+        """Load spec from a YAML file."""
+        import yaml
+
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(yaml.dump(PETSTORE_SPEC))
+        result = load_openapi_spec(str(spec_file))
+        assert result["info"]["title"] == "Petstore"
+
+    def test_load_nonexistent_file(self):
+        """Non-existent file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_openapi_spec("/nonexistent/path/spec.json")
+
+    @pytest.mark.asyncio
+    async def test_load_async_from_file(self, tmp_path):
+        """Async load from file path."""
+        spec_file = tmp_path / "spec.json"
+        spec_file.write_text(json.dumps(PETSTORE_SPEC))
+        result = await load_openapi_spec_async(str(spec_file))
+        assert result["info"]["title"] == "Petstore"

--- a/tests/test_tool_wrapper.py
+++ b/tests/test_tool_wrapper.py
@@ -1,0 +1,183 @@
+"""Tests for BaseToolWrapper ABC."""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from toolregistry.tool_wrapper import BaseToolWrapper
+
+
+# ---------------------------------------------------------------------------
+# Concrete subclass for testing
+# ---------------------------------------------------------------------------
+
+
+class ConcreteWrapper(BaseToolWrapper):
+    """Concrete implementation of BaseToolWrapper for testing."""
+
+    def __init__(
+        self, name="test_wrapper", params=None, sync_result=None, async_result=None
+    ):
+        super().__init__(name=name, params=params)
+        self._sync_result = sync_result or "sync_result"
+        self._async_result = async_result or "async_result"
+
+    def call_sync(self, *args: Any, **kwargs: Any) -> Any:
+        kwargs = self._process_args(*args, **kwargs)
+        return {"result": self._sync_result, "kwargs": kwargs}
+
+    async def call_async(self, *args: Any, **kwargs: Any) -> Any:
+        kwargs = self._process_args(*args, **kwargs)
+        return {"result": self._async_result, "kwargs": kwargs}
+
+
+class FailingWrapper(BaseToolWrapper):
+    """Wrapper that raises exceptions."""
+
+    def call_sync(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("sync error")
+
+    async def call_async(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("async error")
+
+
+# ===========================================================================
+# TestProcessArgs
+# ===========================================================================
+
+
+class TestProcessArgs:
+    """Tests for BaseToolWrapper._process_args()."""
+
+    def test_kwargs_passthrough(self):
+        """Keyword arguments pass through unchanged."""
+        wrapper = ConcreteWrapper(params=["a", "b"])
+        result = wrapper._process_args(a=1, b=2)
+        assert result == {"a": 1, "b": 2}
+
+    def test_positional_args_mapped(self):
+        """Positional args are mapped to param names."""
+        wrapper = ConcreteWrapper(params=["x", "y"])
+        result = wrapper._process_args(10, 20)
+        assert result == {"x": 10, "y": 20}
+
+    def test_mixed_args(self):
+        """Positional and keyword args together."""
+        wrapper = ConcreteWrapper(params=["a", "b", "c"])
+        result = wrapper._process_args(1, c=3)
+        assert result == {"a": 1, "c": 3}
+
+    def test_no_args(self):
+        """No arguments returns empty dict."""
+        wrapper = ConcreteWrapper(params=["a"])
+        result = wrapper._process_args()
+        assert result == {}
+
+    def test_positional_without_params_raises(self):
+        """Positional args without params definition raises ValueError."""
+        wrapper = ConcreteWrapper(params=None)
+        with pytest.raises(ValueError, match="not initialized"):
+            wrapper._process_args(1, 2)
+
+    def test_too_many_positional_raises(self):
+        """Too many positional args raises TypeError."""
+        wrapper = ConcreteWrapper(params=["a"])
+        with pytest.raises(TypeError, match="at most 1"):
+            wrapper._process_args(1, 2)
+
+    def test_duplicate_arg_raises(self):
+        """Positional + keyword for same param raises TypeError."""
+        wrapper = ConcreteWrapper(params=["a", "b"])
+        with pytest.raises(TypeError, match="both a positional and a keyword"):
+            wrapper._process_args(1, a=10)
+
+    def test_empty_params_no_args(self):
+        """Empty params list with no args works."""
+        wrapper = ConcreteWrapper(params=[])
+        result = wrapper._process_args()
+        assert result == {}
+
+
+# ===========================================================================
+# TestCallDispatch
+# ===========================================================================
+
+
+class TestCallDispatch:
+    """Tests for BaseToolWrapper.__call__() dispatch."""
+
+    def test_sync_context_calls_sync(self):
+        """In sync context, __call__ returns call_sync result."""
+        wrapper = ConcreteWrapper(
+            params=["a"], sync_result="from_sync", async_result="from_async"
+        )
+        result = wrapper(a=42)
+        assert result["result"] == "from_sync"
+        assert result["kwargs"] == {"a": 42}
+
+    @pytest.mark.asyncio
+    async def test_async_context_calls_async(self):
+        """In async context, __call__ returns a coroutine from call_async."""
+        wrapper = ConcreteWrapper(
+            params=["a"], sync_result="from_sync", async_result="from_async"
+        )
+        result = wrapper(a=42)
+        # In async context, __call__ returns a coroutine
+        if asyncio.iscoroutine(result):
+            result = await result
+        assert result["result"] == "from_async"
+
+    def test_sync_exception_propagates(self):
+        """Exceptions from call_sync propagate through __call__."""
+        wrapper = FailingWrapper(name="fail")
+        with pytest.raises(RuntimeError, match="sync error"):
+            wrapper()
+
+    @pytest.mark.asyncio
+    async def test_async_exception_propagates(self):
+        """Exceptions from call_async propagate through __call__."""
+        wrapper = FailingWrapper(name="fail")
+        result = wrapper()
+        if asyncio.iscoroutine(result):
+            with pytest.raises(RuntimeError, match="async error"):
+                await result
+
+
+# ===========================================================================
+# TestWrapperProtocol
+# ===========================================================================
+
+
+class TestWrapperProtocol:
+    """Tests for BaseToolWrapper as ABC."""
+
+    def test_cannot_instantiate_abc(self):
+        """Cannot directly instantiate BaseToolWrapper."""
+        with pytest.raises(TypeError):
+            BaseToolWrapper(name="test")
+
+    def test_incomplete_subclass_raises(self):
+        """Subclass without call_sync/call_async cannot be instantiated."""
+
+        class IncompleteWrapper(BaseToolWrapper):
+            def call_sync(self, *args, **kwargs):
+                pass
+
+        with pytest.raises(TypeError):
+            IncompleteWrapper(name="test")
+
+    def test_name_stored(self):
+        """Name is stored correctly."""
+        wrapper = ConcreteWrapper(name="my_tool")
+        assert wrapper.name == "my_tool"
+
+    def test_params_stored(self):
+        """Params are stored correctly."""
+        wrapper = ConcreteWrapper(params=["x", "y", "z"])
+        assert wrapper.params == ["x", "y", "z"]
+
+    def test_params_default_none(self):
+        """Params default to None."""
+        wrapper = ConcreteWrapper()
+        assert wrapper.params is None


### PR DESCRIPTION
## Summary

- Add 109 new tests covering previously untested integration modules
- `test_openapi_integration.py` (46 tests): OpenAPIToolWrapper, OpenAPITool, OpenAPIIntegration, utils (extract_base_url, determine_urls, load_openapi_spec)
- `test_langchain_integration.py` (25 tests): LangChainToolWrapper, LangChainTool, LangChainIntegration, end-to-end flows
- `test_mcp_post_processing.py` (21 tests): MCPToolWrapper._post_process_result with all content types, MCPTool.from_tool_json
- `test_tool_wrapper.py` (17 tests): BaseToolWrapper ABC, _process_args, __call__ sync/async dispatch

Total test count: 645 → 754

## Test plan
- [x] All 109 new tests pass
- [x] Full regression (754 tests) passes
- [x] ruff check + format clean