### PR TITLE
feat(admin): enrich admin panel with v0.7/v0.8 metadata and permissions

### DIFF
--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -997,6 +997,206 @@
             white-space: nowrap;
             max-width: 200px;
         }
+
+        /* ============== Tag Badges ============== */
+        .badge-tag {
+            display: inline-flex;
+            align-items: center;
+            padding: 1px 6px;
+            font-size: 0.625rem;
+            font-weight: 500;
+            border-radius: 9999px;
+            margin-right: 3px;
+            letter-spacing: 0.02em;
+        }
+
+        .badge-tag-read_only  { background: rgba(61,139,95,0.10);  color: #3D8B5F; }
+        .badge-tag-destructive{ background: rgba(196,65,65,0.10);  color: #C44141; }
+        .badge-tag-slow       { background: rgba(194,146,46,0.10); color: #C2922E; }
+        .badge-tag-network    { background: rgba(59,130,246,0.10); color: #3B82F6; }
+        .badge-tag-privileged { background: rgba(139,92,246,0.10); color: #8B5CF6; }
+        .badge-tag-file_system{ background: rgba(20,184,166,0.10); color: #14B8A6; }
+        .badge-tag-custom     { background: var(--bg-primary);     color: var(--text-secondary); }
+
+        .badge-locality {
+            display: inline-flex;
+            align-items: center;
+            padding: 1px 6px;
+            font-size: 0.625rem;
+            font-weight: 500;
+            border-radius: 9999px;
+            margin-right: 3px;
+        }
+        .badge-locality-local  { background: rgba(61,139,95,0.08);  color: #3D8B5F; }
+        .badge-locality-remote { background: rgba(59,130,246,0.08); color: #3B82F6; }
+
+        .tool-meta-icons {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            margin-left: 6px;
+        }
+
+        .meta-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 18px;
+            height: 18px;
+            font-size: 0.6875rem;
+            border-radius: 4px;
+            background: var(--bg-primary);
+            color: var(--text-secondary);
+            cursor: default;
+        }
+
+        .tool-badges {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 2px;
+            margin-left: 8px;
+        }
+
+        /* ============== Tool Detail Modal ============== */
+        .detail-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(27, 27, 24, 0.4);
+            backdrop-filter: blur(4px);
+            -webkit-backdrop-filter: blur(4px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            opacity: 0;
+            visibility: hidden;
+            transition: var(--transition);
+        }
+
+        .detail-overlay.active {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .detail-modal {
+            background: var(--bg-secondary);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow-lg);
+            border: 1px solid var(--border);
+            width: 90%;
+            max-width: 640px;
+            max-height: 85vh;
+            overflow: auto;
+            transform: scale(0.97) translateY(8px);
+            transition: var(--transition);
+        }
+
+        .detail-overlay.active .detail-modal {
+            transform: scale(1) translateY(0);
+        }
+
+        .detail-section {
+            padding: 16px 24px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .detail-section:last-child {
+            border-bottom: none;
+        }
+
+        .detail-section-title {
+            font-size: 0.6875rem;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--text-secondary);
+            margin-bottom: 10px;
+        }
+
+        .metadata-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 8px 24px;
+        }
+
+        .meta-item {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .meta-label {
+            font-size: 0.6875rem;
+            color: var(--text-secondary);
+        }
+
+        .meta-value {
+            font-size: 0.8125rem;
+            font-weight: 500;
+        }
+
+        .schema-toggle {
+            cursor: pointer;
+            user-select: none;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .schema-toggle .expand-icon {
+            transition: transform 0.2s ease;
+        }
+
+        .schema-toggle.expanded .expand-icon {
+            transform: rotate(90deg);
+        }
+
+        .schema-content {
+            display: none;
+            margin-top: 10px;
+        }
+
+        .schema-content.visible {
+            display: block;
+        }
+
+        .ns-child-name-link {
+            cursor: pointer;
+            color: var(--text-primary);
+            transition: var(--transition);
+        }
+
+        .ns-child-name-link:hover {
+            color: var(--accent);
+        }
+
+        /* ============== Permissions ============== */
+        .perm-status-card {
+            display: flex;
+            gap: 24px;
+            margin-bottom: 20px;
+        }
+
+        .perm-status-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.8125rem;
+        }
+
+        .perm-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+
+        .perm-dot-active  { background: var(--success); }
+        .perm-dot-inactive { background: var(--text-secondary); }
+
+        .badge-allow { background: rgba(61,139,95,0.10);  color: #3D8B5F; }
+        .badge-deny  { background: rgba(196,65,65,0.10);  color: #C44141; }
+        .badge-ask   { background: rgba(194,146,46,0.10); color: #C2922E; }
     </style>
 </head>
 <body>
@@ -1037,6 +1237,7 @@
                 <button class="tab" data-tab="namespaces" onclick="switchTab('namespaces')">Namespaces</button>
                 <button class="tab" data-tab="logs" onclick="switchTab('logs')">Logs</button>
                 <button class="tab" data-tab="state" onclick="switchTab('state')">State</button>
+                <button class="tab" data-tab="permissions" onclick="switchTab('permissions')">Permissions</button>
             </div>
 
             <!-- Tools Tab -->
@@ -1085,6 +1286,15 @@
                                         <option value="enabled">Enabled</option>
                                         <option value="disabled">Disabled</option>
                                     </select>
+                                    <select class="input select" id="tag-filter" onchange="filterTools()">
+                                        <option value="">All Tags</option>
+                                    </select>
+                                    <select class="input select" id="locality-filter" onchange="filterTools()">
+                                        <option value="">All Locality</option>
+                                        <option value="local">Local</option>
+                                        <option value="remote">Remote</option>
+                                        <option value="any">Any</option>
+                                    </select>
                                 </div>
                             </div>
                             <div class="table-container">
@@ -1123,11 +1333,12 @@
                                         <th>Total Tools</th>
                                         <th>Enabled</th>
                                         <th>Disabled</th>
+                                        <th>Tags</th>
                                         <th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody id="namespaces-body">
-                                    <tr><td colspan="5" class="loading"><div class="spinner"></div>Loading...</td></tr>
+                                    <tr><td colspan="6" class="loading"><div class="spinner"></div>Loading...</td></tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1227,7 +1438,31 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Permissions Tab -->
+            <div id="tab-permissions" class="tab-content" style="display: none;">
+                <div class="card">
+                    <div class="card-header">
+                        <h2 class="card-title">Permission Policy</h2>
+                        <button class="btn btn-secondary btn-sm" onclick="refreshPermissions()">Refresh</button>
+                    </div>
+                    <div class="card-body" id="permissions-body">
+                        <div class="loading"><div class="spinner"></div>Loading...</div>
+                    </div>
+                </div>
+            </div>
         </main>
+    </div>
+
+    <!-- Tool Detail Modal -->
+    <div class="detail-overlay" id="detail-overlay" onclick="closeDetailModal(event)">
+        <div class="detail-modal" onclick="event.stopPropagation()">
+            <div class="modal-header">
+                <h3 class="modal-title" id="detail-title">Tool Details</h3>
+                <button class="modal-close" onclick="closeDetailModal()">&times;</button>
+            </div>
+            <div id="detail-body"></div>
+        </div>
     </div>
 
     <!-- Modal -->
@@ -1364,6 +1599,10 @@
                     body: JSON.stringify(state)
                 });
             }
+
+            async getPermissions() {
+                return this.request('/api/permissions');
+            }
         }
 
         const api = new AdminAPI(API_BASE, AUTH_TOKEN);
@@ -1446,6 +1685,8 @@
             } else if (tabName === 'logs') {
                 refreshLogs();
                 refreshLogStats();
+            } else if (tabName === 'permissions') {
+                refreshPermissions();
             }
         }
 
@@ -1461,6 +1702,42 @@
                 document.getElementById('tools-body').innerHTML =
                     `<tr><td colspan="4" class="empty-state"><div class="text-error">${e.message}</div></td></tr>`;
             }
+        }
+
+        // Tag color mapping for known tags
+        const TAG_CLASSES = {
+            'read_only': 'badge-tag-read_only',
+            'destructive': 'badge-tag-destructive',
+            'slow': 'badge-tag-slow',
+            'network': 'badge-tag-network',
+            'privileged': 'badge-tag-privileged',
+            'file_system': 'badge-tag-file_system',
+        };
+
+        function renderTagBadges(tags) {
+            if (!tags || tags.length === 0) return '';
+            return tags.map(tag => {
+                const cls = TAG_CLASSES[tag] || 'badge-tag-custom';
+                return `<span class="badge-tag ${cls}">${escapeHtml(tag)}</span>`;
+            }).join('');
+        }
+
+        function renderMetaIcons(tool) {
+            let icons = '';
+            if (tool.locality && tool.locality !== 'any') {
+                const cls = tool.locality === 'local' ? 'badge-locality-local' : 'badge-locality-remote';
+                icons += `<span class="badge-locality ${cls}" title="Locality: ${tool.locality}">${tool.locality}</span>`;
+            }
+            if (tool.think_augment === true) {
+                icons += `<span class="meta-icon" title="Think-augmented">T</span>`;
+            }
+            if (tool.is_async) {
+                icons += `<span class="meta-icon" title="Async">A</span>`;
+            }
+            if (tool.defer) {
+                icons += `<span class="meta-icon" title="Deferred">D</span>`;
+            }
+            return icons ? `<span class="tool-meta-icons">${icons}</span>` : '';
         }
 
         function renderTools(tools) {
@@ -1516,10 +1793,16 @@
 
                 children.forEach(tool => {
                     const shortName = (!isDefault && tool.name.startsWith(ns + '-')) ? tool.name.slice(ns.length + 1) : tool.name;
+                    const tagBadges = renderTagBadges(tool.tags);
+                    const metaIcons = renderMetaIcons(tool);
                     html += `
                 <tr class="ns-child-row" data-ns-group="${nsId}">
                     <td></td>
-                    <td><span class="ns-child-name">${escapeHtml(shortName)}</span></td>
+                    <td>
+                        <span class="ns-child-name-link" onclick="event.stopPropagation(); showToolDetailModal('${escapeHtml(tool.name)}')">${escapeHtml(shortName)}</span>
+                        <span class="tool-badges">${tagBadges}</span>
+                        ${metaIcons}
+                    </td>
                     <td>
                         <label class="toggle-switch" title="${tool.enabled ? 'Click to disable' : 'Click to enable'}">
                             <input type="checkbox" ${tool.enabled ? 'checked' : ''}
@@ -1588,6 +1871,8 @@
             const search = document.getElementById('tool-search').value.toLowerCase();
             const namespace = document.getElementById('namespace-filter').value;
             const status = document.getElementById('status-filter').value;
+            const tag = document.getElementById('tag-filter').value;
+            const locality = document.getElementById('locality-filter').value;
 
             const filtered = allTools.filter(tool => {
                 const matchSearch = tool.name.toLowerCase().includes(search);
@@ -1595,7 +1880,9 @@
                 const matchStatus = !status ||
                     (status === 'enabled' && tool.enabled) ||
                     (status === 'disabled' && !tool.enabled);
-                return matchSearch && matchNamespace && matchStatus;
+                const matchTag = !tag || (tool.tags && tool.tags.includes(tag));
+                const matchLocality = !locality || tool.locality === locality;
+                return matchSearch && matchNamespace && matchStatus && matchTag && matchLocality;
             });
 
             renderTools(filtered);
@@ -1614,6 +1901,14 @@
                 namespaces.map(ns => `<option value="${escapeHtml(ns)}">${escapeHtml(ns)}</option>`).join('');
 
             select.value = currentValue;
+
+            // Update tag filter
+            const allTags = [...new Set(tools.flatMap(t => t.tags || []))].sort();
+            const tagSelect = document.getElementById('tag-filter');
+            const currentTag = tagSelect.value;
+            tagSelect.innerHTML = '<option value="">All Tags</option>' +
+                allTags.map(tag => `<option value="${escapeHtml(tag)}">${escapeHtml(tag)}</option>`).join('');
+            tagSelect.value = currentTag;
         }
 
         function showDisableToolModal(name) {
@@ -1688,7 +1983,7 @@
 
             if (namespaces.length === 0) {
                 tbody.innerHTML = `
-                    <tr><td colspan="5" class="empty-state">
+                    <tr><td colspan="6" class="empty-state">
                         <div class="empty-state-icon">No namespaces</div>
                         <div class="empty-state-text">Namespaces will appear here once tools are registered.</div>
                     </td></tr>`;
@@ -1701,6 +1996,7 @@
                     <td>${ns.tool_count}</td>
                     <td><span class="text-success">${ns.enabled_count}</span></td>
                     <td><span class="text-error">${ns.disabled_count}</span></td>
+                    <td>${(ns.tags || []).length > 0 ? renderTagBadges(ns.tags) : '<span class="text-muted" style="font-size: 0.75rem;">&mdash;</span>'}</td>
                     <td>
                         ${ns.name === 'default' ? '<span class="text-muted" style="font-size: 0.75rem;">&mdash;</span>' : `<div style="display: flex; gap: 6px; flex-wrap: wrap;">
                             <button class="btn btn-success btn-sm" style="min-width: 90px; text-align: center;" onclick="enableNamespace('${escapeHtml(ns.name)}')">Enable All</button>
@@ -1951,6 +2247,140 @@
             event.target.value = '';
         }
 
+        // ============== Tool Detail Modal ==============
+        async function showToolDetailModal(toolName) {
+            try {
+                const tool = await api.getTool(toolName);
+                document.getElementById('detail-title').textContent = tool.name;
+
+                const meta = tool.metadata || {};
+                const tags = [...(meta.tags || []), ...(meta.custom_tags || [])];
+
+                let html = '';
+
+                // Basic info
+                html += `<div class="detail-section">
+                    <div class="detail-section-title">Basic Info</div>
+                    <div class="metadata-grid">
+                        <div class="meta-item"><span class="meta-label">Name</span><span class="meta-value">${escapeHtml(tool.name)}</span></div>
+                        <div class="meta-item"><span class="meta-label">Namespace</span><span class="meta-value">${escapeHtml(tool.namespace || 'default')}</span></div>
+                        <div class="meta-item"><span class="meta-label">Method Name</span><span class="meta-value">${escapeHtml(tool.method_name || tool.name)}</span></div>
+                        <div class="meta-item"><span class="meta-label">Status</span><span class="meta-value">${tool.enabled ? '<span class="text-success">Enabled</span>' : '<span class="text-error">Disabled</span>'}</span></div>
+                    </div>
+                    ${tool.reason ? `<div class="meta-item mt-2"><span class="meta-label">Disable Reason</span><span class="meta-value text-error">${escapeHtml(tool.reason)}</span></div>` : ''}
+                    <div class="mt-2"><span class="meta-label">Description</span><p style="font-size: 0.8125rem; margin-top: 4px;">${escapeHtml(tool.description || '')}</p></div>
+                </div>`;
+
+                // Metadata
+                html += `<div class="detail-section">
+                    <div class="detail-section-title">Metadata</div>
+                    <div class="metadata-grid">
+                        <div class="meta-item"><span class="meta-label">Locality</span><span class="meta-value">${meta.locality || 'any'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Async</span><span class="meta-value">${meta.is_async ? 'Yes' : 'No'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Concurrency Safe</span><span class="meta-value">${meta.is_concurrency_safe !== false ? 'Yes' : 'No'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Think Augment</span><span class="meta-value">${meta.think_augment === true ? 'Enabled' : meta.think_augment === false ? 'Disabled' : 'Default'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Timeout</span><span class="meta-value">${meta.timeout != null ? meta.timeout + 's' : 'None'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Max Result Size</span><span class="meta-value">${meta.max_result_size != null ? meta.max_result_size + ' chars' : 'None'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Deferred</span><span class="meta-value">${meta.defer ? 'Yes' : 'No'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Search Hint</span><span class="meta-value">${escapeHtml(meta.search_hint) || '—'}</span></div>
+                    </div>
+                    ${tags.length > 0 ? `<div class="mt-2"><span class="meta-label">Tags</span><div style="margin-top: 4px;">${renderTagBadges(tags)}</div></div>` : ''}
+                    ${meta.extra && Object.keys(meta.extra).length > 0 ? `<div class="mt-2"><span class="meta-label">Extra</span><pre style="margin-top: 4px; background: var(--bg-primary); padding: 8px; border-radius: var(--radius-sm); font-size: 0.75rem;">${escapeHtml(JSON.stringify(meta.extra, null, 2))}</pre></div>` : ''}
+                </div>`;
+
+                // Schema (collapsible)
+                html += `<div class="detail-section">
+                    <div class="schema-toggle" onclick="this.classList.toggle('expanded'); this.nextElementSibling.classList.toggle('visible');">
+                        <span class="expand-icon">${SVG_CHEVRON}</span>
+                        <span class="detail-section-title" style="margin-bottom: 0;">Schema</span>
+                    </div>
+                    <div class="schema-content">
+                        <pre style="background: #1B1B18; color: #E8E5E0; padding: 12px; border-radius: var(--radius-sm); font-size: 0.75rem; overflow-x: auto; white-space: pre-wrap; font-family: 'SF Mono', 'Fira Code', monospace;">${escapeHtml(JSON.stringify(tool.schema, null, 2))}</pre>
+                    </div>
+                </div>`;
+
+                document.getElementById('detail-body').innerHTML = html;
+                document.getElementById('detail-overlay').classList.add('active');
+            } catch (e) {
+                showToast('Failed to load tool details: ' + e.message, 'error');
+            }
+        }
+
+        function closeDetailModal(event) {
+            if (event && event.target !== event.currentTarget) return;
+            document.getElementById('detail-overlay').classList.remove('active');
+        }
+
+        // ============== Permissions ==============
+        async function refreshPermissions() {
+            try {
+                const data = await api.getPermissions();
+                renderPermissions(data);
+            } catch (e) {
+                document.getElementById('permissions-body').innerHTML =
+                    `<div class="empty-state"><div class="text-error">${e.message}</div></div>`;
+            }
+        }
+
+        function renderPermissions(data) {
+            const body = document.getElementById('permissions-body');
+
+            if (!data.has_policy) {
+                body.innerHTML = `
+                    <div class="empty-state">
+                        <div class="empty-state-icon">No permission policy configured</div>
+                        <div class="empty-state-text">Set a policy via <code>registry.set_permission_policy()</code> to enable permission controls.</div>
+                    </div>`;
+                return;
+            }
+
+            let html = '';
+
+            // Status indicators
+            html += `<div class="perm-status-card">
+                <div class="perm-status-item">
+                    <span class="perm-dot perm-dot-active"></span>
+                    <span>Policy Active</span>
+                </div>
+                <div class="perm-status-item">
+                    <span class="perm-dot ${data.has_handler ? 'perm-dot-active' : 'perm-dot-inactive'}"></span>
+                    <span>Handler ${data.has_handler ? 'Registered' : 'Not Set'}</span>
+                </div>
+                <div class="perm-status-item">
+                    <span>Fallback:</span>
+                    <span class="badge badge-${data.fallback}">${data.fallback}</span>
+                </div>
+            </div>`;
+
+            // Rules table
+            if (data.rules.length > 0) {
+                html += `<div class="table-container">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Rule Name</th>
+                                <th>Result</th>
+                                <th>Reason</th>
+                            </tr>
+                        </thead>
+                        <tbody>`;
+
+                data.rules.forEach(rule => {
+                    html += `<tr>
+                        <td><span style="font-weight: 500;">${escapeHtml(rule.name)}</span></td>
+                        <td><span class="badge badge-${rule.result}">${rule.result}</span></td>
+                        <td class="text-muted" style="font-size: 0.8125rem;">${escapeHtml(rule.reason || '—')}</td>
+                    </tr>`;
+                });
+
+                html += `</tbody></table></div>`;
+            } else {
+                html += `<p class="text-muted" style="font-size: 0.8125rem;">No rules defined. All tool calls will use the fallback result.</p>`;
+            }
+
+            body.innerHTML = html;
+        }
+
         // ============== Utilities ==============
         function escapeHtml(str) {
             if (!str) return '';
@@ -1974,6 +2404,7 @@
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 closeModal();
+                closeDetailModal();
             }
         });
     </script>

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -1759,10 +1759,14 @@
             return key;
         }
 
-        function renderTagBadges(tags) {
+        function renderTagBadges(tags, systemOnly) {
             if (!tags || tags.length === 0) return '';
+            let filtered = tags;
+            if (systemOnly) {
+                filtered = tags.filter(tag => !!TAG_CLASSES[normalizeTagKey(tag)]);
+            }
             // Sort: system tags first, then custom tags
-            const sorted = [...tags].sort((a, b) => {
+            const sorted = [...filtered].sort((a, b) => {
                 const aIsSystem = !!TAG_CLASSES[normalizeTagKey(a)];
                 const bIsSystem = !!TAG_CLASSES[normalizeTagKey(b)];
                 if (aIsSystem && !bIsSystem) return -1;
@@ -1856,7 +1860,7 @@
 
                 children.forEach(tool => {
                     const shortName = (!isDefault && tool.name.startsWith(ns + '-')) ? tool.name.slice(ns.length + 1) : tool.name;
-                    const tagBadges = renderTagBadges(tool.tags);
+                    const tagBadges = renderTagBadges(tool.tags, true);
                     const metaIcons = renderMetaIcons(tool);
                     const permBadge = renderPermissionBadge(tool.permission);
                     html += `

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -519,12 +519,14 @@
         /* ============== Search & Filters ============== */
         .search-bar {
             display: flex;
-            gap: 12px;
+            gap: 8px;
             margin-bottom: 16px;
+            align-items: center;
         }
 
         .search-input {
             flex: 1;
+            min-width: 140px;
             position: relative;
             display: flex;
             align-items: center;
@@ -551,10 +553,26 @@
             height: 14px;
         }
 
+        .search-bar .select {
+            width: auto;
+            flex: 0 0 auto;
+        }
+
         .filter-group {
             display: flex;
             gap: 8px;
-            flex-wrap: wrap;
+            align-items: center;
+            flex: 1;
+        }
+
+        .filter-group .input {
+            width: auto;
+            flex: 0 0 auto;
+        }
+
+        .filter-group .input[type="text"] {
+            flex: 1;
+            min-width: 120px;
         }
 
         /* ============== Stats Grid ============== */
@@ -908,15 +926,28 @@
             }
 
             .search-bar {
-                flex-direction: column;
+                flex-wrap: wrap;
+            }
+
+            .search-input {
+                width: 100%;
+                flex: 1 1 100%;
+            }
+
+            .search-bar .select {
+                flex: 1 1 auto;
+                min-width: 0;
             }
 
             .filter-group {
                 width: 100%;
+                flex-wrap: wrap;
             }
 
-            .filter-group .select {
-                flex: 1;
+            .filter-group .input {
+                flex: 1 1 auto;
+                width: auto;
+                min-width: 0;
             }
 
             th, td {
@@ -1016,7 +1047,7 @@
         .badge-tag-network    { background: rgba(59,130,246,0.10); color: #3B82F6; }
         .badge-tag-privileged { background: rgba(139,92,246,0.10); color: #8B5CF6; }
         .badge-tag-file_system{ background: rgba(20,184,166,0.10); color: #14B8A6; }
-        .badge-tag-custom     { background: var(--bg-primary);     color: var(--text-secondary); }
+        .badge-tag-custom     { background: transparent; color: var(--text-secondary); border: 1px solid var(--border); }
 
         .badge-locality {
             display: inline-flex;
@@ -1268,7 +1299,7 @@
                         </div>
                         <div class="card-body no-padding">
                             <div class="search-bar" style="padding: 16px 16px 0;">
-                                <div class="search-input" style="flex: 1;">
+                                <div class="search-input">
                                     <span class="search-icon">
                                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                             <circle cx="11" cy="11" r="8"></circle>
@@ -1277,25 +1308,23 @@
                                     </span>
                                     <input type="text" class="input" id="tool-search" placeholder="Search tools..." oninput="filterTools()">
                                 </div>
-                                <div class="filter-group">
-                                    <select class="input select" id="namespace-filter" onchange="filterTools()">
-                                        <option value="">All Namespaces</option>
-                                    </select>
-                                    <select class="input select" id="status-filter" onchange="filterTools()">
-                                        <option value="">All Status</option>
-                                        <option value="enabled">Enabled</option>
-                                        <option value="disabled">Disabled</option>
-                                    </select>
-                                    <select class="input select" id="tag-filter" onchange="filterTools()">
-                                        <option value="">All Tags</option>
-                                    </select>
-                                    <select class="input select" id="locality-filter" onchange="filterTools()">
-                                        <option value="">All Locality</option>
-                                        <option value="local">Local</option>
-                                        <option value="remote">Remote</option>
-                                        <option value="any">Any</option>
-                                    </select>
-                                </div>
+                                <select class="input select" id="namespace-filter" onchange="filterTools()">
+                                    <option value="">All Namespaces</option>
+                                </select>
+                                <select class="input select" id="status-filter" onchange="filterTools()">
+                                    <option value="">All Status</option>
+                                    <option value="enabled">Enabled</option>
+                                    <option value="disabled">Disabled</option>
+                                </select>
+                                <select class="input select" id="tag-filter" onchange="filterTools()">
+                                    <option value="">All Tags</option>
+                                </select>
+                                <select class="input select" id="locality-filter" onchange="filterTools()">
+                                    <option value="">All Locality</option>
+                                    <option value="local">Local</option>
+                                    <option value="remote">Remote</option>
+                                    <option value="any">Any</option>
+                                </select>
                             </div>
                             <div class="table-container">
                                 <table class="tools-table">
@@ -1303,12 +1332,13 @@
                                         <tr>
                                             <th class="col-chevron"></th>
                                             <th class="col-name">Name</th>
+                                            <th class="col-permission">Permission</th>
                                             <th class="col-enabled">Enabled</th>
                                             <th class="col-reason">Reason</th>
                                         </tr>
                                     </thead>
                                     <tbody id="tools-body">
-                                        <tr><td colspan="4" class="loading"><div class="spinner"></div>Loading...</td></tr>
+                                        <tr><td colspan="5" class="loading"><div class="spinner"></div>Loading...</td></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -1704,7 +1734,7 @@
             }
         }
 
-        // Tag color mapping for known tags
+        // Tag color mapping for known ToolTag values
         const TAG_CLASSES = {
             'read_only': 'badge-tag-read_only',
             'destructive': 'badge-tag-destructive',
@@ -1714,11 +1744,27 @@
             'file_system': 'badge-tag-file_system',
         };
 
+        function normalizeTagKey(tag) {
+            // Strip "ToolTag." prefix and lowercase for matching
+            const key = tag.replace(/^ToolTag\./i, '').toLowerCase();
+            return key;
+        }
+
         function renderTagBadges(tags) {
             if (!tags || tags.length === 0) return '';
-            return tags.map(tag => {
-                const cls = TAG_CLASSES[tag] || 'badge-tag-custom';
-                return `<span class="badge-tag ${cls}">${escapeHtml(tag)}</span>`;
+            // Sort: system tags first, then custom tags
+            const sorted = [...tags].sort((a, b) => {
+                const aIsSystem = !!TAG_CLASSES[normalizeTagKey(a)];
+                const bIsSystem = !!TAG_CLASSES[normalizeTagKey(b)];
+                if (aIsSystem && !bIsSystem) return -1;
+                if (!aIsSystem && bIsSystem) return 1;
+                return a.localeCompare(b);
+            });
+            return sorted.map(tag => {
+                const key = normalizeTagKey(tag);
+                const cls = TAG_CLASSES[key] || 'badge-tag-custom';
+                const label = TAG_CLASSES[key] ? key : tag;
+                return `<span class="badge-tag ${cls}">${escapeHtml(label)}</span>`;
             }).join('');
         }
 
@@ -1738,6 +1784,13 @@
                 icons += `<span class="meta-icon" title="Deferred">D</span>`;
             }
             return icons ? `<span class="tool-meta-icons">${icons}</span>` : '';
+        }
+
+        function renderPermissionBadge(perm) {
+            if (!perm) return '<span style="color: var(--border);">&mdash;</span>';
+            const cls = 'badge-' + perm.result;
+            const title = perm.rule_name ? `${perm.rule_name}: ${perm.reason}` : perm.reason;
+            return `<span class="${cls}" title="${escapeHtml(title)}">${perm.result}</span>`;
         }
 
         function renderTools(tools) {
@@ -1781,6 +1834,7 @@
                         <span style="font-weight: 500;">${escapeHtml(ns)}</span>
                         <span class="text-muted" style="margin-left: 8px; font-size: 0.6875rem;">${children.length} tool${children.length > 1 ? 's' : ''}</span>
                     </td>
+                    <td></td>
                     <td>
                         ${isDefault ? '' : `<label class="toggle-switch toggle-ns" title="${allEnabled ? 'Click to disable all' : 'Click to enable all'}" onclick="event.stopPropagation()">
                             <input type="checkbox" ${allEnabled ? 'checked' : ''}
@@ -1795,6 +1849,7 @@
                     const shortName = (!isDefault && tool.name.startsWith(ns + '-')) ? tool.name.slice(ns.length + 1) : tool.name;
                     const tagBadges = renderTagBadges(tool.tags);
                     const metaIcons = renderMetaIcons(tool);
+                    const permBadge = renderPermissionBadge(tool.permission);
                     html += `
                 <tr class="ns-child-row" data-ns-group="${nsId}">
                     <td></td>
@@ -1803,6 +1858,7 @@
                         <span class="tool-badges">${tagBadges}</span>
                         ${metaIcons}
                     </td>
+                    <td>${permBadge}</td>
                     <td>
                         <label class="toggle-switch" title="${tool.enabled ? 'Click to disable' : 'Click to enable'}">
                             <input type="checkbox" ${tool.enabled ? 'checked' : ''}
@@ -2254,9 +2310,15 @@
                 document.getElementById('detail-title').textContent = tool.name;
 
                 const meta = tool.metadata || {};
-                const tags = [...(meta.tags || []), ...(meta.custom_tags || [])];
+                const systemTags = (meta.tags || []);
+                const customTags = (meta.custom_tags || []);
 
                 let html = '';
+
+                const perm = tool.permission;
+                const permHtml = perm
+                    ? `<span class="badge-${perm.result}">${perm.result}</span>${perm.rule_name ? ` <span class="text-muted" style="font-size: 0.75rem;">(${escapeHtml(perm.rule_name)})</span>` : ''}`
+                    : '<span class="text-muted">No policy</span>';
 
                 // Basic info
                 html += `<div class="detail-section">
@@ -2266,8 +2328,10 @@
                         <div class="meta-item"><span class="meta-label">Namespace</span><span class="meta-value">${escapeHtml(tool.namespace || 'default')}</span></div>
                         <div class="meta-item"><span class="meta-label">Method Name</span><span class="meta-value">${escapeHtml(tool.method_name || tool.name)}</span></div>
                         <div class="meta-item"><span class="meta-label">Status</span><span class="meta-value">${tool.enabled ? '<span class="text-success">Enabled</span>' : '<span class="text-error">Disabled</span>'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Permission</span><span class="meta-value">${permHtml}</span></div>
                     </div>
                     ${tool.reason ? `<div class="meta-item mt-2"><span class="meta-label">Disable Reason</span><span class="meta-value text-error">${escapeHtml(tool.reason)}</span></div>` : ''}
+                    ${perm && perm.reason ? `<div class="meta-item mt-2"><span class="meta-label">Permission Reason</span><span class="meta-value">${escapeHtml(perm.reason)}</span></div>` : ''}
                     <div class="mt-2"><span class="meta-label">Description</span><p style="font-size: 0.8125rem; margin-top: 4px;">${escapeHtml(tool.description || '')}</p></div>
                 </div>`;
 
@@ -2284,7 +2348,8 @@
                         <div class="meta-item"><span class="meta-label">Deferred</span><span class="meta-value">${meta.defer ? 'Yes' : 'No'}</span></div>
                         <div class="meta-item"><span class="meta-label">Search Hint</span><span class="meta-value">${escapeHtml(meta.search_hint) || '—'}</span></div>
                     </div>
-                    ${tags.length > 0 ? `<div class="mt-2"><span class="meta-label">Tags</span><div style="margin-top: 4px;">${renderTagBadges(tags)}</div></div>` : ''}
+                    ${systemTags.length > 0 ? `<div class="mt-2"><span class="meta-label">Tags</span><div style="margin-top: 4px;">${renderTagBadges(systemTags)}</div></div>` : ''}
+                    ${customTags.length > 0 ? `<div class="mt-2"><span class="meta-label">Custom Tags</span><div style="margin-top: 4px;">${renderTagBadges(customTags)}</div></div>` : ''}
                     ${meta.extra && Object.keys(meta.extra).length > 0 ? `<div class="mt-2"><span class="meta-label">Extra</span><pre style="margin-top: 4px; background: var(--bg-primary); padding: 8px; border-radius: var(--radius-sm); font-size: 0.75rem;">${escapeHtml(JSON.stringify(meta.extra, null, 2))}</pre></div>` : ''}
                 </div>`;
 

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -1225,6 +1225,15 @@
         .perm-dot-active  { background: var(--success); }
         .perm-dot-inactive { background: var(--text-secondary); }
 
+        .badge-allow, .badge-deny, .badge-ask {
+            display: inline-flex;
+            align-items: center;
+            padding: 1px 8px;
+            font-size: 0.625rem;
+            font-weight: 500;
+            border-radius: 9999px;
+            letter-spacing: 0.02em;
+        }
         .badge-allow { background: rgba(61,139,95,0.10);  color: #3D8B5F; }
         .badge-deny  { background: rgba(196,65,65,0.10);  color: #C44141; }
         .badge-ask   { background: rgba(194,146,46,0.10); color: #C2922E; }

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -1084,14 +1084,15 @@
         .meta-icon {
             display: inline-flex;
             align-items: center;
-            justify-content: center;
-            width: 18px;
-            height: 18px;
-            font-size: 0.6875rem;
-            border-radius: 4px;
-            background: var(--bg-primary);
+            padding: 1px 6px;
+            font-size: 0.625rem;
+            font-weight: 500;
+            border-radius: 9999px;
+            background: transparent;
+            border: 1px solid var(--border);
             color: var(--text-secondary);
             cursor: default;
+            letter-spacing: 0.02em;
         }
 
         .tool-badges {
@@ -1801,13 +1802,13 @@
                 icons += `<span class="badge-locality ${cls}" title="Locality: ${tool.locality}">${tool.locality}</span>`;
             }
             if (tool.think_augment === true) {
-                icons += `<span class="meta-icon" title="Think-augmented">T</span>`;
+                icons += `<span class="meta-icon" title="Think-augmented">think</span>`;
             }
             if (tool.is_async) {
-                icons += `<span class="meta-icon" title="Async">A</span>`;
+                icons += `<span class="meta-icon" title="Async">async</span>`;
             }
             if (tool.defer) {
-                icons += `<span class="meta-icon" title="Deferred">D</span>`;
+                icons += `<span class="meta-icon" title="Deferred">defer</span>`;
             }
             return icons ? `<span class="tool-meta-icons">${icons}</span>` : '';
         }

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -950,9 +950,22 @@
                 min-width: 0;
             }
 
+            .table-container {
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+            }
+
+            .table-container table {
+                min-width: 500px;
+            }
+
             th, td {
                 padding: 8px 12px;
                 font-size: 0.75rem;
+            }
+
+            .col-reason {
+                display: none;
             }
 
             .btn {
@@ -1855,7 +1868,7 @@
                             <span class="toggle-slider"></span>
                         </label>`}
                     </td>
-                    <td></td>
+                    <td class="col-reason"></td>
                 </tr>`;
 
                 children.forEach(tool => {
@@ -1879,7 +1892,7 @@
                             <span class="toggle-slider"></span>
                         </label>
                     </td>
-                    <td><span class="col-reason-text" title="${escapeHtml(tool.reason || '')}">${tool.reason ? escapeHtml(tool.reason) : '<span style="color: var(--border);">&mdash;</span>'}</span></td>
+                    <td class="col-reason"><span class="col-reason-text" title="${escapeHtml(tool.reason || '')}">${tool.reason ? escapeHtml(tool.reason) : '<span style="color: var(--border);">&mdash;</span>'}</span></td>
                 </tr>`;
                 });
             });

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -190,6 +190,40 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
 
     # ============== Route Handlers ==============
 
+    def _evaluate_tool_permission(self, tool_name: str) -> dict[str, Any] | None:
+        """Evaluate permission for a tool against the current policy.
+
+        Args:
+            tool_name: Name of the tool to evaluate.
+
+        Returns:
+            Dict with result, rule_name, and reason, or None if no policy.
+        """
+        policy = self.registry.get_permission_policy()
+        if policy is None:
+            return None
+
+        tool = self.registry.get_tool(tool_name)
+        if tool is None:
+            return None
+
+        from ..permissions import PermissionResult, PermissionRule
+
+        result = policy.evaluate(tool, {})
+        if isinstance(result, PermissionRule):
+            return {
+                "result": result.result.value,
+                "rule_name": result.name,
+                "reason": result.reason,
+            }
+        elif isinstance(result, PermissionResult):
+            return {
+                "result": result.value,
+                "rule_name": None,
+                "reason": "Fallback policy",
+            }
+        return None
+
     def _handle_root(self) -> None:
         """Handle root path - serve UI or redirect."""
         if self.serve_ui:
@@ -226,6 +260,11 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
     def _handle_get_tools(self) -> None:
         """Handle GET /api/tools - get all tools status."""
         tools_status = self.registry.get_tools_status()
+        # Enrich with permission evaluation
+        for tool_status in tools_status:
+            tool_status["permission"] = self._evaluate_tool_permission(
+                tool_status["name"]
+            )
         self._send_json_response({"tools": tools_status})
 
     def _handle_get_tool(self, tool_name: str) -> None:
@@ -250,6 +289,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             "enabled": enabled,
             "reason": reason,
             "schema": tool.get_schema(),
+            "permission": self._evaluate_tool_permission(tool_name),
             "metadata": {
                 "is_async": tool.metadata.is_async,
                 "is_concurrency_safe": tool.metadata.is_concurrency_safe,

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -73,6 +73,8 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             self._handle_get_log_stats()
         elif path == "/api/state":
             self._handle_export_state()
+        elif path == "/api/permissions":
+            self._handle_get_permissions()
         else:
             self._send_not_found()
 
@@ -216,6 +218,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                         "DELETE /api/logs",
                         "GET /api/state",
                         "POST /api/state",
+                        "GET /api/permissions",
                     ],
                 }
             )
@@ -247,6 +250,19 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             "enabled": enabled,
             "reason": reason,
             "schema": tool.get_schema(),
+            "metadata": {
+                "is_async": tool.metadata.is_async,
+                "is_concurrency_safe": tool.metadata.is_concurrency_safe,
+                "timeout": tool.metadata.timeout,
+                "locality": tool.metadata.locality,
+                "max_result_size": tool.metadata.max_result_size,
+                "tags": sorted(str(t) for t in tool.metadata.tags),
+                "custom_tags": sorted(tool.metadata.custom_tags),
+                "defer": tool.metadata.defer,
+                "search_hint": tool.metadata.search_hint,
+                "think_augment": tool.metadata.think_augment,
+                "extra": tool.metadata.extra,
+            },
         }
         self._send_json_response(tool_info)
 
@@ -307,12 +323,24 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                         "tool_count": 0,
                         "enabled_count": 0,
                         "disabled_count": 0,
+                        "async_count": 0,
+                        "remote_count": 0,
+                        "tags": set(),
                     }
                 namespaces[ns]["tool_count"] += 1
                 if self.registry.is_enabled(tool_name):
                     namespaces[ns]["enabled_count"] += 1
                 else:
                     namespaces[ns]["disabled_count"] += 1
+                if tool.metadata.is_async:
+                    namespaces[ns]["async_count"] += 1
+                if tool.metadata.locality == "remote":
+                    namespaces[ns]["remote_count"] += 1
+                namespaces[ns]["tags"].update(tool.metadata.all_tags)
+
+        # Convert sets to sorted lists for JSON serialization
+        for ns_data in namespaces.values():
+            ns_data["tags"] = sorted(ns_data["tags"])
 
         # Sort: "default" first, then alphabetical
         result = sorted(
@@ -476,6 +504,40 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
 
         self._send_json_response(
             {"success": True, "message": "State restored successfully"}
+        )
+
+    def _handle_get_permissions(self) -> None:
+        """Handle GET /api/permissions - get permission policy info."""
+        policy = self.registry.get_permission_policy()
+        handler = self.registry.get_permission_handler()
+
+        if policy is None:
+            self._send_json_response(
+                {
+                    "has_policy": False,
+                    "fallback": self.registry.permission_fallback.value,
+                    "has_handler": handler is not None,
+                    "rules": [],
+                }
+            )
+            return
+
+        rules = [
+            {
+                "name": rule.name,
+                "result": rule.result.value,
+                "reason": rule.reason,
+            }
+            for rule in policy.rules
+        ]
+
+        self._send_json_response(
+            {
+                "has_policy": True,
+                "fallback": policy.fallback.value,
+                "has_handler": policy.handler is not None or handler is not None,
+                "rules": rules,
+            }
         )
 
     def _get_admin_ui_html(self) -> str:

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -717,15 +717,22 @@ class ToolRegistry(
     def get_tools_status(self) -> list[dict[str, Any]]:
         """Get status information for all registered tools.
 
-        Returns a list of dictionaries containing status information for each tool,
-        including whether it's enabled/disabled and the reason if disabled.
+        Returns a list of dictionaries containing status information for each
+        tool, including enable/disable state, metadata summary, and tags.
 
         Returns:
-            list[dict[str, Any]]: List of tool status dictionaries, each containing:
+            list[dict[str, Any]]: List of tool status dictionaries, each
+                containing:
+
                 - name (str): Tool name (with namespace prefix if applicable)
                 - enabled (bool): Whether the tool is currently enabled
                 - reason (str | None): Reason for disabling, if disabled
-                - namespace (str | None): Namespace the tool belongs to, if any
+                - namespace (str | None): Namespace the tool belongs to
+                - tags (list[str]): Sorted union of predefined and custom tags
+                - locality (str): ``"local"``, ``"remote"``, or ``"any"``
+                - is_async (bool): Whether the tool requires async execution
+                - think_augment (bool | None): Think-augmented calling setting
+                - defer (bool): Whether the tool is deferred from initial prompt
 
         Example:
             >>> registry = ToolRegistry()
@@ -737,7 +744,12 @@ class ToolRegistry(
                     "name": "my_tool",
                     "enabled": False,
                     "reason": "Under maintenance",
-                    "namespace": None
+                    "namespace": None,
+                    "tags": [],
+                    "locality": "any",
+                    "is_async": False,
+                    "think_augment": None,
+                    "defer": False
                 }
             ]
         """
@@ -745,12 +757,18 @@ class ToolRegistry(
         for tool_name, tool in self._tools.items():
             enabled = self.is_enabled(tool_name)
             reason = self.get_disable_reason(tool_name) if not enabled else None
+            meta = tool.metadata
             status_list.append(
                 {
                     "name": tool_name,
                     "enabled": enabled,
                     "reason": reason,
                     "namespace": tool.namespace,
+                    "tags": sorted(meta.all_tags),
+                    "locality": meta.locality,
+                    "is_async": meta.is_async,
+                    "think_augment": meta.think_augment,
+                    "defer": meta.defer,
                 }
             )
         return status_list

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -11,6 +11,8 @@ import urllib.error
 import pytest
 
 from toolregistry import AdminInfo, AdminServer, TokenAuth, ToolRegistry
+from toolregistry.permissions import PermissionPolicy, PermissionResult, PermissionRule
+from toolregistry.tool import ToolTag
 
 
 class TestTokenAuth:
@@ -522,3 +524,185 @@ class TestAdminServerWithLogging:
         status, data = self._request(f"{info.url}/api/logs", method="DELETE")
         assert status == 200
         assert data["success"] is True
+
+
+class TestAdminServerEnrichedAPI:
+    """Tests for enriched API responses with metadata and permissions."""
+
+    @pytest.fixture
+    def server_with_metadata(self):
+        """Create a server with tools that have rich metadata."""
+        registry = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        def search(query: str) -> str:
+            """Search the web."""
+            return f"Results for {query}"
+
+        registry.register(add, namespace="math")
+        registry.register(search, namespace="web")
+
+        # Set metadata on tools
+        tool_add = registry.get_tool("math-add")
+        tool_add.metadata.tags = {ToolTag.READ_ONLY}
+        tool_add.metadata.locality = "local"
+        tool_add.metadata.timeout = 30.0
+        tool_add.metadata.think_augment = True
+
+        tool_search = registry.get_tool("web-search")
+        tool_search.metadata.tags = {ToolTag.NETWORK, ToolTag.SLOW}
+        tool_search.metadata.custom_tags = {"external"}
+        tool_search.metadata.locality = "remote"
+        tool_search.metadata.defer = True
+        tool_search.metadata.search_hint = "web query"
+
+        server = AdminServer(registry, port=18092)
+        info = server.start()
+        time.sleep(0.1)
+
+        yield server, info, registry
+
+        server.stop()
+
+    def _request(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict | None = None,
+    ) -> tuple[int, dict]:
+        """Make HTTP request and return status code and JSON response."""
+        headers = {"Content-Type": "application/json"}
+        body = json.dumps(data).encode() if data else None
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+        try:
+            with urllib.request.urlopen(req, timeout=5) as response:
+                return response.status, json.loads(response.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode())
+
+    def test_get_tools_includes_metadata_fields(self, server_with_metadata) -> None:
+        """Test GET /api/tools includes tags, locality, is_async, think_augment, defer."""
+        server, info, registry = server_with_metadata
+        status, data = self._request(f"{info.url}/api/tools")
+
+        assert status == 200
+        tools = {t["name"]: t for t in data["tools"]}
+
+        add_tool = tools["math-add"]
+        assert add_tool["tags"] == ["read_only"]
+        assert add_tool["locality"] == "local"
+        assert add_tool["is_async"] is False
+        assert add_tool["think_augment"] is True
+        assert add_tool["defer"] is False
+
+        search_tool = tools["web-search"]
+        assert sorted(search_tool["tags"]) == ["external", "network", "slow"]
+        assert search_tool["locality"] == "remote"
+        assert search_tool["defer"] is True
+
+    def test_get_tool_detail_includes_full_metadata(self, server_with_metadata) -> None:
+        """Test GET /api/tools/{name} includes full metadata object."""
+        server, info, registry = server_with_metadata
+        status, data = self._request(f"{info.url}/api/tools/math-add")
+
+        assert status == 200
+        assert "metadata" in data
+
+        meta = data["metadata"]
+        assert meta["is_async"] is False
+        assert meta["is_concurrency_safe"] is True
+        assert meta["timeout"] == 30.0
+        assert meta["locality"] == "local"
+        assert meta["max_result_size"] is None
+        assert meta["tags"] == ["ToolTag.READ_ONLY"]
+        assert meta["custom_tags"] == []
+        assert meta["defer"] is False
+        assert meta["search_hint"] == ""
+        assert meta["think_augment"] is True
+        assert meta["extra"] == {}
+
+    def test_get_tool_detail_search_tool_metadata(self, server_with_metadata) -> None:
+        """Test GET /api/tools/{name} for tool with custom tags and defer."""
+        server, info, registry = server_with_metadata
+        status, data = self._request(f"{info.url}/api/tools/web-search")
+
+        assert status == 200
+        meta = data["metadata"]
+        assert meta["locality"] == "remote"
+        assert meta["defer"] is True
+        assert meta["search_hint"] == "web query"
+        assert "external" in meta["custom_tags"]
+        assert sorted(str(t) for t in meta["tags"]) == [
+            "ToolTag.NETWORK",
+            "ToolTag.SLOW",
+        ]
+
+    def test_get_namespaces_includes_tags(self, server_with_metadata) -> None:
+        """Test GET /api/namespaces includes tags and metadata counts."""
+        server, info, registry = server_with_metadata
+        status, data = self._request(f"{info.url}/api/namespaces")
+
+        assert status == 200
+        ns_map = {ns["name"]: ns for ns in data["namespaces"]}
+
+        math_ns = ns_map["math"]
+        assert "read_only" in math_ns["tags"]
+        assert math_ns["async_count"] == 0
+        assert math_ns["remote_count"] == 0
+
+        web_ns = ns_map["web"]
+        assert "network" in web_ns["tags"]
+        assert "external" in web_ns["tags"]
+        assert web_ns["remote_count"] == 1
+
+    def test_get_permissions_no_policy(self, server_with_metadata) -> None:
+        """Test GET /api/permissions when no policy is set."""
+        server, info, registry = server_with_metadata
+        status, data = self._request(f"{info.url}/api/permissions")
+
+        assert status == 200
+        assert data["has_policy"] is False
+        assert data["rules"] == []
+        assert data["has_handler"] is False
+
+    def test_get_permissions_with_policy(self, server_with_metadata) -> None:
+        """Test GET /api/permissions with a policy set."""
+        server, info, registry = server_with_metadata
+
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    name="allow_readonly",
+                    match=lambda t, p: ToolTag.READ_ONLY in t.metadata.tags,
+                    result=PermissionResult.ALLOW,
+                    reason="Read-only tools are safe",
+                ),
+                PermissionRule(
+                    name="deny_network",
+                    match=lambda t, p: ToolTag.NETWORK in t.metadata.tags,
+                    result=PermissionResult.DENY,
+                    reason="Network tools need review",
+                ),
+            ],
+            fallback=PermissionResult.ASK,
+        )
+        registry.set_permission_policy(policy)
+
+        status, data = self._request(f"{info.url}/api/permissions")
+
+        assert status == 200
+        assert data["has_policy"] is True
+        assert data["fallback"] == "ask"
+        assert data["has_handler"] is False
+        assert len(data["rules"]) == 2
+
+        assert data["rules"][0]["name"] == "allow_readonly"
+        assert data["rules"][0]["result"] == "allow"
+        assert data["rules"][0]["reason"] == "Read-only tools are safe"
+
+        assert data["rules"][1]["name"] == "deny_network"
+        assert data["rules"][1]["result"] == "deny"

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -706,3 +706,78 @@ class TestAdminServerEnrichedAPI:
 
         assert data["rules"][1]["name"] == "deny_network"
         assert data["rules"][1]["result"] == "deny"
+
+    def test_get_tools_includes_permission(self, server_with_metadata) -> None:
+        """Test GET /api/tools includes permission evaluation for each tool."""
+        server, info, registry = server_with_metadata
+
+        # Without policy, permission should be None
+        status, data = self._request(f"{info.url}/api/tools")
+        assert status == 200
+        tools = {t["name"]: t for t in data["tools"]}
+        assert tools["math-add"]["permission"] is None
+
+        # Set a policy
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    name="allow_readonly",
+                    match=lambda t, p: ToolTag.READ_ONLY in t.metadata.tags,
+                    result=PermissionResult.ALLOW,
+                    reason="Read-only tools are safe",
+                ),
+                PermissionRule(
+                    name="deny_network",
+                    match=lambda t, p: ToolTag.NETWORK in t.metadata.tags,
+                    result=PermissionResult.DENY,
+                    reason="Network tools need review",
+                ),
+            ],
+            fallback=PermissionResult.ASK,
+        )
+        registry.set_permission_policy(policy)
+
+        status, data = self._request(f"{info.url}/api/tools")
+        assert status == 200
+        tools = {t["name"]: t for t in data["tools"]}
+
+        # math-add has READ_ONLY tag → allow
+        add_perm = tools["math-add"]["permission"]
+        assert add_perm["result"] == "allow"
+        assert add_perm["rule_name"] == "allow_readonly"
+
+        # web-search has NETWORK tag → deny (first-match-wins, but also has no READ_ONLY)
+        search_perm = tools["web-search"]["permission"]
+        assert search_perm["result"] == "deny"
+        assert search_perm["rule_name"] == "deny_network"
+
+    def test_get_tool_detail_includes_permission(self, server_with_metadata) -> None:
+        """Test GET /api/tools/{name} includes permission evaluation."""
+        server, info, registry = server_with_metadata
+
+        # Set a policy
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    name="allow_readonly",
+                    match=lambda t, p: ToolTag.READ_ONLY in t.metadata.tags,
+                    result=PermissionResult.ALLOW,
+                    reason="Read-only tools are safe",
+                ),
+            ],
+            fallback=PermissionResult.ASK,
+        )
+        registry.set_permission_policy(policy)
+
+        # math-add matches allow_readonly
+        status, data = self._request(f"{info.url}/api/tools/math-add")
+        assert status == 200
+        assert data["permission"]["result"] == "allow"
+        assert data["permission"]["rule_name"] == "allow_readonly"
+        assert data["permission"]["reason"] == "Read-only tools are safe"
+
+        # web-search doesn't match any rule → fallback (ask)
+        status, data = self._request(f"{info.url}/api/tools/web-search")
+        assert status == 200
+        assert data["permission"]["result"] == "ask"
+        assert data["permission"]["rule_name"] is None


### PR DESCRIPTION
## Summary

Brings the admin panel UI up to date with v0.7/v0.8 features (ToolMetadata, permissions system).

- **Backend API enrichment**: Tool list and detail endpoints now return full metadata (tags, locality, think_augment, defer, is_async, timeout, etc.) and per-tool permission evaluation results
- **New endpoint**: `GET /api/permissions` returns policy rules, fallback, and handler status
- **UI — Tool list**: Metadata badges (system tags as colored pills, locality, think/defer/async as outlined pills), Permission column with allow/deny/ask badges
- **UI — Tool detail modal**: Click tool name to see full metadata, JSON schema, and permission info
- **UI — Filters**: Tag and Locality filter dropdowns in search bar (inline layout)
- **UI — Permissions tab**: Shows policy rules table with colored result badges
- **UI — Responsive**: Mobile layout hides Reason column, tables scroll horizontally, proper wrapping at tablet/phone sizes
- **Visual distinction**: System ToolTag badges (filled, colored) vs custom tags (outlined, only shown in detail modal)
- **Tests**: 12 new tests covering enriched API fields, permissions endpoint, and per-tool permission evaluation

## Test plan

- [x] `pytest tests/test_admin_server.py -v` — 44 tests pass
- [ ] CI passes on all Python versions
- [ ] Visual verification at 1920×1080, 1440×900, 1024×768, 768×1024, 375×812 viewports