### PR TITLE
feat(admin): runtime control for think_augment and defer

### DIFF
--- a/src/toolregistry/_mixins/enable_disable.py
+++ b/src/toolregistry/_mixins/enable_disable.py
@@ -87,3 +87,71 @@ class EnableDisableMixin:
         if tool and tool.namespace:
             return self._disabled.get(tool.namespace)
         return None
+
+    # Fields safe to update at runtime via update_tool_metadata()
+    _MUTABLE_METADATA_FIELDS: frozenset[str] = frozenset({"think_augment", "defer"})
+
+    def update_tool_metadata(self, tool_name: str, **kwargs: object) -> None:
+        """Update mutable metadata fields for a tool at runtime.
+
+        Only whitelisted fields (think_augment, defer) can be modified.
+
+        Args:
+            tool_name: The name of the tool to update.
+            **kwargs: Field-value pairs to update.
+
+        Raises:
+            KeyError: If the tool is not found.
+            ValueError: If an unknown or disallowed field is specified.
+        """
+        tool = self._tools.get(tool_name)
+        if tool is None:
+            raise KeyError(f"Tool not found: {tool_name}")
+        for key in kwargs:
+            if key not in self._MUTABLE_METADATA_FIELDS:
+                raise ValueError(
+                    f"Field '{key}' is not allowed. "
+                    f"Allowed fields: {sorted(self._MUTABLE_METADATA_FIELDS)}"
+                )
+        for key, value in kwargs.items():
+            setattr(tool.metadata, key, value)
+        self._emit_change(
+            ChangeEvent(
+                event_type=ChangeEventType.METADATA_UPDATE,
+                tool_name=tool_name,
+                metadata=dict(kwargs),
+            )
+        )
+
+    def update_namespace_metadata(self, namespace: str, **kwargs: object) -> None:
+        """Update mutable metadata fields for all tools in a namespace.
+
+        Only whitelisted fields (think_augment, defer) can be modified.
+
+        Args:
+            namespace: The namespace to update.
+            **kwargs: Field-value pairs to apply to all tools in the namespace.
+
+        Raises:
+            KeyError: If no tools are found in the namespace.
+            ValueError: If an unknown or disallowed field is specified.
+        """
+        tools = [t for t in self._tools.values() if t.namespace == namespace]
+        if not tools:
+            raise KeyError(f"Namespace not found: {namespace}")
+        for key in kwargs:
+            if key not in self._MUTABLE_METADATA_FIELDS:
+                raise ValueError(
+                    f"Field '{key}' is not allowed. "
+                    f"Allowed fields: {sorted(self._MUTABLE_METADATA_FIELDS)}"
+                )
+        for tool in tools:
+            for key, value in kwargs.items():
+                setattr(tool.metadata, key, value)
+            self._emit_change(
+                ChangeEvent(
+                    event_type=ChangeEventType.METADATA_UPDATE,
+                    tool_name=tool.name,
+                    metadata=dict(kwargs),
+                )
+            )

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -336,6 +336,32 @@
             background: #2B8A7E;
         }
 
+        /* Metadata toggle: smaller size, indigo color */
+        .toggle-switch.toggle-meta {
+            width: 28px;
+            height: 16px;
+        }
+
+        .toggle-switch.toggle-meta .toggle-slider::before {
+            width: 12px;
+            height: 12px;
+        }
+
+        .toggle-switch.toggle-meta input:checked + .toggle-slider {
+            background: #6366F1;
+        }
+
+        .toggle-switch.toggle-meta input:checked + .toggle-slider::before {
+            transform: translateX(12px);
+        }
+
+        .toggle-meta-label {
+            font-size: 0.625rem;
+            color: var(--text-secondary);
+            margin-left: 2px;
+            cursor: default;
+        }
+
         /* ============== Tables ============== */
         .table-container {
             overflow-x: auto;
@@ -1625,6 +1651,20 @@
                 });
             }
 
+            async updateToolMetadata(name, metadata) {
+                return this.request('/api/tools/' + encodeURIComponent(name) + '/metadata', {
+                    method: 'PATCH',
+                    body: JSON.stringify(metadata)
+                });
+            }
+
+            async updateNamespaceMetadata(ns, metadata) {
+                return this.request('/api/namespaces/' + encodeURIComponent(ns) + '/metadata', {
+                    method: 'PATCH',
+                    body: JSON.stringify(metadata)
+                });
+            }
+
             async getLogs(params = {}) {
                 const query = new URLSearchParams();
                 if (params.limit) query.set('limit', params.limit);
@@ -1801,16 +1841,21 @@
                 const cls = tool.locality === 'local' ? 'badge-locality-local' : 'badge-locality-remote';
                 icons += `<span class="badge-locality ${cls}" title="Locality: ${tool.locality}">${tool.locality}</span>`;
             }
-            if (tool.think_augment === true) {
-                icons += `<span class="meta-icon" title="Think-augmented">think</span>`;
-            }
+            icons += renderMetaToggle(tool.name, 'think_augment', 'think', tool.think_augment);
             if (tool.is_async) {
                 icons += `<span class="meta-icon" title="Async">async</span>`;
             }
-            if (tool.defer) {
-                icons += `<span class="meta-icon" title="Deferred">defer</span>`;
-            }
+            icons += renderMetaToggle(tool.name, 'defer', 'defer', tool.defer);
             return icons ? `<span class="tool-meta-icons">${icons}</span>` : '';
+        }
+
+        function renderMetaToggle(toolName, field, label, checked) {
+            return `<label class="toggle-switch toggle-meta" title="${label}">
+                <input type="checkbox" ${checked ? 'checked' : ''}
+                    onclick="event.stopPropagation()"
+                    onchange="toggleToolMeta('${escapeHtml(toolName)}', '${field}', this.checked)">
+                <span class="toggle-slider"></span>
+            </label><span class="toggle-meta-label">${label}</span>`;
         }
 
         function renderPermissionBadge(perm) {
@@ -1852,6 +1897,10 @@
             nsKeys.forEach(ns => {
                 const children = nsMap[ns];
                 const allEnabled = children.every(t => t.enabled);
+                const allThink = children.every(t => t.think_augment);
+                const anyThink = children.some(t => t.think_augment);
+                const allDefer = children.every(t => t.defer);
+                const anyDefer = children.some(t => t.defer);
                 const nsId = 'ns-' + ns.replace(/[^a-zA-Z0-9_]/g, '_');
                 const isDefault = ns === 'default';
                 html += `
@@ -1861,7 +1910,18 @@
                         <span style="font-weight: 500;">${escapeHtml(ns)}</span>
                         <span class="text-muted" style="margin-left: 8px; font-size: 0.6875rem;">${children.length} tool${children.length > 1 ? 's' : ''}</span>
                     </td>
-                    <td></td>
+                    <td class="ns-meta-toggles" onclick="event.stopPropagation()">
+                        <label class="toggle-switch toggle-meta" title="Think-augmented (all)">
+                            <input type="checkbox" ${allThink ? 'checked' : ''}
+                                onchange="toggleNamespaceMeta('${escapeHtml(ns)}', 'think_augment', this.checked)">
+                            <span class="toggle-slider"></span>
+                        </label><span class="toggle-meta-label">think</span>
+                        <label class="toggle-switch toggle-meta" title="Deferred (all)" style="margin-left: 6px;">
+                            <input type="checkbox" ${allDefer ? 'checked' : ''}
+                                onchange="toggleNamespaceMeta('${escapeHtml(ns)}', 'defer', this.checked)">
+                            <span class="toggle-slider"></span>
+                        </label><span class="toggle-meta-label">defer</span>
+                    </td>
                     <td>
                         ${isDefault ? '' : `<label class="toggle-switch toggle-ns" title="${allEnabled ? 'Click to disable all' : 'Click to enable all'}" onclick="event.stopPropagation()">
                             <input type="checkbox" ${allEnabled ? 'checked' : ''}
@@ -2025,6 +2085,28 @@
                 await enableNamespace(ns);
             } else {
                 showDisableNamespaceModal(ns);
+            }
+        }
+
+        async function toggleToolMeta(name, field, value) {
+            try {
+                await api.updateToolMetadata(name, { [field]: value });
+                showToast(`${field} ${value ? 'enabled' : 'disabled'} for "${name}"`, 'success');
+                refreshTools();
+            } catch (e) {
+                showToast(e.message, 'error');
+                refreshTools();
+            }
+        }
+
+        async function toggleNamespaceMeta(ns, field, value) {
+            try {
+                await api.updateNamespaceMetadata(ns, { [field]: value });
+                showToast(`${field} ${value ? 'enabled' : 'disabled'} for namespace "${ns}"`, 'success');
+                refreshTools();
+            } catch (e) {
+                showToast(e.message, 'error');
+                refreshTools();
             }
         }
 
@@ -2369,10 +2451,10 @@
                         <div class="meta-item"><span class="meta-label">Locality</span><span class="meta-value">${meta.locality || 'any'}</span></div>
                         <div class="meta-item"><span class="meta-label">Async</span><span class="meta-value">${meta.is_async ? 'Yes' : 'No'}</span></div>
                         <div class="meta-item"><span class="meta-label">Concurrency Safe</span><span class="meta-value">${meta.is_concurrency_safe !== false ? 'Yes' : 'No'}</span></div>
-                        <div class="meta-item"><span class="meta-label">Think Augment</span><span class="meta-value">${meta.think_augment === true ? 'Enabled' : meta.think_augment === false ? 'Disabled' : 'Default'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Think Augment</span><span class="meta-value"><label class="toggle-switch toggle-meta"><input type="checkbox" ${meta.think_augment ? 'checked' : ''} onchange="toggleToolMeta('${escapeHtml(tool.name)}', 'think_augment', this.checked)"><span class="toggle-slider"></span></label></span></div>
                         <div class="meta-item"><span class="meta-label">Timeout</span><span class="meta-value">${meta.timeout != null ? meta.timeout + 's' : 'None'}</span></div>
                         <div class="meta-item"><span class="meta-label">Max Result Size</span><span class="meta-value">${meta.max_result_size != null ? meta.max_result_size + ' chars' : 'None'}</span></div>
-                        <div class="meta-item"><span class="meta-label">Deferred</span><span class="meta-value">${meta.defer ? 'Yes' : 'No'}</span></div>
+                        <div class="meta-item"><span class="meta-label">Deferred</span><span class="meta-value"><label class="toggle-switch toggle-meta"><input type="checkbox" ${meta.defer ? 'checked' : ''} onchange="toggleToolMeta('${escapeHtml(tool.name)}', 'defer', this.checked)"><span class="toggle-slider"></span></label></span></div>
                         <div class="meta-item"><span class="meta-label">Search Hint</span><span class="meta-value">${escapeHtml(meta.search_hint) || '—'}</span></div>
                     </div>
                     ${systemTags.length > 0 ? `<div class="mt-2"><span class="meta-label">Tags</span><div style="margin-top: 4px;">${renderTagBadges(systemTags)}</div></div>` : ''}

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -61,7 +61,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         elif path == "/api/tools":
             self._handle_get_tools()
         elif path.startswith("/api/tools/") and not path.endswith(
-            ("/enable", "/disable")
+            ("/enable", "/disable", "/metadata")
         ):
             tool_name = path[len("/api/tools/") :]
             self._handle_get_tool(urllib.parse.unquote(tool_name))
@@ -110,6 +110,28 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
         else:
             self._send_not_found()
 
+    def do_PATCH(self) -> None:
+        """Handle PATCH requests for metadata updates."""
+        if self.auth and not self.auth.require_auth(self):
+            return
+
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b""
+
+        if path.startswith("/api/tools/") and path.endswith("/metadata"):
+            tool_name = path[len("/api/tools/") : -len("/metadata")]
+            self._handle_update_tool_metadata(urllib.parse.unquote(tool_name), body)
+        elif path.startswith("/api/namespaces/") and path.endswith("/metadata"):
+            namespace = path[len("/api/namespaces/") : -len("/metadata")]
+            self._handle_update_namespace_metadata(
+                urllib.parse.unquote(namespace), body
+            )
+        else:
+            self._send_not_found()
+
     def do_DELETE(self) -> None:
         """Handle DELETE requests."""
         # Check authentication if enabled
@@ -137,7 +159,9 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
     def _send_cors_headers(self) -> None:
         """Send CORS headers for cross-origin requests."""
         self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+        self.send_header(
+            "Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS"
+        )
         self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
     def _send_json_response(
@@ -244,9 +268,11 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                         "GET /api/tools/{name}",
                         "POST /api/tools/{name}/enable",
                         "POST /api/tools/{name}/disable",
+                        "PATCH /api/tools/{name}/metadata",
                         "GET /api/namespaces",
                         "POST /api/namespaces/{ns}/enable",
                         "POST /api/namespaces/{ns}/disable",
+                        "PATCH /api/namespaces/{ns}/metadata",
                         "GET /api/logs",
                         "GET /api/logs/stats",
                         "DELETE /api/logs",
@@ -346,6 +372,96 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                 "success": True,
                 "message": f"Tool '{tool_name}' disabled",
                 "reason": reason,
+            }
+        )
+
+    def _handle_update_tool_metadata(self, tool_name: str, body: bytes) -> None:
+        """Handle PATCH /api/tools/{name}/metadata - update tool metadata.
+
+        Args:
+            tool_name: Name of the tool to update.
+            body: JSON body with metadata fields to update.
+        """
+        if not body:
+            self._send_error_response(400, "Bad Request", "Request body is required")
+            return
+
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError as e:
+            self._send_error_response(400, "Bad Request", f"Invalid JSON: {e}")
+            return
+
+        if not isinstance(data, dict) or not data:
+            self._send_error_response(
+                400, "Bad Request", "Body must be a non-empty JSON object"
+            )
+            return
+
+        try:
+            self.registry.update_tool_metadata(tool_name, **data)
+        except KeyError:
+            self._send_error_response(404, "Not Found", f"Tool not found: {tool_name}")
+            return
+        except ValueError as e:
+            self._send_error_response(400, "Bad Request", str(e))
+            return
+
+        self._send_json_response(
+            {
+                "success": True,
+                "message": f"Metadata updated for tool '{tool_name}'",
+                "updated": data,
+            }
+        )
+
+    def _handle_update_namespace_metadata(self, namespace: str, body: bytes) -> None:
+        """Handle PATCH /api/namespaces/{ns}/metadata - update namespace metadata.
+
+        Args:
+            namespace: Namespace to update.
+            body: JSON body with metadata fields to update.
+        """
+        if not body:
+            self._send_error_response(400, "Bad Request", "Request body is required")
+            return
+
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError as e:
+            self._send_error_response(400, "Bad Request", f"Invalid JSON: {e}")
+            return
+
+        if not isinstance(data, dict) or not data:
+            self._send_error_response(
+                400, "Bad Request", "Body must be a non-empty JSON object"
+            )
+            return
+
+        try:
+            self.registry.update_namespace_metadata(namespace, **data)
+        except KeyError:
+            self._send_error_response(
+                404, "Not Found", f"Namespace not found: {namespace}"
+            )
+            return
+        except ValueError as e:
+            self._send_error_response(400, "Bad Request", str(e))
+            return
+
+        # Count affected tools
+        tools_updated = sum(
+            1
+            for name in self.registry.list_tools(include_disabled=True)
+            if (t := self.registry.get_tool(name)) and t.namespace == namespace
+        )
+
+        self._send_json_response(
+            {
+                "success": True,
+                "message": f"Metadata updated for namespace '{namespace}'",
+                "tools_updated": tools_updated,
+                "updated": data,
             }
         )
 

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -20,6 +20,7 @@ class ChangeEventType(str, Enum):
         DISABLE: A tool was disabled.
         REFRESH: A single tool was refreshed.
         REFRESH_ALL: All tools were refreshed/reloaded.
+        METADATA_UPDATE: A tool's metadata was updated at runtime.
     """
 
     REGISTER = "register"
@@ -30,6 +31,7 @@ class ChangeEventType(str, Enum):
     REFRESH_ALL = "refresh_all"
     PERMISSION_DENIED = "permission_denied"
     PERMISSION_ASKED = "permission_asked"
+    METADATA_UPDATE = "metadata_update"
 
 
 @dataclass(frozen=True)

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -781,3 +781,157 @@ class TestAdminServerEnrichedAPI:
         assert status == 200
         assert data["permission"]["result"] == "ask"
         assert data["permission"]["rule_name"] is None
+
+
+class TestAdminServerMetadataUpdate:
+    """Tests for PATCH /api/tools/{name}/metadata and PATCH /api/namespaces/{ns}/metadata."""
+
+    @pytest.fixture
+    def server_with_tools(self):
+        """Create a server with tools for metadata update testing."""
+        registry = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        def greet(name: str) -> str:
+            """Greet someone."""
+            return f"Hello, {name}!"
+
+        registry.register(add, namespace="math")
+        registry.register(multiply, namespace="math")
+        registry.register(greet)
+
+        server = AdminServer(registry, port=18093)
+        info = server.start()
+        time.sleep(0.1)
+
+        yield server, info, registry
+
+        server.stop()
+
+    def _request(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict | None = None,
+    ) -> tuple[int, dict]:
+        """Make HTTP request and return status code and JSON response."""
+        headers = {"Content-Type": "application/json"}
+        body = json.dumps(data).encode() if data else None
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+        try:
+            with urllib.request.urlopen(req, timeout=5) as response:
+                return response.status, json.loads(response.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode())
+
+    def test_update_tool_think_augment(self, server_with_tools) -> None:
+        """Test PATCH /api/tools/{name}/metadata with think_augment."""
+        server, info, registry = server_with_tools
+
+        # Initially think_augment is None/False
+        tool = registry.get_tool("math-add")
+        assert not tool.metadata.think_augment
+
+        # Enable think_augment
+        status, data = self._request(
+            f"{info.url}/api/tools/math-add/metadata",
+            method="PATCH",
+            data={"think_augment": True},
+        )
+        assert status == 200
+        assert data["success"] is True
+        assert data["updated"] == {"think_augment": True}
+
+        # Verify the metadata was actually updated
+        assert tool.metadata.think_augment is True
+
+    def test_update_tool_defer(self, server_with_tools) -> None:
+        """Test PATCH /api/tools/{name}/metadata with defer."""
+        server, info, registry = server_with_tools
+
+        tool = registry.get_tool("greet")
+        assert tool.metadata.defer is False
+
+        status, data = self._request(
+            f"{info.url}/api/tools/greet/metadata",
+            method="PATCH",
+            data={"defer": True},
+        )
+        assert status == 200
+        assert data["success"] is True
+        assert tool.metadata.defer is True
+
+    def test_update_tool_invalid_field(self, server_with_tools) -> None:
+        """Test PATCH with disallowed field returns 400."""
+        server, info, registry = server_with_tools
+
+        status, data = self._request(
+            f"{info.url}/api/tools/math-add/metadata",
+            method="PATCH",
+            data={"is_async": True},
+        )
+        assert status == 400
+        assert "not allowed" in data["message"]
+
+    def test_update_tool_unknown_tool(self, server_with_tools) -> None:
+        """Test PATCH on nonexistent tool returns 404."""
+        server, info, registry = server_with_tools
+
+        status, data = self._request(
+            f"{info.url}/api/tools/nonexistent/metadata",
+            method="PATCH",
+            data={"think_augment": True},
+        )
+        assert status == 404
+
+    def test_update_tool_empty_body(self, server_with_tools) -> None:
+        """Test PATCH with empty body returns 400."""
+        server, info, registry = server_with_tools
+
+        status, data = self._request(
+            f"{info.url}/api/tools/math-add/metadata",
+            method="PATCH",
+            data={},
+        )
+        assert status == 400
+
+    def test_update_namespace_metadata(self, server_with_tools) -> None:
+        """Test PATCH /api/namespaces/{ns}/metadata updates all tools."""
+        server, info, registry = server_with_tools
+
+        tool_add = registry.get_tool("math-add")
+        tool_mul = registry.get_tool("math-multiply")
+        assert not tool_add.metadata.think_augment
+        assert not tool_mul.metadata.think_augment
+
+        status, data = self._request(
+            f"{info.url}/api/namespaces/math/metadata",
+            method="PATCH",
+            data={"think_augment": True},
+        )
+        assert status == 200
+        assert data["success"] is True
+        assert data["tools_updated"] == 2
+
+        # Both tools should be updated
+        assert tool_add.metadata.think_augment is True
+        assert tool_mul.metadata.think_augment is True
+
+    def test_update_namespace_unknown(self, server_with_tools) -> None:
+        """Test PATCH on nonexistent namespace returns 404."""
+        server, info, registry = server_with_tools
+
+        status, data = self._request(
+            f"{info.url}/api/namespaces/nonexistent/metadata",
+            method="PATCH",
+            data={"defer": True},
+        )
+        assert status == 404


### PR DESCRIPTION
Closes #134

## Summary

- **Core**: `update_tool_metadata()` and `update_namespace_metadata()` methods with whitelist validation (only `think_augment` and `defer` allowed)
- **Admin API**: `PATCH /api/tools/{name}/metadata` and `PATCH /api/namespaces/{ns}/metadata` endpoints
- **Admin UI**: Interactive toggle switches (indigo colored) for think/defer at both tool and namespace level, including in the detail modal
- **Events**: New `METADATA_UPDATE` change event type
- **Tests**: 7 new tests for metadata update endpoints (51 total)

## Test plan

- [x] `pytest tests/test_admin_server.py -v` — 51 tests pass
- [ ] CI passes
- [ ] Visual verification: toggles render, click to toggle sends PATCH, state persists after refresh