### PR TITLE
feat: add declarative tool config loader (JSONC/YAML)

### DIFF
--- a/src/toolregistry/_vendor/jsonc.py
+++ b/src/toolregistry/_vendor/jsonc.py
@@ -1,0 +1,352 @@
+# /// zerodep
+# version = "0.3.0"
+# deps = []
+# tier = "simple"
+# category = "data"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+
+"""JSONC (JSON with Comments) parser — zero dependencies, stdlib only, Python 3.10+.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Drop-in replacement for commentjson / stdlib json with JSONC support.
+
+Supports:
+    - Single-line comments: ``//`` and ``#``
+    - Block comments: ``/* ... */``
+    - Trailing commas in objects and arrays
+    - All standard JSON types
+
+Example::
+
+    loads('{"a": 1, // comment\n"b": 2}')
+    # {'a': 1, 'b': 2}
+    load(open("config.jsonc"))
+    # {...}
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import IO, Any
+
+__all__ = [
+    "JSONCDecodeError",
+    "loads",
+    "load",
+    "dumps",
+    "dump",
+]
+
+# ── Comment stripping ─────────────────────────────────────────────────────────
+
+# Matches (in priority order):
+#   1. Double-quoted strings (group 1) — preserved as-is
+#   2. Single-line // comments — removed
+#   3. Single-line # comments — removed
+#   4. Block /* ... */ comments — removed
+_COMMENT_RE = re.compile(
+    r"""
+    ( "(?:[^"\\]|\\.)*" )   # group 1: double-quoted string (keep)
+    | //[^\n]*              # single-line // comment
+    | \#[^\n]*              # single-line # comment
+    | /\*[\s\S]*?\*/        # block /* */ comment
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+# Trailing comma before closing ] or }
+_TRAILING_COMMA_RE = re.compile(
+    r"""
+    ( "(?:[^"\\]|\\.)*" )   # group 1: double-quoted string (keep)
+    | ,\s*(?=[}\]])         # comma followed by optional whitespace then } or ]
+    """,
+    re.VERBOSE,
+)
+
+
+def _strip_comments(text: str) -> str:
+    """Remove ``//``, ``#``, and ``/* */`` comments, preserving strings."""
+
+    def _replace(m: re.Match[str]) -> str:
+        if m.group(1) is not None:
+            return m.group(1)
+        return ""
+
+    return _COMMENT_RE.sub(_replace, text)
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas before ``}`` and ``]``, preserving strings."""
+
+    def _replace(m: re.Match[str]) -> str:
+        if m.group(1) is not None:
+            return m.group(1)
+        return ""
+
+    return _TRAILING_COMMA_RE.sub(_replace, text)
+
+
+def _preprocess(text: str) -> str:
+    """Strip comments and trailing commas from JSONC text."""
+    text = _strip_comments(text)
+    text = _strip_trailing_commas(text)
+    return text
+
+
+# ── Line-number error mapping ────────────────────────────────────────────────
+
+
+def _remap_error_position(
+    original: str, cleaned: str, clean_pos: int
+) -> tuple[int, int]:
+    """Map a character offset in *cleaned* text back to *original* line/col.
+
+    Returns (line, column), both 1-based.
+    """
+    # Build a mapping from cleaned-offset → original-offset by replaying the
+    # comment-stripping regex.  Each matched region in the original either maps
+    # 1:1 (strings) or collapses to zero length (comments).
+    orig_idx = 0
+    clean_idx = 0
+    mapping: list[tuple[int, int, int]] = []  # (clean_start, clean_end, orig_start)
+
+    for m in _COMMENT_RE.finditer(original):
+        # Characters before this match map 1:1
+        pre_len = m.start() - orig_idx
+        if pre_len > 0:
+            mapping.append((clean_idx, clean_idx + pre_len, orig_idx))
+            clean_idx += pre_len
+        orig_idx = m.start()
+
+        if m.group(1) is not None:
+            # Preserved string — maps 1:1
+            span_len = m.end() - m.start()
+            mapping.append((clean_idx, clean_idx + span_len, orig_idx))
+            clean_idx += span_len
+        # else: comment — removed, clean_idx doesn't advance
+
+        orig_idx = m.end()
+
+    # Tail after last match
+    tail_len = len(original) - orig_idx
+    if tail_len > 0:
+        mapping.append((clean_idx, clean_idx + tail_len, orig_idx))
+
+    # Look up clean_pos in the mapping
+    orig_offset = clean_pos  # fallback
+    for cs, ce, os_ in mapping:
+        if cs <= clean_pos < ce:
+            orig_offset = os_ + (clean_pos - cs)
+            break
+        if clean_pos < cs:
+            orig_offset = os_
+            break
+
+    # Convert original offset to line/col
+    line = original[:orig_offset].count("\n") + 1
+    last_nl = original.rfind("\n", 0, orig_offset)
+    col = orig_offset - last_nl  # 1-based
+    return line, col
+
+
+class JSONCDecodeError(json.JSONDecodeError):
+    """Error raised when JSONC parsing fails.
+
+    Provides line and column numbers relative to the original JSONC source
+    (before comment/trailing-comma stripping).
+    """
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def loads(
+    text: str,
+    *,
+    cls: type[json.JSONDecoder] | None = None,
+    object_hook: Any = None,
+    parse_float: Any = None,
+    parse_int: Any = None,
+    parse_constant: Any = None,
+    object_pairs_hook: Any = None,
+    **kwargs: Any,
+) -> Any:
+    """Deserialize a JSONC string to a Python object.
+
+    Strips ``//``, ``#``, and ``/* */`` comments and trailing commas before
+    delegating to :func:`json.loads`.
+
+    Args:
+        text: JSONC source string.
+        cls: Custom JSON decoder class.
+        object_hook: Called with the result of any object literal decoded.
+        parse_float: Called with every JSON float string decoded.
+        parse_int: Called with every JSON int string decoded.
+        parse_constant: Called with ``-Infinity``, ``Infinity``, ``NaN``.
+        object_pairs_hook: Called with an ordered list of pairs.
+        **kwargs: Additional keyword arguments passed to :func:`json.loads`.
+
+    Returns:
+        Deserialized Python object.
+
+    Raises:
+        JSONCDecodeError: If the text is not valid JSONC.
+    """
+    cleaned = _preprocess(text)
+    try:
+        return json.loads(
+            cleaned,
+            cls=cls,
+            object_hook=object_hook,
+            parse_float=parse_float,
+            parse_int=parse_int,
+            parse_constant=parse_constant,
+            object_pairs_hook=object_pairs_hook,
+            **kwargs,
+        )
+    except json.JSONDecodeError as exc:
+        line, col = _remap_error_position(text, cleaned, exc.pos)
+        raise JSONCDecodeError(exc.msg, text, exc.pos) from None
+
+
+def load(
+    fp: IO[str],
+    *,
+    cls: type[json.JSONDecoder] | None = None,
+    object_hook: Any = None,
+    parse_float: Any = None,
+    parse_int: Any = None,
+    parse_constant: Any = None,
+    object_pairs_hook: Any = None,
+    **kwargs: Any,
+) -> Any:
+    """Deserialize a JSONC file to a Python object.
+
+    Args:
+        fp: A text file-like object containing JSONC.
+        cls: Custom JSON decoder class.
+        object_hook: Called with the result of any object literal decoded.
+        parse_float: Called with every JSON float string decoded.
+        parse_int: Called with every JSON int string decoded.
+        parse_constant: Called with ``-Infinity``, ``Infinity``, ``NaN``.
+        object_pairs_hook: Called with an ordered list of pairs.
+        **kwargs: Additional keyword arguments passed to :func:`json.loads`.
+
+    Returns:
+        Deserialized Python object.
+
+    Raises:
+        JSONCDecodeError: If the content is not valid JSONC.
+    """
+    return loads(
+        fp.read(),
+        cls=cls,
+        object_hook=object_hook,
+        parse_float=parse_float,
+        parse_int=parse_int,
+        parse_constant=parse_constant,
+        object_pairs_hook=object_pairs_hook,
+        **kwargs,
+    )
+
+
+def dumps(
+    obj: Any,
+    *,
+    skipkeys: bool = False,
+    ensure_ascii: bool = True,
+    check_circular: bool = True,
+    allow_nan: bool = True,
+    cls: type[json.JSONEncoder] | None = None,
+    indent: int | str | None = None,
+    separators: tuple[str, str] | None = None,
+    default: Any = None,
+    sort_keys: bool = False,
+    **kwargs: Any,
+) -> str:
+    """Serialize a Python object to a JSON string.
+
+    This is a pass-through to :func:`json.dumps` for API compatibility.
+
+    Args:
+        obj: Python object to serialize.
+        skipkeys: Skip keys that are not basic types.
+        ensure_ascii: Escape non-ASCII characters.
+        check_circular: Check for circular references.
+        allow_nan: Allow ``NaN``, ``Infinity``, ``-Infinity``.
+        cls: Custom JSON encoder class.
+        indent: Indentation level for pretty-printing.
+        separators: Item and key separators.
+        default: Called for objects that are not serializable.
+        sort_keys: Sort dictionary keys.
+        **kwargs: Additional keyword arguments passed to :func:`json.dumps`.
+
+    Returns:
+        JSON string.
+    """
+    return json.dumps(
+        obj,
+        skipkeys=skipkeys,
+        ensure_ascii=ensure_ascii,
+        check_circular=check_circular,
+        allow_nan=allow_nan,
+        cls=cls,
+        indent=indent,
+        separators=separators,
+        default=default,
+        sort_keys=sort_keys,
+        **kwargs,
+    )
+
+
+def dump(
+    obj: Any,
+    fp: IO[str],
+    *,
+    skipkeys: bool = False,
+    ensure_ascii: bool = True,
+    check_circular: bool = True,
+    allow_nan: bool = True,
+    cls: type[json.JSONEncoder] | None = None,
+    indent: int | str | None = None,
+    separators: tuple[str, str] | None = None,
+    default: Any = None,
+    sort_keys: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Serialize a Python object to a JSON file.
+
+    This is a pass-through to :func:`json.dump` for API compatibility.
+
+    Args:
+        obj: Python object to serialize.
+        fp: A text file-like object to write to.
+        skipkeys: Skip keys that are not basic types.
+        ensure_ascii: Escape non-ASCII characters.
+        check_circular: Check for circular references.
+        allow_nan: Allow ``NaN``, ``Infinity``, ``-Infinity``.
+        cls: Custom JSON encoder class.
+        indent: Indentation level for pretty-printing.
+        separators: Item and key separators.
+        default: Called for objects that are not serializable.
+        sort_keys: Sort dictionary keys.
+        **kwargs: Additional keyword arguments passed to :func:`json.dump`.
+    """
+    json.dump(
+        obj,
+        fp,
+        skipkeys=skipkeys,
+        ensure_ascii=ensure_ascii,
+        check_circular=check_circular,
+        allow_nan=allow_nan,
+        cls=cls,
+        indent=indent,
+        separators=separators,
+        default=default,
+        sort_keys=sort_keys,
+        **kwargs,
+    )

--- a/src/toolregistry/_vendor/yaml.py
+++ b/src/toolregistry/_vendor/yaml.py
@@ -1,0 +1,1114 @@
+# /// zerodep
+# version = "0.3.0"
+# deps = []
+# tier = "subsystem"
+# category = "data"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+
+"""YAML parser and serializer (common subset) — zero dependencies, stdlib only, Python 3.10+.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Supports the most commonly used YAML features: mappings, sequences,
+scalars (str/int/float/bool/null), flow style, block scalars,
+multi-document streams, and comments.
+
+Does NOT implement: anchors/aliases, tags, merge keys, complex keys.
+
+Example::
+
+    data = load("name: Alice\nage: 30")
+    # {'name': 'Alice', 'age': 30}
+    print(dump(data))
+    # age: 30
+    # name: Alice
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import IO, Any, overload
+from collections.abc import Iterator
+
+__all__ = [
+    "YAMLError",
+    "load",
+    "load_all",
+    "dump",
+    "dump_all",
+]
+
+# ── Exceptions ─────────────────────────────────────────────────────────────────
+
+
+class YAMLError(Exception):
+    """Raised when YAML parsing fails."""
+
+
+# ── Scalar type resolution ─────────────────────────────────────────────────────
+
+_NULL_RE = re.compile(r"\A(?:null|Null|NULL|~)\Z")
+_BOOL_TRUE_RE = re.compile(r"\A(?:true|True|TRUE|yes|Yes|YES|on|On|ON)\Z")
+_BOOL_FALSE_RE = re.compile(r"\A(?:false|False|FALSE|no|No|NO|off|Off|OFF)\Z")
+_INT_RE = re.compile(r"\A[-+]?(?:0|[1-9][0-9_]*)\Z")
+_INT_HEX_RE = re.compile(r"\A0x[0-9a-fA-F_]+\Z")
+_INT_OCT_RE = re.compile(r"\A0[0-7_]+\Z")  # YAML 1.1 octal: 0777 (not 0o777)
+_INT_BIN_RE = re.compile(r"\A0b[01_]+\Z")
+# YAML 1.1 requires explicit sign (+/-) in exponent when base has decimal point
+_FLOAT_RE = re.compile(r"\A[-+]?(?:\.[0-9]+|[0-9]+\.[0-9]*)(?:[eE][-+][0-9]+)?\Z")
+_INF_RE = re.compile(r"\A[-+]?\.(?:inf|Inf|INF)\Z")
+_NAN_RE = re.compile(r"\A\.(?:nan|NaN|NAN)\Z")
+
+
+def _resolve_scalar(value: str) -> str | int | float | bool | None:
+    """Resolve a plain (unquoted) scalar string to a typed Python value."""
+    if not value:
+        return None
+    if _NULL_RE.match(value):
+        return None
+    if _BOOL_TRUE_RE.match(value):
+        return True
+    if _BOOL_FALSE_RE.match(value):
+        return False
+    if _INT_RE.match(value):
+        return int(value.replace("_", ""))
+    if _INT_HEX_RE.match(value):
+        return int(value.replace("_", ""), 16)
+    if _INT_OCT_RE.match(value):
+        return int(value.replace("_", ""), 8)  # YAML 1.1: 0777 -> 511
+    if _INT_BIN_RE.match(value):
+        return int(value.replace("_", ""), 2)
+    if _FLOAT_RE.match(value):
+        return float(value.replace("_", ""))
+    if _INF_RE.match(value):
+        return float("-inf") if value.startswith("-") else float("inf")
+    if _NAN_RE.match(value):
+        return float("nan")
+    return value
+
+
+# ── String unquoting ───────────────────────────────────────────────────────────
+
+_DQ_ESCAPE_MAP = {
+    "\\": "\\",
+    '"': '"',
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "0": "\0",
+    "a": "\a",
+    "b": "\b",
+    "e": "\x1b",
+    "v": "\v",
+    "/": "/",
+    " ": " ",
+    "N": "\x85",
+    "_": "\xa0",
+}
+
+
+def _unescape_double_quoted(s: str) -> str:
+    """Process escape sequences in a double-quoted YAML string."""
+    result: list[str] = []
+    i = 0
+    while i < len(s):
+        if s[i] == "\\" and i + 1 < len(s):
+            nxt = s[i + 1]
+            if nxt in _DQ_ESCAPE_MAP:
+                result.append(_DQ_ESCAPE_MAP[nxt])
+                i += 2
+            elif nxt == "x" and i + 3 < len(s):
+                result.append(chr(int(s[i + 2 : i + 4], 16)))
+                i += 4
+            elif nxt == "u" and i + 5 < len(s):
+                result.append(chr(int(s[i + 2 : i + 6], 16)))
+                i += 6
+            elif nxt == "U" and i + 9 < len(s):
+                result.append(chr(int(s[i + 2 : i + 10], 16)))
+                i += 10
+            else:
+                result.append(s[i])
+                i += 1
+        else:
+            result.append(s[i])
+            i += 1
+    return "".join(result)
+
+
+def _unquote(s: str) -> str:
+    """Remove quotes from a YAML scalar and process escapes if needed."""
+    if len(s) >= 2:
+        if s[0] == "'" and s[-1] == "'":
+            # Single-quoted: only '' escapes to '
+            return s[1:-1].replace("''", "'")
+        if s[0] == '"' and s[-1] == '"':
+            return _unescape_double_quoted(s[1:-1])
+    return s
+
+
+# ── Scanner ────────────────────────────────────────────────────────────────────
+
+
+class _Line:
+    """A logical line with tracked indentation and line number."""
+
+    __slots__ = ("indent", "text", "lineno")
+
+    def __init__(self, indent: int, text: str, lineno: int):
+        self.indent = indent
+        self.text = text
+        self.lineno = lineno
+
+    def __repr__(self) -> str:
+        return f"_Line({self.lineno}: indent={self.indent}, {self.text!r})"
+
+
+def _strip_inline_comment(text: str) -> str:
+    """Remove inline comments from a line, respecting quoted strings."""
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and in_double and i + 1 < len(text):
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            # Must be preceded by whitespace to be a comment
+            if i == 0 or text[i - 1] in (" ", "\t"):
+                return text[:i].rstrip()
+        i += 1
+    return text
+
+
+def _scan(text: str) -> list[_Line]:
+    """Convert raw YAML text into a list of logical lines."""
+    lines: list[_Line] = []
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        # Preserve completely empty lines for block scalar detection
+        stripped = raw.lstrip()
+        if not stripped or stripped[0] == "#":
+            continue
+        indent = len(raw) - len(stripped)
+        # Don't strip comments from block scalar indicators or document markers
+        if stripped.startswith("---") or stripped.startswith("..."):
+            lines.append(_Line(indent, stripped, lineno))
+        else:
+            cleaned = _strip_inline_comment(stripped)
+            if cleaned:
+                lines.append(_Line(indent, cleaned, lineno))
+    return lines
+
+
+# ── Parser ─────────────────────────────────────────────────────────────────────
+
+
+class _Parser:
+    """Recursive-descent YAML parser for the common subset."""
+
+    def __init__(self, lines: list[_Line], raw_lines: list[str]):
+        self._lines = lines
+        self._raw_lines = raw_lines  # original text lines for block scalars
+        self._pos = 0
+
+    def _peek(self) -> _Line | None:
+        if self._pos < len(self._lines):
+            return self._lines[self._pos]
+        return None
+
+    def _advance(self) -> _Line:
+        line = self._lines[self._pos]
+        self._pos += 1
+        return line
+
+    def _error(self, msg: str, lineno: int | None = None) -> YAMLError:
+        if lineno is None:
+            cur = self._peek()
+            lineno = cur.lineno if cur else -1
+        return YAMLError(f"line {lineno}: {msg}")
+
+    # ── Document parsing ──
+
+    def parse_stream(self) -> list[Any]:
+        """Parse the entire stream, returning a list of documents."""
+        documents: list[Any] = []
+
+        # Skip leading document marker if present
+        cur = self._peek()
+        if cur is not None and cur.text == "---":
+            self._advance()
+
+        while self._pos < len(self._lines):
+            doc = self._parse_node(-1)
+            documents.append(doc)
+
+            # Check for document separator
+            cur = self._peek()
+            if cur is not None and cur.text in ("---", "..."):
+                self._advance()
+                # '...' without following '---' ends the stream
+                if cur.text == "...":
+                    cur2 = self._peek()
+                    if cur2 is None or cur2.text != "---":
+                        break
+                    self._advance()  # skip the ---
+
+        if not documents:
+            documents.append(None)
+
+        return documents
+
+    def _parse_node(self, parent_indent: int) -> Any:
+        """Parse a YAML node (mapping, sequence, or scalar)."""
+        cur = self._peek()
+        if cur is None:
+            return None
+
+        # Document end markers
+        if cur.text in ("---", "..."):
+            return None
+
+        text = cur.text
+
+        # Flow collections
+        if text.startswith("{"):
+            return self._parse_flow_mapping()
+        if text.startswith("["):
+            return self._parse_flow_sequence()
+
+        # Block scalar
+        if text.startswith("|") or text.startswith(">"):
+            return self._parse_block_scalar()
+
+        # Block sequence
+        if text.startswith("- ") or text == "-":
+            return self._parse_block_sequence(cur.indent)
+
+        # Check if it's a mapping (contains ': ' or ends with ':')
+        if self._is_mapping_line(text):
+            return self._parse_block_mapping(cur.indent)
+
+        # Plain scalar
+        self._advance()
+        return self._parse_scalar_value(text)
+
+    def _is_mapping_line(self, text: str) -> bool:
+        """Check if a line represents a mapping key."""
+        # Must handle quoted keys with colons inside
+        i = 0
+        if text.startswith("'"):
+            # Skip to closing single quote
+            i = text.find("'", 1)
+            if i < 0:
+                return False
+            i += 1
+        elif text.startswith('"'):
+            # Skip to closing double quote (handle escapes)
+            i = 1
+            while i < len(text):
+                if text[i] == "\\" and i + 1 < len(text):
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+
+        # Look for ': ' or ':' at end after the key
+        while i < len(text):
+            if text[i] == ":":
+                if i + 1 == len(text):
+                    return True
+                if text[i + 1] == " " or text[i + 1] == "\t":
+                    return True
+            i += 1
+        return False
+
+    def _split_mapping_line(self, text: str) -> tuple[str, str]:
+        """Split a mapping line into key and value parts."""
+        i = 0
+        if text.startswith("'"):
+            i = text.find("'", 1)
+            if i < 0:
+                return text, ""
+            i += 1
+        elif text.startswith('"'):
+            i = 1
+            while i < len(text):
+                if text[i] == "\\" and i + 1 < len(text):
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+
+        while i < len(text):
+            if text[i] == ":":
+                if i + 1 == len(text):
+                    return text[:i], ""
+                if text[i + 1] in (" ", "\t"):
+                    return text[:i], text[i + 2 :].strip()
+            i += 1
+        return text, ""
+
+    # ── Block mapping ──
+
+    def _parse_block_mapping(self, indent: int) -> dict:
+        result: dict[Any, Any] = {}
+        while True:
+            cur = self._peek()
+            if cur is None or cur.indent < indent:
+                break
+            if cur.text in ("---", "..."):
+                break
+            if cur.indent != indent:
+                break
+            if not self._is_mapping_line(cur.text):
+                break
+
+            self._advance()
+            raw_key, raw_value = self._split_mapping_line(cur.text)
+            key = self._parse_scalar_value(raw_key)
+
+            if raw_value:
+                # Inline value
+                if raw_value.startswith("{"):
+                    # Need to parse as flow mapping from this text
+                    value = self._parse_flow_from_text(raw_value)
+                elif raw_value.startswith("["):
+                    value = self._parse_flow_from_text(raw_value)
+                elif raw_value.startswith("|") or raw_value.startswith(">"):
+                    # Block scalar indicator as inline value
+                    value = self._parse_block_scalar_from_indicator(
+                        raw_value, cur.lineno
+                    )
+                else:
+                    value = self._parse_scalar_value(raw_value)
+            else:
+                # Value on next line(s)
+                nxt = self._peek()
+                if nxt is None or nxt.indent <= indent or nxt.text in ("---", "..."):
+                    value = None
+                else:
+                    value = self._parse_node(indent)
+            result[key] = value
+        return result
+
+    # ── Block sequence ──
+
+    def _parse_block_sequence(self, indent: int) -> list:
+        result: list[Any] = []
+        while True:
+            cur = self._peek()
+            if cur is None or cur.indent < indent:
+                break
+            if cur.text in ("---", "..."):
+                break
+            if cur.indent != indent:
+                break
+            if not (cur.text.startswith("- ") or cur.text == "-"):
+                break
+
+            self._advance()
+            item_text = cur.text[2:].strip() if cur.text.startswith("- ") else ""
+
+            if not item_text:
+                # Value on next line(s)
+                nxt = self._peek()
+                if nxt is None or nxt.indent <= indent or nxt.text in ("---", "..."):
+                    result.append(None)
+                else:
+                    result.append(self._parse_node(indent))
+            elif item_text.startswith("{"):
+                result.append(self._parse_flow_from_text(item_text))
+            elif item_text.startswith("["):
+                result.append(self._parse_flow_from_text(item_text))
+            elif self._is_mapping_line(item_text):
+                # Sequence of mappings: - key: value
+                # The mapping continues at indent+2
+                raw_key, raw_value = self._split_mapping_line(item_text)
+                key = self._parse_scalar_value(raw_key)
+                mapping: dict[Any, Any] = {}
+
+                if raw_value:
+                    if raw_value.startswith("{"):
+                        mapping[key] = self._parse_flow_from_text(raw_value)
+                    elif raw_value.startswith("["):
+                        mapping[key] = self._parse_flow_from_text(raw_value)
+                    elif raw_value.startswith("|") or raw_value.startswith(">"):
+                        mapping[key] = self._parse_block_scalar_from_indicator(
+                            raw_value, cur.lineno
+                        )
+                    else:
+                        mapping[key] = self._parse_scalar_value(raw_value)
+                else:
+                    nxt = self._peek()
+                    if (
+                        nxt is not None
+                        and nxt.indent > indent
+                        and nxt.text not in ("---", "...")
+                    ):
+                        mapping[key] = self._parse_node(indent)
+                    else:
+                        mapping[key] = None
+
+                # Continue reading mapping entries at deeper indent
+                nxt = self._peek()
+                if (
+                    nxt is not None
+                    and nxt.indent > indent
+                    and self._is_mapping_line(nxt.text)
+                ):
+                    rest = self._parse_block_mapping(nxt.indent)
+                    mapping.update(rest)
+
+                result.append(mapping)
+            else:
+                result.append(self._parse_scalar_value(item_text))
+
+        return result
+
+    # ── Block scalars ──
+
+    def _parse_block_scalar(self) -> str:
+        cur = self._advance()
+        return self._parse_block_scalar_from_indicator(cur.text, cur.lineno)
+
+    def _parse_block_scalar_from_indicator(
+        self, indicator_line: str, lineno: int
+    ) -> str:
+        """Parse a | or > block scalar, reading content lines from raw_lines."""
+        indicator = indicator_line[0]
+        header = indicator_line[1:].strip()
+
+        # Parse chomping and explicit indent
+        chomp = "clip"  # default
+        explicit_indent = 0
+        for ch in header:
+            if ch == "-":
+                chomp = "strip"
+            elif ch == "+":
+                chomp = "keep"
+            elif ch.isdigit():
+                explicit_indent = int(ch)
+
+        # Collect content lines from the raw text
+        # We need to find lines after the indicator in the raw text
+        content_lines: list[str] = []
+        raw_lineno = lineno  # lineno is 1-based index into raw_lines
+
+        if raw_lineno < len(self._raw_lines):
+            # Determine content indent from first non-empty content line
+            content_indent = 0
+            if explicit_indent > 0:
+                content_indent = explicit_indent
+            else:
+                for j in range(raw_lineno, len(self._raw_lines)):
+                    raw = self._raw_lines[j]
+                    stripped = raw.lstrip()
+                    if stripped and not stripped.startswith("#"):
+                        content_indent = len(raw) - len(stripped)
+                        break
+
+            if content_indent == 0:
+                # Could not determine indent, return empty
+                return ""
+
+            # Collect lines at or deeper than content_indent
+            for j in range(raw_lineno, len(self._raw_lines)):
+                raw = self._raw_lines[j]
+                if not raw.strip():
+                    # Empty line
+                    content_lines.append("")
+                    continue
+                line_indent = len(raw) - len(raw.lstrip())
+                if line_indent < content_indent:
+                    break
+                content_lines.append(raw[content_indent:])
+
+        # Skip consumed content lines in the scanner
+        while True:
+            nxt = self._peek()
+            if nxt is None:
+                break
+            # If the next scanned line is one we already consumed as block scalar content
+            if nxt.lineno <= lineno + len(content_lines):
+                self._advance()
+            else:
+                break
+
+        # Remove trailing empty lines for processing
+        while content_lines and not content_lines[-1]:
+            content_lines.pop()
+
+        if indicator == "|":
+            # Literal: preserve line breaks
+            text = "\n".join(content_lines)
+        else:
+            # Folded: replace single newlines with spaces
+            parts: list[str] = []
+            for line in content_lines:
+                if not line:
+                    parts.append("\n")
+                elif parts and parts[-1] != "\n" and not parts[-1].endswith("\n"):
+                    parts.append(" " + line)
+                else:
+                    parts.append(line)
+            text = "".join(parts)
+
+        # Apply chomping
+        if chomp == "strip":
+            return text
+        elif chomp == "keep":
+            return text + "\n"
+        else:  # clip
+            return text + "\n" if text else ""
+
+    # ── Flow collections ──
+
+    def _parse_flow_mapping(self) -> dict:
+        cur = self._advance()
+        return self._parse_flow_from_text(cur.text)
+
+    def _parse_flow_sequence(self) -> list:
+        cur = self._advance()
+        return self._parse_flow_from_text(cur.text)
+
+    def _parse_flow_from_text(self, text: str) -> Any:
+        """Parse a flow collection from raw text."""
+        tokens = _FlowTokenizer(text)
+        return tokens.parse()
+
+    # ── Scalar value ──
+
+    def _parse_scalar_value(self, text: str) -> Any:
+        """Parse a scalar value, handling quoting and type resolution."""
+        if not text:
+            return None
+        # Quoted strings
+        if (text.startswith("'") and text.endswith("'")) or (
+            text.startswith('"') and text.endswith('"')
+        ):
+            return _unquote(text)
+        # Plain scalar
+        return _resolve_scalar(text)
+
+
+# ── Flow tokenizer ────────────────────────────────────────────────────────────
+
+
+class _FlowTokenizer:
+    """Character-level parser for flow-style YAML collections."""
+
+    def __init__(self, text: str):
+        self._text = text
+        self._pos = 0
+
+    def _skip_ws(self) -> None:
+        while self._pos < len(self._text) and self._text[self._pos] in (
+            " ",
+            "\t",
+            "\n",
+            "\r",
+        ):
+            self._pos += 1
+
+    def _peek(self) -> str:
+        if self._pos < len(self._text):
+            return self._text[self._pos]
+        return ""
+
+    def parse(self) -> Any:
+        self._skip_ws()
+        ch = self._peek()
+        if ch == "{":
+            return self._parse_mapping()
+        if ch == "[":
+            return self._parse_sequence()
+        return self._parse_value()
+
+    def _parse_mapping(self) -> dict:
+        self._pos += 1  # skip {
+        result: dict[Any, Any] = {}
+        self._skip_ws()
+        if self._peek() == "}":
+            self._pos += 1
+            return result
+
+        while True:
+            self._skip_ws()
+            key = self._parse_value()
+            self._skip_ws()
+            if self._peek() == ":":
+                self._pos += 1
+                self._skip_ws()
+                value = self.parse()
+            else:
+                value = None
+            result[key] = value
+            self._skip_ws()
+            if self._peek() == ",":
+                self._pos += 1
+                self._skip_ws()
+                if self._peek() == "}":
+                    self._pos += 1
+                    break
+            elif self._peek() == "}":
+                self._pos += 1
+                break
+            else:
+                break
+        return result
+
+    def _parse_sequence(self) -> list:
+        self._pos += 1  # skip [
+        result: list[Any] = []
+        self._skip_ws()
+        if self._peek() == "]":
+            self._pos += 1
+            return result
+
+        while True:
+            self._skip_ws()
+            item = self.parse()
+            result.append(item)
+            self._skip_ws()
+            if self._peek() == ",":
+                self._pos += 1
+                self._skip_ws()
+                if self._peek() == "]":
+                    self._pos += 1
+                    break
+            elif self._peek() == "]":
+                self._pos += 1
+                break
+            else:
+                break
+        return result
+
+    def _parse_value(self) -> Any:
+        self._skip_ws()
+        ch = self._peek()
+        if ch == "{":
+            return self._parse_mapping()
+        if ch == "[":
+            return self._parse_sequence()
+        if ch == "'":
+            return self._parse_single_quoted()
+        if ch == '"':
+            return self._parse_double_quoted()
+        return self._parse_plain_scalar()
+
+    def _parse_single_quoted(self) -> str:
+        self._pos += 1  # skip opening '
+        parts: list[str] = []
+        while self._pos < len(self._text):
+            ch = self._text[self._pos]
+            if ch == "'":
+                if self._pos + 1 < len(self._text) and self._text[self._pos + 1] == "'":
+                    parts.append("'")
+                    self._pos += 2
+                else:
+                    self._pos += 1
+                    break
+            else:
+                parts.append(ch)
+                self._pos += 1
+        return "".join(parts)
+
+    def _parse_double_quoted(self) -> str:
+        self._pos += 1  # skip opening "
+        parts: list[str] = []
+        while self._pos < len(self._text):
+            ch = self._text[self._pos]
+            if ch == "\\" and self._pos + 1 < len(self._text):
+                nxt = self._text[self._pos + 1]
+                if nxt in _DQ_ESCAPE_MAP:
+                    parts.append(_DQ_ESCAPE_MAP[nxt])
+                    self._pos += 2
+                else:
+                    parts.append(ch)
+                    self._pos += 1
+            elif ch == '"':
+                self._pos += 1
+                break
+            else:
+                parts.append(ch)
+                self._pos += 1
+        return "".join(parts)
+
+    def _parse_plain_scalar(self) -> Any:
+        start = self._pos
+        # Read until a flow indicator or end
+        while self._pos < len(self._text):
+            ch = self._text[self._pos]
+            if ch in (",", "}", "]", "{", "[", ":"):
+                break
+            self._pos += 1
+        raw = self._text[start : self._pos].strip()
+        if not raw:
+            return None
+        return _resolve_scalar(raw)
+
+
+# ── Dumper ─────────────────────────────────────────────────────────────────────
+
+# Characters that force quoting in a plain scalar
+_NEEDS_QUOTE_RE = re.compile(
+    r"[:\#{}\[\],&*?|>!%@`]"
+    r"|^[-?]$"
+    r"|^\s"
+    r"|\s$"
+    r"|\n"
+)
+
+
+class _Dumper:
+    """YAML serializer."""
+
+    def __init__(
+        self,
+        indent: int = 2,
+        default_flow_style: bool | None = None,
+        sort_keys: bool = True,
+        allow_unicode: bool = True,
+    ):
+        self._indent = indent
+        self._flow = default_flow_style
+        self._sort_keys = sort_keys
+        self._allow_unicode = allow_unicode
+        self._seen: set[int] = set()
+
+    def dump(self, data: Any) -> str:
+        self._seen.clear()
+        result = self._represent(data, 0)
+        if result.endswith("\n"):
+            return result
+        return result + "\n"
+
+    def _represent(self, data: Any, level: int) -> str:
+        if isinstance(data, dict):
+            return self._represent_mapping(data, level)
+        if isinstance(data, (list, tuple)):
+            return self._represent_sequence(data, level)
+        return self._represent_scalar(data)
+
+    def _represent_mapping(self, data: dict, level: int) -> str:
+        if id(data) in self._seen:
+            raise YAMLError("Circular reference detected")
+        self._seen.add(id(data))
+
+        if not data:
+            return "{}"
+
+        if self._flow is True:
+            items = []
+            keys = sorted(data.keys(), key=str) if self._sort_keys else data.keys()
+            for key in keys:
+                k = self._represent_scalar(key)
+                v = self._represent(data[key], level)
+                items.append(f"{k}: {v}")
+            self._seen.discard(id(data))
+            return "{" + ", ".join(items) + "}"
+
+        lines: list[str] = []
+        prefix = " " * (self._indent * level)
+        keys = sorted(data.keys(), key=str) if self._sort_keys else data.keys()
+        for key in keys:
+            k = self._represent_scalar(key)
+            val = data[key]
+            if isinstance(val, dict) and val:
+                lines.append(f"{prefix}{k}:")
+                lines.append(self._represent_mapping(val, level + 1))
+            elif isinstance(val, (list, tuple)) and val:
+                lines.append(f"{prefix}{k}:")
+                lines.append(self._represent_sequence(val, level + 1))
+            else:
+                v = self._represent(val, level + 1)
+                lines.append(f"{prefix}{k}: {v}")
+        self._seen.discard(id(data))
+        return "\n".join(lines)
+
+    def _represent_sequence(self, data: list | tuple, level: int) -> str:
+        if id(data) in self._seen:
+            raise YAMLError("Circular reference detected")
+        self._seen.add(id(data))
+
+        if not data:
+            return "[]"
+
+        if self._flow is True:
+            items = [self._represent(item, level) for item in data]
+            self._seen.discard(id(data))
+            return "[" + ", ".join(items) + "]"
+
+        lines: list[str] = []
+        prefix = " " * (self._indent * level)
+        for item in data:
+            if isinstance(item, dict) and item:
+                # First key on the same line as -
+                keys = (
+                    sorted(item.keys(), key=str)
+                    if self._sort_keys
+                    else list(item.keys())
+                )
+                first_key = keys[0]
+                first_val = item[first_key]
+                k = self._represent_scalar(first_key)
+
+                if isinstance(first_val, (dict, list, tuple)) and first_val:
+                    lines.append(f"{prefix}- {k}:")
+                    lines.append(self._represent(first_val, level + 2))
+                else:
+                    v = self._represent(first_val, level + 2)
+                    lines.append(f"{prefix}- {k}: {v}")
+
+                # Remaining keys
+                for rk in keys[1:]:
+                    rv = item[rk]
+                    rk_s = self._represent_scalar(rk)
+                    inner_prefix = prefix + " " * self._indent
+                    if isinstance(rv, (dict, list, tuple)) and rv:
+                        lines.append(f"{inner_prefix}{rk_s}:")
+                        lines.append(self._represent(rv, level + 2))
+                    else:
+                        rv_s = self._represent(rv, level + 2)
+                        lines.append(f"{inner_prefix}{rk_s}: {rv_s}")
+            elif isinstance(item, (list, tuple)) and item:
+                lines.append(f"{prefix}-")
+                lines.append(self._represent_sequence(item, level + 1))
+            else:
+                v = self._represent(item, level + 1)
+                lines.append(f"{prefix}- {v}")
+
+        self._seen.discard(id(data))
+        return "\n".join(lines)
+
+    def _represent_scalar(self, data: Any) -> str:
+        if data is None:
+            return "null"
+        if isinstance(data, bool):
+            return "true" if data else "false"
+        if isinstance(data, int):
+            return str(data)
+        if isinstance(data, float):
+            if math.isnan(data):
+                return ".nan"
+            if math.isinf(data):
+                return ".inf" if data > 0 else "-.inf"
+            return str(data)
+        if isinstance(data, str):
+            return self._represent_str(data)
+        return str(data)
+
+    def _represent_str(self, s: str) -> str:
+        if not s:
+            return "''"
+
+        # Check if it looks like a special YAML value
+        if (
+            _NULL_RE.match(s)
+            or _BOOL_TRUE_RE.match(s)
+            or _BOOL_FALSE_RE.match(s)
+            or _INT_RE.match(s)
+            or _INT_HEX_RE.match(s)
+            or _FLOAT_RE.match(s)
+            or _INF_RE.match(s)
+            or _NAN_RE.match(s)
+        ):
+            return f"'{s}'"
+
+        # Check if quoting is needed
+        if _NEEDS_QUOTE_RE.search(s):
+            if "\n" in s:
+                # Use literal block scalar for multiline
+                return "|\n" + "\n".join("  " + line for line in s.split("\n"))
+            # Use single quotes, escaping internal single quotes
+            return "'" + s.replace("'", "''") + "'"
+
+        return s
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def load(text: str) -> Any:
+    """Parse a YAML string and return a Python object.
+
+    Only produces safe types: dict, list, str, int, float, bool, None.
+    Equivalent to PyYAML's ``yaml.safe_load()``.
+
+    Args:
+        text: YAML document string.
+
+    Returns:
+        Parsed Python object.
+
+    Raises:
+        YAMLError: If the YAML is malformed.
+    """
+    if not text or not text.strip():
+        return None
+    raw_lines = text.splitlines()
+    lines = _scan(text)
+    if not lines:
+        return None
+    parser = _Parser(lines, raw_lines)
+    docs = parser.parse_stream()
+    return docs[0] if docs else None
+
+
+def load_all(text: str) -> Iterator[Any]:
+    """Parse a multi-document YAML string.
+
+    Yields one Python object per YAML document (separated by ``---``).
+
+    Args:
+        text: Multi-document YAML string.
+
+    Yields:
+        Parsed Python objects, one per document.
+    """
+    if not text or not text.strip():
+        yield None
+        return
+    raw_lines = text.splitlines()
+    lines = _scan(text)
+    if not lines:
+        yield None
+        return
+    parser = _Parser(lines, raw_lines)
+    docs = parser.parse_stream()
+    yield from docs
+
+
+@overload
+def dump(
+    data: Any,
+    stream: None = None,
+    *,
+    default_flow_style: bool | None = None,
+    indent: int = 2,
+    sort_keys: bool = True,
+    allow_unicode: bool = True,
+) -> str: ...
+
+
+@overload
+def dump(
+    data: Any,
+    stream: IO[str],
+    *,
+    default_flow_style: bool | None = None,
+    indent: int = 2,
+    sort_keys: bool = True,
+    allow_unicode: bool = True,
+) -> None: ...
+
+
+def dump(
+    data: Any,
+    stream: IO[str] | None = None,
+    *,
+    default_flow_style: bool | None = None,
+    indent: int = 2,
+    sort_keys: bool = True,
+    allow_unicode: bool = True,
+) -> str | None:
+    """Serialize a Python object to a YAML string.
+
+    Args:
+        data: Python object to serialize.
+        stream: If provided, write to this stream and return None.
+        default_flow_style: True for flow (inline) style, False for block,
+            None for auto (empty collections use flow).
+        indent: Number of spaces per indentation level.
+        sort_keys: Sort mapping keys alphabetically.
+        allow_unicode: Allow unicode characters in output.
+
+    Returns:
+        YAML string if *stream* is None, otherwise None.
+    """
+    dumper = _Dumper(
+        indent=indent,
+        default_flow_style=default_flow_style,
+        sort_keys=sort_keys,
+        allow_unicode=allow_unicode,
+    )
+    result = dumper.dump(data)
+    if stream is not None:
+        stream.write(result)
+        return None
+    return result
+
+
+@overload
+def dump_all(
+    documents: list[Any] | tuple[Any, ...],
+    stream: None = None,
+    *,
+    default_flow_style: bool | None = None,
+    indent: int = 2,
+    sort_keys: bool = True,
+    allow_unicode: bool = True,
+) -> str: ...
+
+
+@overload
+def dump_all(
+    documents: list[Any] | tuple[Any, ...],
+    stream: IO[str],
+    *,
+    default_flow_style: bool | None = None,
+    indent: int = 2,
+    sort_keys: bool = True,
+    allow_unicode: bool = True,
+) -> None: ...
+
+
+def dump_all(
+    documents: list[Any] | tuple[Any, ...],
+    stream: IO[str] | None = None,
+    *,
+    default_flow_style: bool | None = None,
+    indent: int = 2,
+    sort_keys: bool = True,
+    allow_unicode: bool = True,
+) -> str | None:
+    """Serialize multiple Python objects as a multi-document YAML string.
+
+    Args:
+        documents: Iterable of Python objects to serialize.
+        stream: If provided, write to this stream and return None.
+        default_flow_style: True for flow style, False for block, None for auto.
+        indent: Number of spaces per indentation level.
+        sort_keys: Sort mapping keys alphabetically.
+        allow_unicode: Allow unicode characters in output.
+
+    Returns:
+        YAML string if *stream* is None, otherwise None.
+    """
+    dumper = _Dumper(
+        indent=indent,
+        default_flow_style=default_flow_style,
+        sort_keys=sort_keys,
+        allow_unicode=allow_unicode,
+    )
+    parts: list[str] = []
+    for i, doc in enumerate(documents):
+        if i > 0:
+            parts.append("---\n")
+        parts.append(dumper.dump(doc))
+    result = "".join(parts)
+    if stream is not None:
+        stream.write(result)
+        return None
+    return result

--- a/src/toolregistry/config/__init__.py
+++ b/src/toolregistry/config/__init__.py
@@ -1,0 +1,36 @@
+"""Declarative tool configuration loader.
+
+Parse JSONC or YAML config files into typed Python objects describing
+tool sources (Python classes/modules, OpenAPI endpoints, MCP servers)
+and filtering rules (denylist/allowlist by namespace).
+
+Example::
+
+    from toolregistry.config import load_config
+
+    config = load_config("tools.yaml")
+    for source in config.tools:
+        print(source)
+"""
+
+from ._loader import load_config
+from ._types import (
+    AuthConfig,
+    ConfigError,
+    MCPSource,
+    OpenAPISource,
+    PythonSource,
+    ToolConfig,
+    ToolSource,
+)
+
+__all__ = [
+    "load_config",
+    "AuthConfig",
+    "ConfigError",
+    "MCPSource",
+    "OpenAPISource",
+    "PythonSource",
+    "ToolConfig",
+    "ToolSource",
+]

--- a/src/toolregistry/config/_loader.py
+++ b/src/toolregistry/config/_loader.py
@@ -1,0 +1,314 @@
+"""Config file loading, parsing, and validation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+from ._types import (
+    AuthConfig,
+    ConfigError,
+    MCPSource,
+    OpenAPISource,
+    PythonSource,
+    ToolConfig,
+    ToolSource,
+)
+
+__all__ = ["load_config"]
+
+_TRANSPORT_ALIASES: dict[str, str] = {
+    "http": "streamable-http",
+}
+
+
+def load_config(path: str | Path) -> ToolConfig:
+    """Load and parse a tool configuration file.
+
+    Supports JSONC (``.json``, ``.jsonc``) and YAML (``.yaml``, ``.yml``)
+    formats.  The file format is auto-detected from the extension.
+
+    Args:
+        path: Path to the configuration file.
+
+    Returns:
+        Parsed and validated ``ToolConfig``.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+        ConfigError: If the content is semantically invalid.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(f"Config file not found: {p}")
+    fmt = _detect_format(p)
+    data = _parse_file(p, fmt)
+    return _build_config(data, source=str(p))
+
+
+# --- format detection -------------------------------------------------------
+
+
+def _detect_format(path: Path) -> Literal["jsonc", "yaml"]:
+    suffix = path.suffix.lower()
+    if suffix in (".json", ".jsonc"):
+        return "jsonc"
+    if suffix in (".yaml", ".yml"):
+        return "yaml"
+    raise ConfigError(
+        f"Unsupported config file extension '{suffix}'. "
+        "Expected .json, .jsonc, .yaml, or .yml."
+    )
+
+
+# --- raw parsing -------------------------------------------------------------
+
+
+def _parse_file(path: Path, fmt: Literal["jsonc", "yaml"]) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if fmt == "jsonc":
+        from .._vendor.jsonc import loads as jsonc_loads
+
+        data = jsonc_loads(text)
+    else:
+        from .._vendor.yaml import load as yaml_load
+
+        data = yaml_load(text)
+
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f"Config file must contain a mapping at the top level, "
+            f"got {type(data).__name__}."
+        )
+    return data
+
+
+# --- config building ---------------------------------------------------------
+
+
+def _build_config(data: dict[str, Any], source: str) -> ToolConfig:
+    mode = data.get("mode", "denylist")
+    if mode not in ("denylist", "allowlist"):
+        raise ConfigError(f"Invalid mode '{mode}'. Must be 'denylist' or 'allowlist'.")
+
+    disabled = _validate_string_list(data, "disabled")
+    enabled_list = _validate_string_list(data, "enabled")
+
+    raw_tools = data.get("tools", [])
+    if not isinstance(raw_tools, list):
+        raise ConfigError(f"'tools' must be a list, got {type(raw_tools).__name__}.")
+
+    tools: list[ToolSource] = []
+    for i, entry in enumerate(raw_tools):
+        if not isinstance(entry, dict):
+            raise ConfigError(
+                f"Tool entry at index {i} must be a mapping, "
+                f"got {type(entry).__name__}."
+            )
+        tools.append(_build_tool_source(entry, i))
+
+    return ToolConfig(
+        mode=mode,
+        disabled=tuple(disabled),
+        enabled=tuple(enabled_list),
+        tools=tuple(tools),
+        source=source,
+    )
+
+
+def _validate_string_list(data: dict[str, Any], key: str) -> list[str]:
+    value = data.get(key, [])
+    if not isinstance(value, list):
+        raise ConfigError(f"'{key}' must be a list, got {type(value).__name__}.")
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ConfigError(
+                f"'{key}[{i}]' must be a string, got {type(item).__name__}."
+            )
+    return value
+
+
+# --- tool source dispatch ----------------------------------------------------
+
+
+def _build_tool_source(entry: dict[str, Any], index: int) -> ToolSource:
+    tool_type = _infer_type(entry, index)
+    namespace = entry.get("namespace")
+    enabled = entry.get("enabled", True)
+
+    if tool_type == "python":
+        return _build_python_source(entry, index, namespace, enabled)
+    if tool_type == "mcp":
+        return _build_mcp_source(entry, index, namespace, enabled)
+    if tool_type == "openapi":
+        return _build_openapi_source(entry, index, namespace, enabled)
+    raise ConfigError(f"Tool entry at index {index}: unknown type '{tool_type}'.")
+
+
+def _infer_type(entry: dict[str, Any], index: int) -> str:
+    if "type" in entry:
+        return entry["type"]
+    # Backward compat: class/module keys imply "python"
+    if "class" in entry or "module" in entry:
+        return "python"
+    raise ConfigError(
+        f"Tool entry at index {index}: missing 'type' field "
+        "and cannot infer type from keys."
+    )
+
+
+# --- python source -----------------------------------------------------------
+
+
+def _build_python_source(
+    entry: dict[str, Any],
+    index: int,
+    namespace: str | None,
+    enabled: bool,
+) -> PythonSource:
+    class_val = entry.get("class", "")
+    module_val = entry.get("module", "")
+
+    class_path: str | None = None
+    module_path: str | None = None
+
+    if class_val and module_val:
+        # Legacy: {"module": "pkg", "class": "Cls"} → class_path = "pkg.Cls"
+        if "." not in class_val:
+            class_path = f"{module_val}.{class_val}"
+        else:
+            class_path = class_val
+    elif class_val:
+        class_path = class_val
+    elif module_val:
+        module_path = module_val
+    else:
+        raise ConfigError(
+            f"Tool entry at index {index} (type=python): requires 'class' or 'module'."
+        )
+
+    return PythonSource(
+        class_path=class_path,
+        module_path=module_path,
+        namespace=namespace,
+        enabled=enabled,
+    )
+
+
+# --- mcp source --------------------------------------------------------------
+
+
+def _build_mcp_source(
+    entry: dict[str, Any],
+    index: int,
+    namespace: str | None,
+    enabled: bool,
+) -> MCPSource:
+    raw_transport = entry.get("transport", "")
+    transport = _TRANSPORT_ALIASES.get(raw_transport, raw_transport)
+
+    if transport not in ("stdio", "sse", "streamable-http"):
+        raise ConfigError(
+            f"Tool entry at index {index} (type=mcp): "
+            f"transport must be 'stdio', 'sse', 'streamable-http', or 'http', "
+            f"got '{raw_transport}'."
+        )
+
+    if transport == "stdio":
+        command = entry.get("command")
+        if not command:
+            raise ConfigError(
+                f"Tool entry at index {index} (type=mcp, transport=stdio): "
+                "'command' is required."
+            )
+        if isinstance(command, str):
+            command = [command]
+        return MCPSource(
+            transport=transport,
+            namespace=namespace,
+            enabled=enabled,
+            command=tuple(command),
+            env=entry.get("env"),
+            persistent=entry.get("persistent", True),
+        )
+
+    # sse or streamable-http
+    url = entry.get("url")
+    if not url:
+        raise ConfigError(
+            f"Tool entry at index {index} (type=mcp, transport={raw_transport}): "
+            "'url' is required."
+        )
+    return MCPSource(
+        transport=transport,
+        namespace=namespace,
+        enabled=enabled,
+        url=url,
+        headers=entry.get("headers"),
+        persistent=entry.get("persistent", True),
+    )
+
+
+# --- openapi source ----------------------------------------------------------
+
+
+def _build_openapi_source(
+    entry: dict[str, Any],
+    index: int,
+    namespace: str | None,
+    enabled: bool,
+) -> OpenAPISource:
+    url = entry.get("url")
+    if not url:
+        raise ConfigError(
+            f"Tool entry at index {index} (type=openapi): 'url' is required."
+        )
+
+    auth = None
+    auth_data = entry.get("auth")
+    if auth_data is not None:
+        if not isinstance(auth_data, dict):
+            raise ConfigError(
+                f"Tool entry at index {index} (type=openapi): 'auth' must be a mapping."
+            )
+        auth = _build_auth(auth_data, index)
+
+    return OpenAPISource(
+        url=url,
+        namespace=namespace,
+        enabled=enabled,
+        auth=auth,
+        base_url=entry.get("base_url"),
+    )
+
+
+# --- auth ---------------------------------------------------------------------
+
+
+def _build_auth(data: dict[str, Any], tool_index: int) -> AuthConfig:
+    auth_type = data.get("type", "bearer")
+    token: str | None = None
+    token_env = data.get("token_env")
+
+    if token_env:
+        token = _resolve_env(token_env, tool_index)
+    elif "token" in data:
+        token = data["token"]
+
+    return AuthConfig(
+        type=auth_type,
+        token=token,
+        token_env=token_env,
+        header_name=data.get("header_name", "Authorization"),
+    )
+
+
+def _resolve_env(var_name: str, tool_index: int) -> str:
+    value = os.environ.get(var_name)
+    if value is None:
+        raise ConfigError(
+            f"Tool entry at index {tool_index}: environment variable "
+            f"'{var_name}' is not set (referenced by token_env)."
+        )
+    return value

--- a/src/toolregistry/config/_loader.py
+++ b/src/toolregistry/config/_loader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from ._types import (
     AuthConfig,
@@ -106,7 +106,7 @@ def _build_config(data: dict[str, Any], source: str) -> ToolConfig:
                 f"Tool entry at index {i} must be a mapping, "
                 f"got {type(entry).__name__}."
             )
-        tools.append(_build_tool_source(entry, i))
+        tools.append(_build_tool_source(cast(dict[str, Any], entry), i))
 
     return ToolConfig(
         mode=mode,

--- a/src/toolregistry/config/_types.py
+++ b/src/toolregistry/config/_types.py
@@ -1,0 +1,159 @@
+"""Typed dataclasses for declarative tool configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = [
+    "ConfigError",
+    "AuthConfig",
+    "PythonSource",
+    "MCPSource",
+    "OpenAPISource",
+    "ToolSource",
+    "ToolConfig",
+]
+
+
+class ConfigError(ValueError):
+    """Raised when a tool configuration file is semantically invalid.
+
+    Syntax errors from the underlying parser (JSONCDecodeError, YAMLError)
+    propagate unchanged.  ConfigError covers schema-level issues: unknown
+    tool type, missing required fields, unresolvable env vars, etc.
+    """
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    """Authentication configuration for an OpenAPI tool source.
+
+    Attributes:
+        type: Auth mechanism.  ``"bearer"`` adds an
+            ``Authorization: Bearer <token>`` header.  ``"header"`` sends
+            a custom header whose name is given by *header_name*.
+        token: Resolved token value (from *token_env* or a literal).
+        token_env: Name of the environment variable the token was
+            resolved from.  Retained for diagnostics.
+        header_name: Custom header name (used when *type* is ``"header"``).
+    """
+
+    type: Literal["bearer", "header"] = "bearer"
+    token: str | None = None
+    token_env: str | None = None
+    header_name: str = "Authorization"
+
+
+@dataclass(frozen=True)
+class PythonSource:
+    """A tool source backed by a Python class or module.
+
+    Exactly one of *class_path* or *module_path* must be set.
+
+    * *class_path*: consumer imports the module, gets the class, and calls
+      ``registry.register_from_class()``.
+    * *module_path*: consumer imports the module and registers every
+      public callable it finds.
+
+    Attributes:
+        class_path: Fully-qualified dotted class path
+            (e.g. ``"toolregistry_hub.calculator.Calculator"``).
+        module_path: Fully-qualified dotted module path
+            (e.g. ``"my_package.tools"``).
+        namespace: Optional namespace passed to the registration call.
+        enabled: Per-source enabled flag.
+    """
+
+    class_path: str | None = None
+    module_path: str | None = None
+    namespace: str | None = None
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.class_path and not self.module_path:
+            raise ConfigError(
+                "PythonSource requires at least one of 'class_path' or 'module_path'."
+            )
+        if self.class_path and self.module_path:
+            raise ConfigError(
+                "PythonSource accepts only one of 'class_path' or 'module_path', not both."
+            )
+
+
+@dataclass(frozen=True)
+class MCPSource:
+    """A tool source backed by an MCP server.
+
+    For *stdio* transport, *command* is required and *env* is optional.
+    For *sse* or *streamable-http* transport, *url* is required.
+
+    The config file may use ``"http"`` as a shorthand for
+    ``"streamable-http"``; the loader normalises it before constructing
+    this object.
+
+    Attributes:
+        transport: MCP transport mechanism.
+        namespace: Optional namespace passed to ``register_from_mcp()``.
+        enabled: Per-source enabled flag.
+        command: Command + args for stdio
+            (e.g. ``["python", "-m", "server"]``).
+        env: Extra environment variables for the stdio subprocess.
+        url: Server URL for *sse* or *streamable-http* transport.
+        headers: Extra HTTP headers for network transports.
+        persistent: Whether to keep the MCP connection alive.
+    """
+
+    transport: Literal["stdio", "sse", "streamable-http"]
+    namespace: str | None = None
+    enabled: bool = True
+    command: tuple[str, ...] | None = None
+    env: dict[str, str] | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+    persistent: bool = True
+
+
+@dataclass(frozen=True)
+class OpenAPISource:
+    """A tool source backed by an OpenAPI endpoint.
+
+    Attributes:
+        url: URL to the OpenAPI spec (JSON or YAML).
+        namespace: Optional namespace passed to
+            ``register_from_openapi()``.
+        enabled: Per-source enabled flag.
+        auth: Optional authentication configuration.
+        base_url: Override the ``servers[0].url`` from the spec.
+    """
+
+    url: str
+    namespace: str | None = None
+    enabled: bool = True
+    auth: AuthConfig | None = None
+    base_url: str | None = None
+
+
+ToolSource = PythonSource | MCPSource | OpenAPISource
+"""Discriminated union of all supported tool source types."""
+
+
+@dataclass(frozen=True)
+class ToolConfig:
+    """Top-level configuration parsed from a JSONC or YAML file.
+
+    Attributes:
+        mode: Filtering strategy.  ``"denylist"`` enables everything
+            except namespaces listed in *disabled*.  ``"allowlist"``
+            enables only namespaces listed in *enabled*.
+        disabled: Namespace patterns to disable (denylist mode).
+        enabled: Namespace patterns to enable (allowlist mode).
+        tools: Ordered sequence of tool source declarations.
+        source: Filesystem path of the config file (for diagnostics).
+    """
+
+    mode: Literal["denylist", "allowlist"] = "denylist"
+    disabled: tuple[str, ...] = ()
+    enabled: tuple[str, ...] = ()
+    tools: tuple[ToolSource, ...] = ()
+    source: str = ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,800 @@
+"""Tests for toolregistry.config — declarative tool configuration loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from toolregistry.config import (
+    ConfigError,
+    MCPSource,
+    OpenAPISource,
+    PythonSource,
+    ToolConfig,
+    load_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetection:
+    def test_json_extension(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.json", "{}")
+        cfg = load_config(p)
+        assert isinstance(cfg, ToolConfig)
+
+    def test_jsonc_extension(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.jsonc", "{}")
+        cfg = load_config(p)
+        assert isinstance(cfg, ToolConfig)
+
+    def test_yaml_extension(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "mode: denylist")
+        cfg = load_config(p)
+        assert cfg.mode == "denylist"
+
+    def test_yml_extension(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yml", "mode: allowlist")
+        cfg = load_config(p)
+        assert cfg.mode == "allowlist"
+
+    def test_unsupported_extension(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.toml", "")
+        with pytest.raises(ConfigError, match="Unsupported config file extension"):
+            load_config(p)
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_config(tmp_path / "nonexistent.json")
+
+
+# ---------------------------------------------------------------------------
+# JSONC parsing
+# ---------------------------------------------------------------------------
+
+
+class TestJSONCParsing:
+    def test_line_comments(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.jsonc",
+            """\
+{
+  // This is a comment
+  "mode": "denylist",
+  "tools": []
+}
+""",
+        )
+        cfg = load_config(p)
+        assert cfg.mode == "denylist"
+        assert cfg.tools == ()
+
+    def test_block_comments(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.jsonc",
+            """\
+{
+  /* block comment */
+  "mode": "allowlist",
+  "enabled": ["math"]
+}
+""",
+        )
+        cfg = load_config(p)
+        assert cfg.mode == "allowlist"
+        assert cfg.enabled == ("math",)
+
+    def test_trailing_commas(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.jsonc",
+            """\
+{
+  "disabled": ["web", "fs",],
+  "tools": [],
+}
+""",
+        )
+        cfg = load_config(p)
+        assert cfg.disabled == ("web", "fs")
+
+
+# ---------------------------------------------------------------------------
+# YAML parsing
+# ---------------------------------------------------------------------------
+
+
+class TestYAMLParsing:
+    def test_basic_yaml(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+mode: denylist
+disabled:
+  - web
+  - fs
+tools: []
+""",
+        )
+        cfg = load_config(p)
+        assert cfg.mode == "denylist"
+        assert cfg.disabled == ("web", "fs")
+        assert cfg.tools == ()
+
+    def test_yaml_with_comments(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+# Top-level comment
+mode: allowlist
+enabled:
+  - math  # inline comment
+""",
+        )
+        cfg = load_config(p)
+        assert cfg.mode == "allowlist"
+        assert cfg.enabled == ("math",)
+
+
+# ---------------------------------------------------------------------------
+# PythonSource
+# ---------------------------------------------------------------------------
+
+
+class TestPythonSource:
+    def test_class_path_new_format(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    class: toolregistry_hub.calculator.Calculator
+    namespace: calc
+""",
+        )
+        cfg = load_config(p)
+        assert len(cfg.tools) == 1
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.class_path == "toolregistry_hub.calculator.Calculator"
+        assert src.module_path is None
+        assert src.namespace == "calc"
+
+    def test_module_path(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    module: my_package.tools
+    namespace: custom
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.module_path == "my_package.tools"
+        assert src.class_path is None
+
+    def test_legacy_module_class(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.jsonc",
+            """\
+{
+  "tools": [
+    {"module": "my_module", "class": "MyTool", "namespace": "ns"}
+  ]
+}
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.class_path == "my_module.MyTool"
+
+    def test_legacy_module_only(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.jsonc",
+            '{"tools": [{"module": "examples.tools", "namespace": "ex"}]}',
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.module_path == "examples.tools"
+        assert src.class_path is None
+
+    def test_missing_class_and_module(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    namespace: oops
+""",
+        )
+        with pytest.raises(ConfigError, match="requires 'class' or 'module'"):
+            load_config(p)
+
+
+# ---------------------------------------------------------------------------
+# MCPSource
+# ---------------------------------------------------------------------------
+
+
+class TestMCPSource:
+    def test_stdio(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: stdio
+    command: ["python", "-m", "server"]
+    env:
+      KEY: value
+    namespace: mcp_tools
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.transport == "stdio"
+        assert src.command == ("python", "-m", "server")
+        assert src.env == {"KEY": "value"}
+        assert src.namespace == "mcp_tools"
+        assert src.persistent is True
+
+    def test_sse(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: sse
+    url: http://localhost:8080/sse
+    namespace: remote
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.transport == "sse"
+        assert src.url == "http://localhost:8080/sse"
+
+    def test_http_alias(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: http
+    url: http://localhost:8080/mcp
+    namespace: remote2
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.transport == "streamable-http"
+        assert src.url == "http://localhost:8080/mcp"
+
+    def test_streamable_http(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: streamable-http
+    url: http://localhost:8080/mcp
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.transport == "streamable-http"
+
+    def test_stdio_string_command(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: stdio
+    command: python
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.command == ("python",)
+
+    def test_invalid_transport(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: grpc
+    url: http://localhost:9090
+""",
+        )
+        with pytest.raises(ConfigError, match="transport must be"):
+            load_config(p)
+
+    def test_stdio_missing_command(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: stdio
+""",
+        )
+        with pytest.raises(ConfigError, match="'command' is required"):
+            load_config(p)
+
+    def test_sse_missing_url(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: sse
+""",
+        )
+        with pytest.raises(ConfigError, match="'url' is required"):
+            load_config(p)
+
+    def test_persistent_false(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: sse
+    url: http://localhost:8080/sse
+    persistent: false
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.persistent is False
+
+    def test_headers(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: mcp
+    transport: sse
+    url: http://localhost:8080/sse
+    headers:
+      X-Custom: value
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, MCPSource)
+        assert src.headers == {"X-Custom": "value"}
+
+
+# ---------------------------------------------------------------------------
+# OpenAPISource
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPISource:
+    def test_basic(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    namespace: api
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, OpenAPISource)
+        assert src.url == "https://api.example.com/openapi.json"
+        assert src.namespace == "api"
+        assert src.auth is None
+
+    def test_bearer_auth_with_token_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MY_API_TOKEN", "secret123")
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    namespace: api
+    auth:
+      type: bearer
+      token_env: MY_API_TOKEN
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, OpenAPISource)
+        assert src.auth is not None
+        assert src.auth.type == "bearer"
+        assert src.auth.token == "secret123"
+        assert src.auth.token_env == "MY_API_TOKEN"
+
+    def test_literal_token(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    auth:
+      type: bearer
+      token: hardcoded-token
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, OpenAPISource)
+        assert src.auth is not None
+        assert src.auth.token == "hardcoded-token"
+        assert src.auth.token_env is None
+
+    def test_missing_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    auth:
+      type: bearer
+      token_env: NONEXISTENT_VAR
+""",
+        )
+        with pytest.raises(ConfigError, match="NONEXISTENT_VAR"):
+            load_config(p)
+
+    def test_missing_url(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    namespace: api
+""",
+        )
+        with pytest.raises(ConfigError, match="'url' is required"):
+            load_config(p)
+
+    def test_base_url_override(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    base_url: https://internal.example.com
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, OpenAPISource)
+        assert src.base_url == "https://internal.example.com"
+
+    def test_header_auth(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    auth:
+      type: header
+      header_name: X-API-Key
+      token: my-key
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, OpenAPISource)
+        assert src.auth is not None
+        assert src.auth.type == "header"
+        assert src.auth.header_name == "X-API-Key"
+        assert src.auth.token == "my-key"
+
+
+# ---------------------------------------------------------------------------
+# Mode and filtering
+# ---------------------------------------------------------------------------
+
+
+class TestModeAndFiltering:
+    def test_default_mode(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "tools: []")
+        cfg = load_config(p)
+        assert cfg.mode == "denylist"
+
+    def test_allowlist_mode(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+mode: allowlist
+enabled:
+  - calc
+  - web
+""",
+        )
+        cfg = load_config(p)
+        assert cfg.mode == "allowlist"
+        assert cfg.enabled == ("calc", "web")
+
+    def test_invalid_mode(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "mode: blocklist")
+        with pytest.raises(ConfigError, match="Invalid mode"):
+            load_config(p)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_config(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.json", "{}")
+        cfg = load_config(p)
+        assert cfg.mode == "denylist"
+        assert cfg.disabled == ()
+        assert cfg.enabled == ()
+        assert cfg.tools == ()
+
+    def test_empty_tools_list(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "tools: []")
+        cfg = load_config(p)
+        assert cfg.tools == ()
+
+    def test_per_tool_enabled_false(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    class: mod.Cls
+    enabled: false
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.enabled is False
+
+    def test_top_level_not_mapping(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "- item1\n- item2")
+        with pytest.raises(ConfigError, match="mapping at the top level"):
+            load_config(p)
+
+    def test_tool_entry_not_mapping(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "tools:\n  - just_a_string")
+        with pytest.raises(ConfigError, match="must be a mapping"):
+            load_config(p)
+
+    def test_unknown_type(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: grpc
+    url: http://localhost:9090
+""",
+        )
+        with pytest.raises(ConfigError, match="unknown type"):
+            load_config(p)
+
+    def test_source_field(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "tools: []")
+        cfg = load_config(p)
+        assert cfg.source == str(p)
+
+    def test_string_path(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "cfg.yaml", "tools: []")
+        cfg = load_config(str(p))
+        assert isinstance(cfg, ToolConfig)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: JSONC and YAML produce equal results
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    JSONC_CONTENT = """\
+{
+  "mode": "denylist",
+  "disabled": ["web"],
+  "tools": [
+    {
+      "type": "python",
+      "class": "pkg.Calculator",
+      "namespace": "calc"
+    },
+    {
+      "type": "mcp",
+      "transport": "sse",
+      "url": "http://localhost:8080/sse",
+      "namespace": "remote"
+    },
+    {
+      "type": "openapi",
+      "url": "https://api.example.com/openapi.json",
+      "namespace": "api"
+    }
+  ]
+}
+"""
+
+    YAML_CONTENT = """\
+mode: denylist
+disabled:
+  - web
+tools:
+  - type: python
+    class: pkg.Calculator
+    namespace: calc
+  - type: mcp
+    transport: sse
+    url: http://localhost:8080/sse
+    namespace: remote
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    namespace: api
+"""
+
+    def test_jsonc_yaml_equivalence(self, tmp_path: Path) -> None:
+        jsonc_path = _write(tmp_path, "cfg.jsonc", self.JSONC_CONTENT)
+        yaml_path = _write(tmp_path, "cfg.yaml", self.YAML_CONTENT)
+
+        jsonc_cfg = load_config(jsonc_path)
+        yaml_cfg = load_config(yaml_path)
+
+        # source paths differ, compare everything else
+        assert jsonc_cfg.mode == yaml_cfg.mode
+        assert jsonc_cfg.disabled == yaml_cfg.disabled
+        assert jsonc_cfg.enabled == yaml_cfg.enabled
+        assert jsonc_cfg.tools == yaml_cfg.tools
+
+
+# ---------------------------------------------------------------------------
+# Multi-source config (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSource:
+    def test_mixed_sources(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("API_TOKEN", "tok123")
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+mode: denylist
+disabled:
+  - filesystem
+
+tools:
+  - type: python
+    class: toolregistry_hub.calculator.Calculator
+    namespace: calculator
+
+  - type: python
+    module: my_package.tools
+    namespace: custom
+
+  - type: openapi
+    url: https://api.example.com/openapi.json
+    namespace: external_api
+    auth:
+      type: bearer
+      token_env: API_TOKEN
+
+  - type: mcp
+    transport: stdio
+    command: ["python", "-m", "mcp_server"]
+    namespace: mcp_tools
+    env:
+      DEBUG: "1"
+
+  - type: mcp
+    transport: http
+    url: http://localhost:8080/mcp
+    namespace: remote_mcp
+""",
+        )
+
+        cfg = load_config(p)
+
+        assert cfg.mode == "denylist"
+        assert cfg.disabled == ("filesystem",)
+        assert len(cfg.tools) == 5
+
+        # Python class
+        s0 = cfg.tools[0]
+        assert isinstance(s0, PythonSource)
+        assert s0.class_path == "toolregistry_hub.calculator.Calculator"
+
+        # Python module
+        s1 = cfg.tools[1]
+        assert isinstance(s1, PythonSource)
+        assert s1.module_path == "my_package.tools"
+
+        # OpenAPI with auth
+        s2 = cfg.tools[2]
+        assert isinstance(s2, OpenAPISource)
+        assert s2.auth is not None
+        assert s2.auth.token == "tok123"
+
+        # MCP stdio
+        s3 = cfg.tools[3]
+        assert isinstance(s3, MCPSource)
+        assert s3.transport == "stdio"
+        assert s3.command == ("python", "-m", "mcp_server")
+        assert s3.env == {"DEBUG": "1"}
+
+        # MCP http alias
+        s4 = cfg.tools[4]
+        assert isinstance(s4, MCPSource)
+        assert s4.transport == "streamable-http"
+        assert s4.url == "http://localhost:8080/mcp"


### PR DESCRIPTION
## Summary

- Add `toolregistry.config` module that parses JSONC/YAML config files into typed frozen dataclasses for multi-source tool registration
- Vendor `zerodep/jsonc` and `zerodep/yaml` into `_vendor/` package (follows llm-rosetta pattern)
- Support three tool source types: `python` (class/module), `mcp` (stdio/sse/streamable-http), `openapi` (with auth)
- `transport: "http"` as alias for `"streamable-http"`
- Backward-compatible with legacy `{"module": "x", "class": "Y"}` format
- 46 new tests, 813 total tests passing with zero regression

Closes #120

## Test plan

- [x] `pytest tests/test_config.py -v` — 46/46 passed
- [x] `pytest tests/ -v` — 813/813 passed, no regression
- [x] `ruff check` and `ruff format` clean