### PR TITLE
fix: improve error message for classes with required constructor args

### DIFF
--- a/src/toolregistry/integrations/native/integration.py
+++ b/src/toolregistry/integrations/native/integration.py
@@ -64,15 +64,7 @@ class ClassToolIntegration:
             if _is_all_static_methods(cls_or_instance):
                 self._register_static_methods(cls_or_instance, resolved_ns)
             else:
-                try:
-                    instance = cls_or_instance()
-                except TypeError as e:
-                    raise TypeError(
-                        f"Try to register methods from class {cls_or_instance.__name__}. "
-                        "Found mixed static and instance methods. "
-                        "Attempted to instantiate the class, but failed without arguments. "
-                        "Please provide an instance of the class."
-                    ) from e
+                instance = self._instantiate_class(cls_or_instance)
                 self._register_instance_methods(instance, resolved_ns)
         else:
             self._register_instance_methods(cls_or_instance, resolved_ns)
@@ -98,6 +90,97 @@ class ClassToolIntegration:
         await loop.run_in_executor(
             None, self.register_class_methods, cls_or_instance, namespace
         )
+
+    @staticmethod
+    def _get_required_init_params(
+        cls: type,
+    ) -> list[inspect.Parameter]:
+        """Inspect ``__init__`` and return parameters that have no default value.
+
+        Parameters of kind ``VAR_POSITIONAL`` (``*args``) and
+        ``VAR_KEYWORD`` (``**kwargs``) are excluded because they do not
+        prevent zero-argument instantiation.
+
+        Args:
+            cls: The class to inspect.
+
+        Returns:
+            A list of ``inspect.Parameter`` objects that are required
+            (i.e. have no default and are not variadic).
+        """
+        try:
+            sig = inspect.signature(cls.__init__)
+        except (ValueError, TypeError):
+            return []
+
+        required: list[inspect.Parameter] = []
+        for name, param in sig.parameters.items():
+            if name == "self":
+                continue
+            if param.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                continue
+            if param.default is inspect.Parameter.empty:
+                required.append(param)
+        return required
+
+    @staticmethod
+    def _format_param(param: inspect.Parameter) -> str:
+        """Format a single parameter as ``name: annotation`` or just ``name``.
+
+        Args:
+            param: The parameter to format.
+
+        Returns:
+            A human-readable string representation of the parameter.
+        """
+        if param.annotation is not inspect.Parameter.empty:
+            ann = (
+                param.annotation.__name__
+                if isinstance(param.annotation, type)
+                else str(param.annotation)
+            )
+            return f"{param.name}: {ann}"
+        return param.name
+
+    def _instantiate_class(self, cls: type) -> object:
+        """Attempt to instantiate *cls* with no arguments.
+
+        Before calling ``cls()``, this method inspects ``__init__`` for
+        required parameters.  If any are found, a ``TypeError`` is raised
+        immediately with a message that lists the missing parameters and
+        suggests passing a pre-constructed instance instead.
+
+        Args:
+            cls: The class to instantiate.
+
+        Returns:
+            An instance of *cls*.
+
+        Raises:
+            TypeError: If the class requires constructor arguments or if
+                zero-argument instantiation fails for another reason.
+        """
+        required_params = self._get_required_init_params(cls)
+        if required_params:
+            formatted = ", ".join(self._format_param(p) for p in required_params)
+            example_args = ", ".join(f"{p.name}=..." for p in required_params)
+            raise TypeError(
+                f"Class '{cls.__name__}' requires constructor arguments ({formatted}). "
+                f"Please instantiate it first: "
+                f"register_from_class({cls.__name__}({example_args}))"
+            )
+
+        try:
+            return cls()
+        except TypeError as e:
+            raise TypeError(
+                f"Failed to instantiate class '{cls.__name__}' with no arguments: {e}. "
+                f"Please pass a pre-constructed instance instead: "
+                f"register_from_class({cls.__name__}(...))"
+            ) from e
 
     def _collect_static_methods_from_mro(self, cls: type) -> dict:
         """Collect static methods by traversing the MRO, with subclass priority.

--- a/tests/test_constructor_error.py
+++ b/tests/test_constructor_error.py
@@ -1,0 +1,156 @@
+"""Tests for improved error messages when registering classes with required constructor arguments."""
+
+import pytest
+
+from toolregistry import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Test fixture classes
+# ---------------------------------------------------------------------------
+
+
+class ServiceWithRequiredArgs:
+    """Class that requires constructor arguments."""
+
+    def __init__(self, api_key: str, timeout: int):
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def call_api(self, endpoint: str) -> str:
+        return f"{self.api_key}:{endpoint}"
+
+
+class ServiceWithDefaults:
+    """Class whose constructor has only default arguments."""
+
+    def __init__(self, retries: int = 3, verbose: bool = False):
+        self.retries = retries
+        self.verbose = verbose
+
+    def status(self) -> str:
+        return "ok"
+
+
+class ServiceNoArgs:
+    """Class with a no-argument constructor."""
+
+    def __init__(self):
+        self.ready = True
+
+    def ping(self) -> str:
+        return "pong"
+
+
+class ServiceWithVariadic:
+    """Class whose constructor accepts *args and **kwargs only."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def info(self) -> str:
+        return "variadic"
+
+
+class ServiceMixedWithVariadic:
+    """Class with one required arg plus *args/**kwargs."""
+
+    def __init__(self, name: str, *args, **kwargs):
+        self.name = name
+        self.args = args
+        self.kwargs = kwargs
+
+    def greet(self) -> str:
+        return f"hello {self.name}"
+
+
+class ServiceUnannotated:
+    """Class with required args but no type annotations."""
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def connect(self) -> str:
+        return f"{self.host}:{self.port}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorErrorMessage:
+    """Verify that registering a class with required constructor args
+    produces a clear, actionable error message."""
+
+    def test_required_args_error_mentions_params(self):
+        """Error message should list parameter names and type annotations."""
+        registry = ToolRegistry()
+        with pytest.raises(TypeError, match=r"api_key: str.*timeout: int"):
+            registry.register_from_class(ServiceWithRequiredArgs)
+
+    def test_required_args_error_mentions_class_name(self):
+        """Error message should include the class name."""
+        registry = ToolRegistry()
+        with pytest.raises(TypeError, match=r"ServiceWithRequiredArgs"):
+            registry.register_from_class(ServiceWithRequiredArgs)
+
+    def test_required_args_error_suggests_instantiation(self):
+        """Error message should suggest calling register_from_class with an instance."""
+        registry = ToolRegistry()
+        with pytest.raises(TypeError, match=r"register_from_class\("):
+            registry.register_from_class(ServiceWithRequiredArgs)
+
+    def test_default_args_works(self):
+        """A class whose __init__ has only default args should be instantiated fine."""
+        registry = ToolRegistry()
+        registry.register_from_class(ServiceWithDefaults)
+        assert "status" in registry.list_tools()
+
+    def test_no_args_works(self):
+        """A class with a no-argument constructor should work."""
+        registry = ToolRegistry()
+        registry.register_from_class(ServiceNoArgs)
+        assert "ping" in registry.list_tools()
+
+    def test_pre_instantiated_works(self):
+        """Passing an already-instantiated object should register methods."""
+        registry = ToolRegistry()
+        instance = ServiceWithRequiredArgs(api_key="key123", timeout=30)
+        registry.register_from_class(instance)
+        assert "call_api" in registry.list_tools()
+
+    def test_variadic_only_attempts_instantiation(self):
+        """A class with only *args/**kwargs should not be blocked — instantiation succeeds."""
+        registry = ToolRegistry()
+        registry.register_from_class(ServiceWithVariadic)
+        assert "info" in registry.list_tools()
+
+    def test_mixed_required_and_variadic_reports_required(self):
+        """If there is a required arg alongside *args/**kwargs, the error
+        should mention the required arg but not *args/**kwargs."""
+        registry = ToolRegistry()
+        with pytest.raises(TypeError, match=r"name: str"):
+            registry.register_from_class(ServiceMixedWithVariadic)
+        # Should NOT mention *args or **kwargs in the error
+        with pytest.raises(TypeError) as exc_info:
+            registry.register_from_class(ServiceMixedWithVariadic)
+        assert "*args" not in str(exc_info.value)
+        assert "**kwargs" not in str(exc_info.value)
+
+    def test_unannotated_params_shown_without_type(self):
+        """Parameters without annotations should be listed by name only."""
+        registry = ToolRegistry()
+        with pytest.raises(TypeError, match=r"host, port"):
+            registry.register_from_class(ServiceUnannotated)
+        # Verify no ": <empty>" or similar artifact
+        with pytest.raises(TypeError) as exc_info:
+            registry.register_from_class(ServiceUnannotated)
+        msg = str(exc_info.value)
+        assert "host" in msg
+        assert "port" in msg
+        # Unannotated params should appear without colon
+        assert "host:" not in msg
+        assert "port:" not in msg


### PR DESCRIPTION
## Summary
- Detect required constructor parameters before attempting instantiation
- Raise `TypeError` with a clear message listing parameter names and types, e.g.:
  `Class 'MyService' requires constructor arguments (api_key: str, timeout: int). Please instantiate it first: register_from_class(MyService(api_key=..., timeout=...))`
- `*args`/`**kwargs`-only constructors still proceed to instantiation normally

Closes #127

## Test plan
- [x] Class with required args → error message mentions parameter names and types
- [x] Class with all-default args → registers normally
- [x] Class with no-arg constructor → registers normally
- [x] Pre-instantiated object → registers normally
- [x] Class with only `*args`/`**kwargs` → instantiation proceeds
- [x] Mixed required + variadic → error only mentions required params
- [x] All 850 existing tests pass