### PR TITLE
refactor: consolidate mixin modules into _mixins/ package

### DIFF
--- a/src/toolregistry/_mixins/__init__.py
+++ b/src/toolregistry/_mixins/__init__.py
@@ -1,0 +1,7 @@
+from .admin import AdminMixin as AdminMixin
+from .callbacks import ChangeCallbackMixin as ChangeCallbackMixin
+from .enable_disable import EnableDisableMixin as EnableDisableMixin
+from .logging import ExecutionLoggingMixin as ExecutionLoggingMixin
+from .namespace import NamespaceMixin as NamespaceMixin
+from .permissions import PermissionsMixin as PermissionsMixin
+from .registration import RegistrationMixin as RegistrationMixin

--- a/src/toolregistry/_mixins/admin.py
+++ b/src/toolregistry/_mixins/admin.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .admin import AdminInfo, AdminServer
-    from .tool_registry import ToolRegistry
+    from ..admin import AdminInfo, AdminServer
+    from ..tool_registry import ToolRegistry
 
 
 class AdminMixin:
@@ -58,7 +58,7 @@ class AdminMixin:
 
         from typing import cast
 
-        from .admin import AdminServer
+        from ..admin import AdminServer
 
         self._admin_server = AdminServer(
             registry=cast("ToolRegistry", self),

--- a/src/toolregistry/_mixins/callbacks.py
+++ b/src/toolregistry/_mixins/callbacks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 
-from .events import ChangeCallback, ChangeEvent
+from ..events import ChangeCallback, ChangeEvent
 
 logger = logging.getLogger(__name__)
 

--- a/src/toolregistry/_mixins/enable_disable.py
+++ b/src/toolregistry/_mixins/enable_disable.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .events import ChangeEvent, ChangeEventType
+from ..events import ChangeEvent, ChangeEventType
 
 if TYPE_CHECKING:
-    from .tool import Tool
+    from ..tool import Tool
 
 
 class EnableDisableMixin:

--- a/src/toolregistry/_mixins/logging.py
+++ b/src/toolregistry/_mixins/logging.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .admin import ExecutionLog
+    from ..admin import ExecutionLog
 
 
 class ExecutionLoggingMixin:
@@ -37,7 +37,7 @@ class ExecutionLoggingMixin:
             stats = log.get_stats()
             ```
         """
-        from .admin import ExecutionLog
+        from ..admin import ExecutionLog
 
         self._execution_log = ExecutionLog(max_entries=max_entries)
         return self._execution_log

--- a/src/toolregistry/_mixins/namespace.py
+++ b/src/toolregistry/_mixins/namespace.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 from collections.abc import Callable
 
-from .tool import Tool
+from ..tool import Tool
 
 
 class NamespaceMixin:
@@ -87,7 +87,7 @@ class NamespaceMixin:
         Raises:
             TypeError: If other is not a ToolRegistry instance.
         """
-        from .tool_registry import ToolRegistry
+        from ..tool_registry import ToolRegistry
 
         if not isinstance(other, ToolRegistry):
             raise TypeError("Can only merge with another ToolRegistry instance.")
@@ -154,7 +154,7 @@ class NamespaceMixin:
             When `retain_namespace` is False, the `reduce_namespace` method is called
             to remove the namespace from tools in the current registry.
         """
-        from .tool_registry import ToolRegistry
+        from ..tool_registry import ToolRegistry
 
         # Filter tools with the specified prefix
         spun_off_tools = {

--- a/src/toolregistry/_mixins/permissions.py
+++ b/src/toolregistry/_mixins/permissions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .permissions import (
+from ..permissions import (
     AsyncPermissionHandler,
     PermissionHandler,
     PermissionPolicy,
@@ -14,8 +14,8 @@ from .permissions import (
 )
 
 if TYPE_CHECKING:
-    from .events import ChangeEvent
-    from .tool import Tool
+    from ..events import ChangeEvent
+    from ..tool import Tool
 
 
 class PermissionsMixin:
@@ -116,7 +116,7 @@ class PermissionsMixin:
         """
         import asyncio
 
-        from .events import ChangeEvent, ChangeEventType
+        from ..events import ChangeEvent, ChangeEventType
 
         policy = self._permission_policy
         if policy is None:

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from collections.abc import Callable
 
-from .events import ChangeEvent, ChangeEventType
-from .tool import Tool
-from .utils import HttpxClientConfig, normalize_tool_name
+from ..events import ChangeEvent, ChangeEventType
+from ..tool import Tool
+from ..utils import HttpxClientConfig, normalize_tool_name
 
 if TYPE_CHECKING:
-    from .tool_registry import ToolRegistry
+    from ..tool_registry import ToolRegistry
 
 
 try:
@@ -318,7 +318,7 @@ class RegistrationMixin:
             static method handling capability.
         """
         namespace = _resolve_namespace_compat(namespace, kwargs)
-        from .native import ClassToolIntegration
+        from ..native import ClassToolIntegration
 
         hub = ClassToolIntegration(
             cast("ToolRegistry", self), traverse_mro=traverse_mro
@@ -356,7 +356,7 @@ class RegistrationMixin:
             ```
         """
         namespace = _resolve_namespace_compat(namespace, kwargs)
-        from .native import ClassToolIntegration
+        from ..native import ClassToolIntegration
 
         hub = ClassToolIntegration(
             cast("ToolRegistry", self), traverse_mro=traverse_mro
@@ -392,7 +392,7 @@ def _import_openapi_integration():
         OpenAPIIntegration: The imported OpenAPIIntegration class.
     """
     try:
-        from .openapi import OpenAPIIntegration
+        from ..openapi import OpenAPIIntegration
 
         return OpenAPIIntegration
     except ImportError:
@@ -412,7 +412,7 @@ def _import_mcp_integration():
         MCPIntegration: The imported MCPIntegration class.
     """
     try:
-        from .mcp import MCPIntegration
+        from ..mcp import MCPIntegration
 
         return MCPIntegration
     except ImportError:
@@ -432,7 +432,7 @@ def _import_langchain_integration():
         LangChainIntegration: The imported LangChainIntegration class.
     """
     try:
-        from .langchain import LangChainIntegration
+        from ..langchain import LangChainIntegration
 
         return LangChainIntegration
     except ImportError:

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -26,13 +26,15 @@ from .types import (
 from .events import ChangeCallback, ChangeEvent, ChangeEventType
 from .tool_discovery import TOOL_DISCOVERY_NAME, ToolDiscoveryTool
 
-from ._admin import AdminMixin
-from ._callbacks import ChangeCallbackMixin
-from ._enable_disable import EnableDisableMixin
-from ._logging import ExecutionLoggingMixin
-from ._namespace import NamespaceMixin
-from ._permissions import PermissionsMixin
-from ._registration import RegistrationMixin
+from ._mixins import (
+    AdminMixin,
+    ChangeCallbackMixin,
+    EnableDisableMixin,
+    ExecutionLoggingMixin,
+    NamespaceMixin,
+    PermissionsMixin,
+    RegistrationMixin,
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Move 7 ToolRegistry mixin modules (`_admin.py`, `_callbacks.py`, `_enable_disable.py`, `_logging.py`, `_namespace.py`, `_permissions.py`, `_registration.py`) from package root into `_mixins/` subdirectory
- Add `_mixins/__init__.py` with explicit re-exports
- Update all relative imports to use parent-package references (`..`)

## Test plan
- [x] `ty check src/` passes
- [x] `ruff check --fix && ruff format` passes
- [x] `pytest tests/ -x -q` — 813 passed