### PR TITLE
refactor(admin): migrate to async httpserver from zerodep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ Issues = "https://github.com/Oaklight/ToolRegistry/issues"
 
 [tool.ruff]
 target-version = "py310"
+exclude = ["src/toolregistry/_vendor"]
 
 [tool.ruff.lint]
 select = ["E", "F", "UP"]
@@ -85,9 +86,13 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
+exclude = ["src/toolregistry/_vendor"]
 
 [tool.ty.rules]
 unresolved-import = "ignore"
+
+[tool.complexipy]
+exclude = ["_vendor"]
 
 [tool.setuptools.dynamic]
 version = { attr = "toolregistry.__version__" }

--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -1,6 +1,5 @@
 from .admin import (
     AdminInfo,
-    AdminRequestHandler,
     AdminServer,
     ExecutionLog,
     ExecutionLogEntry,
@@ -28,7 +27,6 @@ from .tool_discovery import ToolDiscoveryTool
 
 __all__ = [
     "AdminInfo",
-    "AdminRequestHandler",
     "AdminServer",
     "AsyncPermissionHandler",
     "ChangeCallback",

--- a/src/toolregistry/_vendor/httpserver.py
+++ b/src/toolregistry/_vendor/httpserver.py
@@ -1,0 +1,1007 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via `zerodep add httpserver`"
+# ///
+
+"""Zero-dependency async HTTP server with decorator-based routing.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Async HTTP/1.1 server built on ``asyncio.start_server()``.  Supports
+decorator-based routing, JSON request/response, static file serving,
+streaming responses (SSE), and graceful shutdown.
+
+Usage::
+
+    from httpserver import App, JSONResponse
+
+    app = App()
+
+    @app.route("/status")
+    async def status(request):
+        return JSONResponse({"state": "idle"})
+
+    @app.route("/echo", methods=["POST"])
+    def echo(request):
+        return JSONResponse(request.json())
+
+    app.run(host="127.0.0.1", port=8000)
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────────
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import inspect
+import json as _json
+import logging
+import mimetypes
+import os
+import re
+import signal
+import sys
+from collections.abc import AsyncIterator, Callable
+from email.utils import formatdate
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+__all__ = [
+    # Application
+    "App",
+    # Request / Response
+    "Request",
+    "Response",
+    "JSONResponse",
+    "StreamingResponse",
+    "FileResponse",
+    # Exceptions
+    "HTTPException",
+    # Utilities
+    "abort",
+]
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_MAX_BODY_SIZE = 1_048_576  # 1 MB
+DEFAULT_READ_TIMEOUT = 30.0  # seconds
+
+_STATUS_REASONS: dict[int, str] = {
+    100: "Continue",
+    101: "Switching Protocols",
+    200: "OK",
+    201: "Created",
+    202: "Accepted",
+    204: "No Content",
+    301: "Moved Permanently",
+    302: "Found",
+    303: "See Other",
+    304: "Not Modified",
+    307: "Temporary Redirect",
+    308: "Permanent Redirect",
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    408: "Request Timeout",
+    409: "Conflict",
+    413: "Content Too Large",
+    415: "Unsupported Media Type",
+    422: "Unprocessable Entity",
+    429: "Too Many Requests",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+}
+
+# Type converters for path parameters
+_PARAM_CONVERTERS: dict[str, tuple[str, Callable[[str], Any]]] = {
+    "str": (r"([^/]+)", str),
+    "int": (r"(-?\d+)", int),
+    "float": (r"(-?[0-9]+(?:\.[0-9]+)?)", float),
+    "path": (r"(.+)", str),
+}
+
+# Regex to find <type:name> or <name> segments in route patterns
+_PARAM_RE = re.compile(r"<(?:(\w+):)?(\w+)>")
+
+_SENTINEL = object()
+
+
+# ── Exceptions ───────────────────────────────────────────────────────────────
+
+
+class HTTPException(Exception):
+    """HTTP error that maps to a specific status code.
+
+    Raise directly or via :func:`abort` to short-circuit request handling.
+
+    Args:
+        status_code: HTTP status code (e.g. 404, 500).
+        message: Optional human-readable error message.
+    """
+
+    __slots__ = ("status_code", "message")
+
+    def __init__(self, status_code: int, message: str | None = None):
+        self.status_code = status_code
+        self.message = message or _STATUS_REASONS.get(status_code, "Error")
+        super().__init__(self.message)
+
+
+class _BadRequest(Exception):
+    """Internal: malformed HTTP request from client."""
+
+
+def abort(status_code: int, message: str | None = None) -> None:
+    """Raise an :class:`HTTPException` with the given status code.
+
+    Args:
+        status_code: HTTP status code.
+        message: Optional error message.
+    """
+    raise HTTPException(status_code, message)
+
+
+# ── Request ──────────────────────────────────────────────────────────────────
+
+
+class Request:
+    """Parsed HTTP request.
+
+    Attributes:
+        method: Uppercase HTTP method (GET, POST, ...).
+        path: URL path, percent-decoded.
+        query_string: Raw query string (without leading ``?``).
+        query_params: Parsed query string as ``{key: [values]}``.
+        headers: Case-insensitive header dict (keys stored lowercase).
+        body: Raw request body bytes.
+        path_params: Parameters extracted from the route pattern.
+        client_addr: Client ``(host, port)`` tuple.
+        app: Reference to the :class:`App` instance handling this request.
+    """
+
+    __slots__ = (
+        "method",
+        "path",
+        "query_string",
+        "query_params",
+        "headers",
+        "body",
+        "path_params",
+        "client_addr",
+        "app",
+        "_json",
+    )
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        query_string: str,
+        headers: dict[str, str],
+        body: bytes,
+        client_addr: tuple[str, int],
+        app: App | None = None,
+    ):
+        self.method = method
+        self.path = path
+        self.query_string = query_string
+        self.query_params: dict[str, list[str]] = parse_qs(query_string)
+        self.headers = headers
+        self.body = body
+        self.path_params: dict[str, Any] = {}
+        self.client_addr = client_addr
+        self.app = app
+        self._json: Any = _SENTINEL
+
+    def json(self) -> Any:
+        """Parse body as JSON (cached)."""
+        if self._json is _SENTINEL:
+            self._json = _json.loads(self.body)
+        return self._json
+
+    def text(self) -> str:
+        """Decode body as UTF-8."""
+        return self.body.decode("utf-8")
+
+    def form(self) -> dict[str, list[str]]:
+        """Parse URL-encoded form body."""
+        return parse_qs(self.body.decode("utf-8"))
+
+
+# ── Response Classes ─────────────────────────────────────────────────────────
+
+
+class Response:
+    """HTTP response with a fixed body.
+
+    Args:
+        body: Response body (bytes or str).
+        status_code: HTTP status code.
+        headers: Extra response headers.
+        content_type: Shorthand for ``Content-Type`` header.
+    """
+
+    __slots__ = ("status_code", "headers", "body")
+
+    def __init__(
+        self,
+        body: bytes | str = b"",
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        content_type: str | None = None,
+    ):
+        self.status_code = status_code
+        self.headers: dict[str, str] = headers.copy() if headers else {}
+        if isinstance(body, str):
+            self.body = body.encode("utf-8")
+        else:
+            self.body = body
+        if content_type is not None:
+            self.headers["Content-Type"] = content_type
+
+    async def _write(self, writer: asyncio.StreamWriter) -> None:
+        """Serialize and write the full HTTP response."""
+        reason = _STATUS_REASONS.get(self.status_code, "Unknown")
+        self.headers.setdefault("Content-Length", str(len(self.body)))
+        self.headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+        self.headers.setdefault("Date", _http_date())
+        self.headers.setdefault("Connection", "close")
+
+        buf = bytearray()
+        buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
+        for k, v in self.headers.items():
+            buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        buf.extend(b"\r\n")
+        buf.extend(self.body)
+        writer.write(bytes(buf))
+        await writer.drain()
+
+
+class JSONResponse(Response):
+    """Response serialized as JSON.
+
+    Args:
+        data: Python object to serialize.
+        status_code: HTTP status code.
+        headers: Extra response headers.
+    """
+
+    def __init__(
+        self,
+        data: Any,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ):
+        body = _json.dumps(data, ensure_ascii=False).encode("utf-8")
+        super().__init__(
+            body=body,
+            status_code=status_code,
+            headers=headers,
+            content_type="application/json; charset=utf-8",
+        )
+
+
+class StreamingResponse:
+    """HTTP response streamed from an async generator.
+
+    Writes chunks using ``Transfer-Encoding: chunked`` unless
+    ``content_type`` is ``text/event-stream`` (SSE), in which case raw
+    bytes are flushed directly for maximum compatibility with SSE clients.
+
+    Args:
+        generator: Async iterator yielding ``bytes`` or ``str`` chunks.
+        status_code: HTTP status code.
+        headers: Extra response headers.
+        content_type: MIME type (default ``application/octet-stream``).
+    """
+
+    __slots__ = ("_generator", "status_code", "headers", "content_type")
+
+    def __init__(
+        self,
+        generator: AsyncIterator[bytes | str],
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        content_type: str = "application/octet-stream",
+    ):
+        self._generator = generator
+        self.status_code = status_code
+        self.headers: dict[str, str] = headers.copy() if headers else {}
+        self.content_type = content_type
+
+    async def _write(self, writer: asyncio.StreamWriter) -> None:
+        """Write status line, headers, then stream the body."""
+        reason = _STATUS_REASONS.get(self.status_code, "Unknown")
+        is_sse = self.content_type.startswith("text/event-stream")
+
+        self.headers["Content-Type"] = self.content_type
+        if not is_sse:
+            self.headers.setdefault("Transfer-Encoding", "chunked")
+        else:
+            self.headers.setdefault("Cache-Control", "no-cache")
+        self.headers.setdefault("Date", _http_date())
+        self.headers.setdefault("Connection", "close")
+
+        buf = bytearray()
+        buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
+        for k, v in self.headers.items():
+            buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        buf.extend(b"\r\n")
+        writer.write(bytes(buf))
+        await writer.drain()
+
+        try:
+            async for chunk in self._generator:
+                if isinstance(chunk, str):
+                    chunk = chunk.encode("utf-8")
+                if is_sse:
+                    writer.write(chunk)
+                else:
+                    writer.write(f"{len(chunk):x}\r\n".encode("latin-1"))
+                    writer.write(chunk)
+                    writer.write(b"\r\n")
+                await writer.drain()
+            if not is_sse:
+                writer.write(b"0\r\n\r\n")
+                await writer.drain()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            logger.debug("Client disconnected during streaming")
+        finally:
+            aclose = getattr(self._generator, "aclose", None)
+            if aclose is not None:
+                await aclose()
+
+
+class FileResponse(Response):
+    """Response serving a file from disk.
+
+    Args:
+        path: Path to the file.
+        content_type: MIME type (auto-detected from extension if ``None``).
+        status_code: HTTP status code.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        content_type: str | None = None,
+        status_code: int = 200,
+    ):
+        file_path = Path(path)
+        body = file_path.read_bytes()
+        if content_type is None:
+            guessed, _ = mimetypes.guess_type(str(file_path))
+            content_type = guessed or "application/octet-stream"
+        headers = {
+            "Last-Modified": _http_date(os.path.getmtime(file_path)),
+        }
+        super().__init__(
+            body=body,
+            status_code=status_code,
+            headers=headers,
+            content_type=content_type,
+        )
+
+
+# ── Routing ──────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Route:
+    """Internal route entry."""
+
+    methods: list[str]  # uppercase, e.g. ["GET", "POST"], or ["*"]
+    pattern: re.Pattern[str]
+    handler: Callable[..., Any]
+    is_async: bool
+    param_names: list[str]
+    param_converters: list[Callable[[str], Any]]
+
+
+def _compile_route(
+    path: str,
+) -> tuple[re.Pattern[str], list[str], list[Callable[[str], Any]]]:
+    """Compile a path pattern into a regex and parameter metadata.
+
+    Supports ``<name>``, ``<int:name>``, ``<float:name>``, ``<path:name>``.
+
+    Args:
+        path: URL path pattern (e.g. ``/users/<int:id>``).
+
+    Returns:
+        Tuple of (compiled regex, param names, param converters).
+    """
+    param_names: list[str] = []
+    param_converters: list[Callable[[str], Any]] = []
+    regex_parts: list[str] = []
+    last_end = 0
+
+    for m in _PARAM_RE.finditer(path):
+        regex_parts.append(re.escape(path[last_end : m.start()]))
+        type_name = m.group(1) or "str"
+        name = m.group(2)
+        if type_name not in _PARAM_CONVERTERS:
+            raise ValueError(f"Unknown path parameter type: {type_name!r}")
+        regex_fragment, converter = _PARAM_CONVERTERS[type_name]
+        regex_parts.append(regex_fragment)
+        param_names.append(name)
+        param_converters.append(converter)
+        last_end = m.end()
+
+    regex_parts.append(re.escape(path[last_end:]))
+    full_regex = "^" + "".join(regex_parts) + "$"
+    return re.compile(full_regex), param_names, param_converters
+
+
+# ── HTTP Parsing ─────────────────────────────────────────────────────────────
+
+
+async def _read_request(
+    reader: asyncio.StreamReader,
+    timeout: float,
+    max_body_size: int,
+) -> tuple[str, str, str, dict[str, str], bytes]:
+    """Read and parse an HTTP request from a stream.
+
+    Returns:
+        Tuple of (method, path, query_string, headers, body).
+
+    Raises:
+        _BadRequest: If the request is malformed.
+        asyncio.TimeoutError: If reading times out.
+    """
+    # -- Request line --
+    raw_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    if not raw_line:
+        raise _BadRequest("Empty request")
+    request_line = raw_line.decode("latin-1").rstrip("\r\n")
+    parts = request_line.split(" ", 2)
+    if len(parts) != 3:
+        raise _BadRequest(f"Malformed request line: {request_line!r}")
+    method, raw_url, _version = parts
+
+    # -- URL --
+    parsed = urlparse(raw_url)
+    path = unquote(parsed.path)
+    query_string = parsed.query
+
+    # -- Headers --
+    headers: dict[str, str] = {}
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        decoded = line.decode("latin-1").rstrip("\r\n")
+        if not decoded:
+            break
+        if ":" in decoded:
+            k, v = decoded.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+
+    # -- Body --
+    body = b""
+    cl = headers.get("content-length")
+    if cl is not None:
+        length = int(cl)
+        if length > max_body_size:
+            raise HTTPException(413, f"Request body too large ({length} bytes)")
+        if length > 0:
+            body = await asyncio.wait_for(reader.readexactly(length), timeout=timeout)
+    elif headers.get("transfer-encoding", "").lower() == "chunked":
+        body = await _read_chunked_body(reader, timeout, max_body_size)
+
+    return method.upper(), path, query_string, headers, body
+
+
+async def _read_chunked_body(
+    reader: asyncio.StreamReader,
+    timeout: float,
+    max_body_size: int,
+) -> bytes:
+    """Read a chunked transfer-encoded body."""
+    parts: list[bytes] = []
+    total = 0
+    while True:
+        size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        size_str = size_line.decode("latin-1").split(";")[0].strip()
+        if not size_str:
+            break
+        chunk_size = int(size_str, 16)
+        if chunk_size == 0:
+            await asyncio.wait_for(reader.readline(), timeout=timeout)
+            break
+        total += chunk_size
+        if total > max_body_size:
+            raise HTTPException(413, "Request body too large")
+        data = await asyncio.wait_for(reader.readexactly(chunk_size), timeout=timeout)
+        await asyncio.wait_for(reader.readline(), timeout=timeout)
+        parts.append(data)
+    return b"".join(parts)
+
+
+# ── Utilities ────────────────────────────────────────────────────────────────
+
+
+def _http_date(timestamp: float | None = None) -> str:
+    """Format a timestamp as an HTTP-date (RFC 7231)."""
+    return formatdate(timeval=timestamp, localtime=False, usegmt=True)
+
+
+def _coerce_response(result: Any) -> Response | StreamingResponse:
+    """Convert a handler return value into a Response object."""
+    if isinstance(result, (Response, StreamingResponse)):
+        return result
+
+    if result is None:
+        return Response(status_code=204)
+
+    if isinstance(result, dict):
+        return JSONResponse(result)
+
+    if isinstance(result, tuple):
+        if len(result) == 2:
+            body, status = result
+            resp = _coerce_response(body)
+            resp.status_code = status
+            return resp
+        if len(result) == 3:
+            body, status, extra_headers = result
+            resp = _coerce_response(body)
+            resp.status_code = status
+            resp.headers.update(extra_headers)
+            return resp
+        raise ValueError(f"Unsupported tuple length: {len(result)}")
+
+    if isinstance(result, bytes):
+        return Response(body=result, content_type="application/octet-stream")
+
+    if isinstance(result, str):
+        return Response(body=result, content_type="text/plain; charset=utf-8")
+
+    raise TypeError(
+        f"Cannot coerce handler return type {type(result).__name__} to Response"
+    )
+
+
+# ── Static File Resolution ───────────────────────────────────────────────────
+
+
+def _resolve_static_file(
+    request_path: str,
+    url_prefix: str,
+    directory: str,
+) -> FileResponse | None:
+    """Try to resolve a static file request.
+
+    Returns a FileResponse if the file exists and the path is safe,
+    otherwise None.
+    """
+    if not request_path.startswith(url_prefix):
+        return None
+
+    relative = request_path[len(url_prefix) :].lstrip("/")
+    if not relative:
+        return None
+
+    base = Path(directory).resolve()
+    target = (base / relative).resolve()
+
+    # Prevent directory traversal
+    if not str(target).startswith(str(base)):
+        return None
+
+    if not target.is_file():
+        return None
+
+    return FileResponse(target)
+
+
+# ── App ──────────────────────────────────────────────────────────────────────
+
+
+class App:
+    """Async HTTP server application.
+
+    Args:
+        max_body_size: Maximum request body size in bytes.
+        read_timeout: Timeout for reading a single request (seconds).
+
+    Example::
+
+        app = App()
+
+        @app.get("/hello")
+        async def hello(request):
+            return {"message": "Hello, world!"}
+
+        app.run()
+    """
+
+    def __init__(
+        self,
+        *,
+        max_body_size: int = DEFAULT_MAX_BODY_SIZE,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+    ):
+        self._routes: list[_Route] = []
+        self._static_routes: list[tuple[str, str]] = []
+        self._before_request_handlers: list[Callable[..., Any]] = []
+        self._after_request_handlers: list[Callable[..., Any]] = []
+        self._error_handlers: dict[int | type, Callable[..., Any]] = {}
+        self._server: asyncio.Server | None = None
+        self._shutdown_event: asyncio.Event | None = None
+        self.max_body_size = max_body_size
+        self.read_timeout = read_timeout
+        self.port: int | None = None
+        self.host: str | None = None
+
+    # ── Route Registration ───────────────────────────────────────────────
+
+    def route(
+        self, url_pattern: str, methods: list[str] | None = None
+    ) -> Callable[..., Any]:
+        """Register a route handler.
+
+        Args:
+            url_pattern: URL pattern with optional parameters.
+            methods: HTTP methods to handle (e.g. ``["GET", "POST"]``).
+                Defaults to ``["GET"]``.
+
+        Example::
+
+            @app.route("/users/<int:id>", methods=["GET", "POST"])
+            async def user(request, id):
+                return {"id": id}
+        """
+        if methods is None:
+            methods = ["GET"]
+
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            pattern, param_names, converters = _compile_route(url_pattern)
+            is_async = inspect.iscoroutinefunction(handler)
+            self._routes.append(
+                _Route(
+                    methods=[m.upper() for m in methods],
+                    pattern=pattern,
+                    handler=handler,
+                    is_async=is_async,
+                    param_names=param_names,
+                    param_converters=converters,
+                )
+            )
+            return handler
+
+        return decorator
+
+    def get(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["GET"])``."""
+        return self.route(path, methods=["GET"])
+
+    def post(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["POST"])``."""
+        return self.route(path, methods=["POST"])
+
+    def put(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["PUT"])``."""
+        return self.route(path, methods=["PUT"])
+
+    def delete(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["DELETE"])``."""
+        return self.route(path, methods=["DELETE"])
+
+    def patch(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["PATCH"])``."""
+        return self.route(path, methods=["PATCH"])
+
+    def static(self, url_prefix: str, directory: str) -> None:
+        """Register a directory for static file serving.
+
+        Args:
+            url_prefix: URL prefix (e.g. ``"/static"``).
+            directory: Filesystem path to the directory.
+
+        Example::
+
+            app.static("/assets", "./public")
+        """
+        url_prefix = url_prefix.rstrip("/")
+        abs_dir = os.path.abspath(directory)
+        self._static_routes.append((url_prefix, abs_dir))
+
+    # ── Middleware ────────────────────────────────────────────────────────
+
+    def before_request(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register a before-request hook.
+
+        The hook receives ``(request)`` and may return a ``Response`` to
+        short-circuit the route handler.
+        """
+        self._before_request_handlers.append(handler)
+        return handler
+
+    def after_request(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register an after-request hook.
+
+        The hook receives ``(request, response)`` and may return a new
+        or modified ``Response``.
+        """
+        self._after_request_handlers.append(handler)
+        return handler
+
+    def errorhandler(self, code_or_exc: int | type) -> Callable[..., Any]:
+        """Register an error handler.
+
+        Args:
+            code_or_exc: HTTP status code (int) or exception class.
+
+        The handler receives ``(request, exception)`` and must return a
+        ``Response``.
+        """
+
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            self._error_handlers[code_or_exc] = handler
+            return handler
+
+        return decorator
+
+    # ── Request Dispatch ─────────────────────────────────────────────────
+
+    def _match_route(
+        self, request: Request
+    ) -> tuple[_Route | None, re.Match[str] | None, bool]:
+        """Find the first route matching the request path and method.
+
+        Returns:
+            (matched_route, regex_match, path_existed).  *path_existed* is
+            True when a route matched the path but not the HTTP method.
+        """
+        path_existed = False
+        for route in self._routes:
+            m = route.pattern.match(request.path)
+            if m is None:
+                continue
+            path_existed = True
+            if "*" not in route.methods and request.method not in route.methods:
+                continue
+            return route, m, True
+        return None, None, path_existed
+
+    async def _invoke_route(
+        self, route: _Route, match: re.Match[str], request: Request
+    ) -> Response | StreamingResponse:
+        """Extract path params, call the handler, return a response."""
+        for name, converter, value in zip(
+            route.param_names, route.param_converters, match.groups()
+        ):
+            request.path_params[name] = converter(value)
+
+        try:
+            result = await _invoke(route.handler, request, **request.path_params)
+            return _coerce_response(result)
+        except HTTPException as exc:
+            return await self._handle_error(request, exc)
+        except Exception as exc:
+            logger.exception(
+                "Unhandled exception in handler %s",
+                getattr(route.handler, "__name__", repr(route.handler)),
+            )
+            return await self._handle_error(request, exc)
+
+    async def _run_after_hooks(
+        self, request: Request, response: Response | StreamingResponse
+    ) -> Response | StreamingResponse:
+        """Run after-request hooks, allowing them to replace the response."""
+        for hook in self._after_request_handlers:
+            hook_result = await _invoke(hook, request, response)
+            if hook_result is not None:
+                response = _coerce_response(hook_result)
+        return response
+
+    async def _dispatch(self, request: Request) -> Response | StreamingResponse:
+        """Match a request to a route and invoke the handler."""
+        # -- before_request hooks --
+        for hook in self._before_request_handlers:
+            result = await _invoke(hook, request)
+            if result is not None:
+                return _coerce_response(result)
+
+        # -- Static file check --
+        for prefix, directory in self._static_routes:
+            file_resp = _resolve_static_file(request.path, prefix, directory)
+            if file_resp is not None:
+                return file_resp
+
+        # -- Route matching --
+        route, match, path_existed = self._match_route(request)
+
+        if route is not None and match is not None:
+            response = await self._invoke_route(route, match, request)
+            return await self._run_after_hooks(request, response)
+
+        # -- No route matched --
+        if path_existed:
+            allowed = sorted(
+                {
+                    m
+                    for r in self._routes
+                    if r.pattern.match(request.path)
+                    for m in r.methods
+                    if m != "*"
+                }
+            )
+            exc = HTTPException(405, "Method Not Allowed")
+            response = await self._handle_error(request, exc)
+            if isinstance(response, Response):
+                response.headers["Allow"] = ", ".join(allowed)
+            return response
+
+        exc = HTTPException(404, "Not Found")
+        return await self._handle_error(request, exc)
+
+    async def _handle_error(
+        self, request: Request, exc: Exception
+    ) -> Response | StreamingResponse:
+        """Resolve an error into a response, consulting registered handlers."""
+        if isinstance(exc, HTTPException):
+            handler = self._error_handlers.get(exc.status_code)
+            if handler is not None:
+                result = await _invoke(handler, request, exc)
+                return _coerce_response(result)
+
+        for exc_cls, handler in self._error_handlers.items():
+            if isinstance(exc_cls, type) and isinstance(exc, exc_cls):
+                result = await _invoke(handler, request, exc)
+                return _coerce_response(result)
+
+        if isinstance(exc, HTTPException):
+            return JSONResponse(
+                {"error": exc.message},
+                status_code=exc.status_code,
+            )
+        return JSONResponse(
+            {"error": "Internal Server Error"},
+            status_code=500,
+        )
+
+    # ── Connection Handling ───────────────────────────────────────────────
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Handle a single client connection."""
+        peer = writer.get_extra_info("peername")
+        client_addr = (peer[0], peer[1]) if peer else ("unknown", 0)
+
+        try:
+            method, path, qs, headers, body = await _read_request(
+                reader, self.read_timeout, self.max_body_size
+            )
+        except _BadRequest as exc:
+            logger.debug("Bad request from %s: %s", client_addr, exc)
+            response = Response(
+                body=str(exc),
+                status_code=400,
+                content_type="text/plain; charset=utf-8",
+            )
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except HTTPException as exc:
+            response = JSONResponse({"error": exc.message}, status_code=exc.status_code)
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+            writer.close()
+            return
+        except Exception:
+            writer.close()
+            return
+
+        request = Request(
+            method=method,
+            path=path,
+            query_string=qs,
+            headers=headers,
+            body=body,
+            client_addr=client_addr,
+            app=self,
+        )
+
+        logger.debug("%s %s from %s", method, path, client_addr)
+
+        try:
+            response = await self._dispatch(request)
+            await response._write(writer)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            logger.debug("Connection reset by %s during response", client_addr)
+        except Exception:
+            logger.exception("Error writing response to %s", client_addr)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    # ── Server Lifecycle ─────────────────────────────────────────────────
+
+    def run(
+        self,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+    ) -> None:
+        """Start the server (blocking).
+
+        Args:
+            host: Bind address.
+            port: Bind port. Use ``0`` for OS-assigned port.
+        """
+        try:
+            asyncio.run(self._serve(host, port))
+        except KeyboardInterrupt:
+            pass
+
+    async def _serve(self, host: str, port: int) -> None:
+        """Internal async server loop."""
+        self._shutdown_event = asyncio.Event()
+
+        server = await asyncio.start_server(
+            self._handle_connection,
+            host,
+            port,
+        )
+
+        self._server = server
+        addrs = server.sockets[0].getsockname() if server.sockets else (host, port)
+        self.host = addrs[0]
+        self.port = addrs[1]
+        logger.info("Serving on %s:%d", self.host, self.port)
+
+        loop = asyncio.get_running_loop()
+        if sys.platform != "win32":
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, self._shutdown_event.set)
+
+        async with server:
+            await self._shutdown_event.wait()
+            logger.info("Shutting down server")
+
+    def shutdown(self) -> None:
+        """Request a graceful server shutdown.
+
+        Safe to call from a request handler.
+        """
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+
+
+# ── Handler Invocation ───────────────────────────────────────────────────────
+
+
+async def _invoke(handler: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Invoke a handler, wrapping sync functions with ``asyncio.to_thread``."""
+    if inspect.iscoroutinefunction(handler):
+        return await handler(*args, **kwargs)
+    return await asyncio.to_thread(handler, *args, **kwargs)

--- a/src/toolregistry/admin/__init__.py
+++ b/src/toolregistry/admin/__init__.py
@@ -6,12 +6,10 @@ including execution logging, monitoring capabilities, and an HTTP admin panel.
 
 from .auth import TokenAuth
 from .execution_log import ExecutionLog, ExecutionLogEntry, ExecutionStatus
-from .handlers import AdminRequestHandler
 from .server import AdminInfo, AdminServer
 
 __all__ = [
     "AdminInfo",
-    "AdminRequestHandler",
     "AdminServer",
     "ExecutionLog",
     "ExecutionLogEntry",

--- a/src/toolregistry/admin/auth.py
+++ b/src/toolregistry/admin/auth.py
@@ -6,7 +6,6 @@ using constant-time comparison to prevent timing attacks.
 
 import hashlib
 import secrets
-from http.server import BaseHTTPRequestHandler
 
 
 class TokenAuth:
@@ -63,51 +62,3 @@ class TokenAuth:
         expected_hash = hashlib.sha256(self._token.encode()).digest()
         provided_hash = hashlib.sha256(provided_token.encode()).digest()
         return secrets.compare_digest(expected_hash, provided_hash)
-
-    def require_auth(self, handler: BaseHTTPRequestHandler) -> bool:
-        """Check Authorization header and send 401 if invalid.
-
-        Expects the Authorization header in the format:
-        "Bearer <token>"
-
-        Args:
-            handler: The HTTP request handler to check and respond to.
-
-        Returns:
-            True if authentication is valid, False otherwise.
-            If False, a 401 response has already been sent.
-        """
-        auth_header = handler.headers.get("Authorization", "")
-
-        if not auth_header:
-            self._send_unauthorized(handler, "Missing Authorization header")
-            return False
-
-        # Parse "Bearer <token>" format
-        parts = auth_header.split(" ", 1)
-        if len(parts) != 2 or parts[0].lower() != "bearer":
-            self._send_unauthorized(handler, "Invalid Authorization format")
-            return False
-
-        provided_token = parts[1]
-        if not self.verify(provided_token):
-            self._send_unauthorized(handler, "Invalid token")
-            return False
-
-        return True
-
-    def _send_unauthorized(self, handler: BaseHTTPRequestHandler, message: str) -> None:
-        """Send a 401 Unauthorized response.
-
-        Args:
-            handler: The HTTP request handler to send the response to.
-            message: The error message to include in the response body.
-        """
-        handler.send_response(401)
-        handler.send_header("Content-Type", "application/json")
-        handler.send_header("WWW-Authenticate", 'Bearer realm="admin"')
-        handler.end_headers()
-        import json
-
-        response = json.dumps({"error": "Unauthorized", "message": message})
-        handler.wfile.write(response.encode("utf-8"))

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -1,311 +1,259 @@
 """HTTP request handlers for admin panel.
 
-This module provides the HTTP request handler for the admin panel,
-implementing REST API endpoints for tool management and monitoring.
+This module provides route registration for the admin panel using
+the zerodep httpserver, implementing REST API endpoints for tool
+management and monitoring.
 """
 
 import json
 import urllib.parse
 from dataclasses import asdict
 from datetime import datetime
-from http.server import BaseHTTPRequestHandler
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
+
+from .._vendor.httpserver import App, HTTPException, Request, Response
 
 from .static import ADMIN_HTML
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
 
-    from .auth import TokenAuth
+
+# ============== CORS Constants ==============
+
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+}
 
 
-class AdminRequestHandler(BaseHTTPRequestHandler):
-    """HTTP request handler for admin panel.
+# ============== Response Helpers ==============
 
-    This handler implements REST API endpoints for:
-    - Tool status and management (enable/disable)
-    - Namespace management
-    - Execution log queries and statistics
-    - State export/import
 
-    Class Attributes:
-        registry: The ToolRegistry instance to manage.
-        auth: Optional TokenAuth instance for authentication.
-        serve_ui: Whether to serve the admin UI at root path.
+def _json_serializer(obj: Any) -> Any:
+    """Custom JSON serializer for non-standard types.
+
+    Args:
+        obj: Object to serialize.
+
+    Returns:
+        JSON-serializable representation.
+
+    Raises:
+        TypeError: If object is not serializable.
     """
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
-    # Class attributes set by AdminServer
-    registry: ClassVar["ToolRegistry"]
-    auth: ClassVar["TokenAuth | None"]
-    serve_ui: ClassVar[bool]
 
-    # Suppress default logging
-    def log_message(self, format: str, *args: Any) -> None:
-        """Suppress default HTTP logging."""
-        pass
+def _json_response(data: Any, status_code: int = 200) -> Response:
+    """Create a JSON response with custom datetime serialization.
 
-    def do_GET(self) -> None:
-        """Handle GET requests."""
-        # Check authentication if enabled
-        if self.auth and not self.auth.require_auth(self):
-            return
+    Args:
+        data: The data to serialize as JSON.
+        status_code: HTTP status code.
 
-        # Parse URL
-        parsed = urllib.parse.urlparse(self.path)
-        path = parsed.path
-        query = urllib.parse.parse_qs(parsed.query)
+    Returns:
+        Response with JSON content type.
+    """
+    body = json.dumps(data, default=_json_serializer)
+    return Response(
+        body=body,
+        status_code=status_code,
+        content_type="application/json; charset=utf-8",
+    )
 
-        # Route requests
-        if path == "/":
-            self._handle_root()
-        elif path == "/api/tools":
-            self._handle_get_tools()
-        elif path.startswith("/api/tools/") and not path.endswith(
-            ("/enable", "/disable", "/metadata")
-        ):
-            tool_name = path[len("/api/tools/") :]
-            self._handle_get_tool(urllib.parse.unquote(tool_name))
-        elif path == "/api/namespaces":
-            self._handle_get_namespaces()
-        elif path == "/api/logs":
-            self._handle_get_logs(query)
-        elif path == "/api/logs/stats":
-            self._handle_get_log_stats()
-        elif path == "/api/state":
-            self._handle_export_state()
-        elif path == "/api/permissions":
-            self._handle_get_permissions()
-        else:
-            self._send_not_found()
 
-    def do_POST(self) -> None:
-        """Handle POST requests."""
-        # Check authentication if enabled
-        if self.auth and not self.auth.require_auth(self):
-            return
+def _error_response(status: int, error: str, message: str) -> Response:
+    """Create an error JSON response.
 
-        # Parse URL
-        parsed = urllib.parse.urlparse(self.path)
-        path = parsed.path
+    Args:
+        status: HTTP status code.
+        error: Error type/name.
+        message: Detailed error message.
 
-        # Read request body
-        content_length = int(self.headers.get("Content-Length", 0))
-        body = self.rfile.read(content_length) if content_length > 0 else b""
+    Returns:
+        Response with error details.
+    """
+    return _json_response({"error": error, "message": message}, status)
 
-        # Route requests
-        if path.startswith("/api/tools/") and path.endswith("/enable"):
-            tool_name = path[len("/api/tools/") : -len("/enable")]
-            self._handle_enable_tool(urllib.parse.unquote(tool_name))
-        elif path.startswith("/api/tools/") and path.endswith("/disable"):
-            tool_name = path[len("/api/tools/") : -len("/disable")]
-            self._handle_disable_tool(urllib.parse.unquote(tool_name), body)
-        elif path.startswith("/api/namespaces/") and path.endswith("/enable"):
-            namespace = path[len("/api/namespaces/") : -len("/enable")]
-            self._handle_enable_namespace(urllib.parse.unquote(namespace))
-        elif path.startswith("/api/namespaces/") and path.endswith("/disable"):
-            namespace = path[len("/api/namespaces/") : -len("/disable")]
-            self._handle_disable_namespace(urllib.parse.unquote(namespace), body)
-        elif path == "/api/state":
-            self._handle_import_state(body)
-        else:
-            self._send_not_found()
 
-    def do_PATCH(self) -> None:
-        """Handle PATCH requests for metadata updates."""
-        if self.auth and not self.auth.require_auth(self):
-            return
+def _add_cors(response: Response) -> Response:
+    """Add CORS headers to a response.
 
-        parsed = urllib.parse.urlparse(self.path)
-        path = parsed.path
+    Args:
+        response: The response to add headers to.
 
-        content_length = int(self.headers.get("Content-Length", 0))
-        body = self.rfile.read(content_length) if content_length > 0 else b""
+    Returns:
+        The response with CORS headers added.
+    """
+    response.headers.update(_CORS_HEADERS)
+    return response
 
-        if path.startswith("/api/tools/") and path.endswith("/metadata"):
-            tool_name = path[len("/api/tools/") : -len("/metadata")]
-            self._handle_update_tool_metadata(urllib.parse.unquote(tool_name), body)
-        elif path.startswith("/api/namespaces/") and path.endswith("/metadata"):
-            namespace = path[len("/api/namespaces/") : -len("/metadata")]
-            self._handle_update_namespace_metadata(
-                urllib.parse.unquote(namespace), body
-            )
-        else:
-            self._send_not_found()
 
-    def do_DELETE(self) -> None:
-        """Handle DELETE requests."""
-        # Check authentication if enabled
-        if self.auth and not self.auth.require_auth(self):
-            return
+def _evaluate_tool_permission(
+    registry: "ToolRegistry", tool_name: str
+) -> dict[str, Any] | None:
+    """Evaluate permission for a tool against the current policy.
 
-        # Parse URL
-        parsed = urllib.parse.urlparse(self.path)
-        path = parsed.path
+    Args:
+        registry: The ToolRegistry instance.
+        tool_name: Name of the tool to evaluate.
 
-        # Route requests
-        if path == "/api/logs":
-            self._handle_clear_logs()
-        else:
-            self._send_not_found()
-
-    def do_OPTIONS(self) -> None:
-        """Handle CORS preflight requests."""
-        self.send_response(204)
-        self._send_cors_headers()
-        self.end_headers()
-
-    # ============== Response Helpers ==============
-
-    def _send_cors_headers(self) -> None:
-        """Send CORS headers for cross-origin requests."""
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header(
-            "Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS"
-        )
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
-
-    def _send_json_response(
-        self, data: Any, status: int = 200, message: str | None = None
-    ) -> None:
-        """Send a JSON response.
-
-        Args:
-            data: The data to serialize as JSON.
-            status: HTTP status code.
-            message: Optional status message.
-        """
-        self.send_response(status, message)
-        self.send_header("Content-Type", "application/json")
-        self._send_cors_headers()
-        self.end_headers()
-        response = json.dumps(data, default=self._json_serializer)
-        self.wfile.write(response.encode("utf-8"))
-
-    def _send_error_response(self, status: int, error: str, message: str) -> None:
-        """Send an error response.
-
-        Args:
-            status: HTTP status code.
-            error: Error type/name.
-            message: Detailed error message.
-        """
-        self._send_json_response({"error": error, "message": message}, status)
-
-    def _send_not_found(self) -> None:
-        """Send a 404 Not Found response."""
-        self._send_error_response(404, "Not Found", f"Path not found: {self.path}")
-
-    @staticmethod
-    def _json_serializer(obj: Any) -> Any:
-        """Custom JSON serializer for non-standard types.
-
-        Args:
-            obj: Object to serialize.
-
-        Returns:
-            JSON-serializable representation.
-
-        Raises:
-            TypeError: If object is not serializable.
-        """
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-    # ============== Route Handlers ==============
-
-    def _evaluate_tool_permission(self, tool_name: str) -> dict[str, Any] | None:
-        """Evaluate permission for a tool against the current policy.
-
-        Args:
-            tool_name: Name of the tool to evaluate.
-
-        Returns:
-            Dict with result, rule_name, and reason, or None if no policy.
-        """
-        policy = self.registry.get_permission_policy()
-        if policy is None:
-            return None
-
-        tool = self.registry.get_tool(tool_name)
-        if tool is None:
-            return None
-
-        from ..permissions import PermissionResult, PermissionRule
-
-        result = policy.evaluate(tool, {})
-        if isinstance(result, PermissionRule):
-            return {
-                "result": result.result.value,
-                "rule_name": result.name,
-                "reason": result.reason,
-            }
-        elif isinstance(result, PermissionResult):
-            return {
-                "result": result.value,
-                "rule_name": None,
-                "reason": "Fallback policy",
-            }
+    Returns:
+        Dict with result, rule_name, and reason, or None if no policy.
+    """
+    policy = registry.get_permission_policy()
+    if policy is None:
         return None
 
-    def _handle_root(self) -> None:
-        """Handle root path - serve UI or redirect."""
-        if self.serve_ui:
-            # Return a simple admin panel UI
-            html = self._get_admin_ui_html()
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self._send_cors_headers()
-            self.end_headers()
-            self.wfile.write(html.encode("utf-8"))
-        else:
-            self._send_json_response(
-                {
-                    "name": "ToolRegistry Admin API",
-                    "version": "1.0.0",
-                    "endpoints": [
-                        "GET /api/tools",
-                        "GET /api/tools/{name}",
-                        "POST /api/tools/{name}/enable",
-                        "POST /api/tools/{name}/disable",
-                        "PATCH /api/tools/{name}/metadata",
-                        "GET /api/namespaces",
-                        "POST /api/namespaces/{ns}/enable",
-                        "POST /api/namespaces/{ns}/disable",
-                        "PATCH /api/namespaces/{ns}/metadata",
-                        "GET /api/logs",
-                        "GET /api/logs/stats",
-                        "DELETE /api/logs",
-                        "GET /api/state",
-                        "POST /api/state",
-                        "GET /api/permissions",
-                    ],
-                }
-            )
+    tool = registry.get_tool(tool_name)
+    if tool is None:
+        return None
 
-    def _handle_get_tools(self) -> None:
-        """Handle GET /api/tools - get all tools status."""
-        tools_status = self.registry.get_tools_status()
-        # Enrich with permission evaluation
+    from ..permissions import PermissionResult, PermissionRule
+
+    result = policy.evaluate(tool, {})
+    if isinstance(result, PermissionRule):
+        return {
+            "result": result.result.value,
+            "rule_name": result.name,
+            "reason": result.reason,
+        }
+    elif isinstance(result, PermissionResult):
+        return {
+            "result": result.value,
+            "rule_name": None,
+            "reason": "Fallback policy",
+        }
+    return None
+
+
+# ============== Route Setup ==============
+
+
+def setup_routes(app: App) -> None:
+    """Register all middleware and routes on the app.
+
+    Args:
+        app: The httpserver App instance. Must have ``registry``, ``auth``,
+            and ``serve_ui`` attributes attached before calling this.
+    """
+
+    # -- Middleware --
+
+    @app.before_request
+    def cors_preflight(request: Request) -> Response | None:
+        """Handle CORS preflight requests."""
+        if request.method == "OPTIONS":
+            return Response(status_code=204, headers=dict(_CORS_HEADERS))
+        return None
+
+    @app.before_request
+    def auth_check(request: Request) -> Response | None:
+        """Check authentication token if auth is enabled."""
+        auth = request.app.auth
+        if auth is None:
+            return None
+
+        auth_header = request.headers.get("authorization", "")
+
+        if not auth_header:
+            resp = _error_response(401, "Unauthorized", "Missing Authorization header")
+            resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
+            return _add_cors(resp)
+
+        parts = auth_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            resp = _error_response(401, "Unauthorized", "Invalid Authorization format")
+            resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
+            return _add_cors(resp)
+
+        if not auth.verify(parts[1]):
+            resp = _error_response(401, "Unauthorized", "Invalid token")
+            resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
+            return _add_cors(resp)
+
+        return None
+
+    @app.after_request
+    def add_cors_headers(request: Request, response: Response) -> None:
+        """Add CORS headers to all routed responses."""
+        _add_cors(response)
+
+    @app.errorhandler(404)
+    def handle_404(request: Request, exc: HTTPException) -> Response:
+        """Handle 404 errors with CORS headers."""
+        return _add_cors(
+            _error_response(404, "Not Found", f"Path not found: {request.path}")
+        )
+
+    @app.errorhandler(405)
+    def handle_405(request: Request, exc: HTTPException) -> Response:
+        """Handle 405 errors with CORS headers."""
+        return _add_cors(
+            _error_response(405, "Method Not Allowed", "Method Not Allowed")
+        )
+
+    # -- Routes --
+
+    @app.get("/")
+    def handle_root(request: Request) -> Response:
+        """Serve UI or API documentation."""
+        if request.app.serve_ui:
+            return Response(
+                body=ADMIN_HTML,
+                status_code=200,
+                content_type="text/html; charset=utf-8",
+            )
+        return _json_response(
+            {
+                "name": "ToolRegistry Admin API",
+                "version": "1.0.0",
+                "endpoints": [
+                    "GET /api/tools",
+                    "GET /api/tools/{name}",
+                    "POST /api/tools/{name}/enable",
+                    "POST /api/tools/{name}/disable",
+                    "PATCH /api/tools/{name}/metadata",
+                    "GET /api/namespaces",
+                    "POST /api/namespaces/{ns}/enable",
+                    "POST /api/namespaces/{ns}/disable",
+                    "PATCH /api/namespaces/{ns}/metadata",
+                    "GET /api/logs",
+                    "GET /api/logs/stats",
+                    "DELETE /api/logs",
+                    "GET /api/state",
+                    "POST /api/state",
+                    "GET /api/permissions",
+                ],
+            }
+        )
+
+    @app.get("/api/tools")
+    def get_tools(request: Request) -> Response:
+        """Get all tools status."""
+        registry = request.app.registry
+        tools_status = registry.get_tools_status()
         for tool_status in tools_status:
-            tool_status["permission"] = self._evaluate_tool_permission(
-                tool_status["name"]
+            tool_status["permission"] = _evaluate_tool_permission(
+                registry, tool_status["name"]
             )
-        self._send_json_response({"tools": tools_status})
+        return _json_response({"tools": tools_status})
 
-    def _handle_get_tool(self, tool_name: str) -> None:
-        """Handle GET /api/tools/{name} - get single tool details.
-
-        Args:
-            tool_name: Name of the tool to get.
-        """
-        tool = self.registry.get_tool(tool_name)
+    @app.get("/api/tools/<name>")
+    def get_tool(request: Request, name: str) -> Response:
+        """Get single tool details."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
+        tool = registry.get_tool(name)
         if tool is None:
-            self._send_error_response(404, "Not Found", f"Tool not found: {tool_name}")
-            return
+            return _error_response(404, "Not Found", f"Tool not found: {name}")
 
-        enabled = self.registry.is_enabled(tool_name)
-        reason = self.registry.get_disable_reason(tool_name) if not enabled else None
+        enabled = registry.is_enabled(name)
+        reason = registry.get_disable_reason(name) if not enabled else None
 
         tool_info = {
             "name": tool.name,
@@ -315,7 +263,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             "enabled": enabled,
             "reason": reason,
             "schema": tool.get_schema(),
-            "permission": self._evaluate_tool_permission(tool_name),
+            "permission": _evaluate_tool_permission(registry, name),
             "metadata": {
                 "is_async": tool.metadata.is_async,
                 "is_concurrency_safe": tool.metadata.is_concurrency_safe,
@@ -330,147 +278,85 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                 "extra": tool.metadata.extra,
             },
         }
-        self._send_json_response(tool_info)
+        return _json_response(tool_info)
 
-    def _handle_enable_tool(self, tool_name: str) -> None:
-        """Handle POST /api/tools/{name}/enable - enable a tool.
+    @app.post("/api/tools/<name>/enable")
+    def enable_tool(request: Request, name: str) -> Response:
+        """Enable a tool."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
+        if name not in registry:
+            return _error_response(404, "Not Found", f"Tool not found: {name}")
 
-        Args:
-            tool_name: Name of the tool to enable.
-        """
-        if tool_name not in self.registry:
-            self._send_error_response(404, "Not Found", f"Tool not found: {tool_name}")
-            return
+        registry.enable(name)
+        return _json_response({"success": True, "message": f"Tool '{name}' enabled"})
 
-        self.registry.enable(tool_name)
-        self._send_json_response(
-            {"success": True, "message": f"Tool '{tool_name}' enabled"}
-        )
-
-    def _handle_disable_tool(self, tool_name: str, body: bytes) -> None:
-        """Handle POST /api/tools/{name}/disable - disable a tool.
-
-        Args:
-            tool_name: Name of the tool to disable.
-            body: Request body containing optional reason.
-        """
-        if tool_name not in self.registry:
-            self._send_error_response(404, "Not Found", f"Tool not found: {tool_name}")
-            return
+    @app.post("/api/tools/<name>/disable")
+    def disable_tool(request: Request, name: str) -> Response:
+        """Disable a tool."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
+        if name not in registry:
+            return _error_response(404, "Not Found", f"Tool not found: {name}")
 
         reason = ""
-        if body:
+        if request.body:
             try:
-                data = json.loads(body)
+                data = request.json()
                 reason = data.get("reason", "")
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, ValueError):
                 pass
 
-        self.registry.disable(tool_name, reason)
-        self._send_json_response(
+        registry.disable(name, reason)
+        return _json_response(
             {
                 "success": True,
-                "message": f"Tool '{tool_name}' disabled",
+                "message": f"Tool '{name}' disabled",
                 "reason": reason,
             }
         )
 
-    def _handle_update_tool_metadata(self, tool_name: str, body: bytes) -> None:
-        """Handle PATCH /api/tools/{name}/metadata - update tool metadata.
+    @app.patch("/api/tools/<name>/metadata")
+    def update_tool_metadata(request: Request, name: str) -> Response:
+        """Update tool metadata."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
 
-        Args:
-            tool_name: Name of the tool to update.
-            body: JSON body with metadata fields to update.
-        """
-        if not body:
-            self._send_error_response(400, "Bad Request", "Request body is required")
-            return
+        if not request.body:
+            return _error_response(400, "Bad Request", "Request body is required")
 
         try:
-            data = json.loads(body)
-        except json.JSONDecodeError as e:
-            self._send_error_response(400, "Bad Request", f"Invalid JSON: {e}")
-            return
+            data = request.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            return _error_response(400, "Bad Request", f"Invalid JSON: {e}")
 
         if not isinstance(data, dict) or not data:
-            self._send_error_response(
+            return _error_response(
                 400, "Bad Request", "Body must be a non-empty JSON object"
             )
-            return
 
         try:
-            self.registry.update_tool_metadata(tool_name, **data)
+            registry.update_tool_metadata(name, **data)
         except KeyError:
-            self._send_error_response(404, "Not Found", f"Tool not found: {tool_name}")
-            return
+            return _error_response(404, "Not Found", f"Tool not found: {name}")
         except ValueError as e:
-            self._send_error_response(400, "Bad Request", str(e))
-            return
+            return _error_response(400, "Bad Request", str(e))
 
-        self._send_json_response(
+        return _json_response(
             {
                 "success": True,
-                "message": f"Metadata updated for tool '{tool_name}'",
+                "message": f"Metadata updated for tool '{name}'",
                 "updated": data,
             }
         )
 
-    def _handle_update_namespace_metadata(self, namespace: str, body: bytes) -> None:
-        """Handle PATCH /api/namespaces/{ns}/metadata - update namespace metadata.
-
-        Args:
-            namespace: Namespace to update.
-            body: JSON body with metadata fields to update.
-        """
-        if not body:
-            self._send_error_response(400, "Bad Request", "Request body is required")
-            return
-
-        try:
-            data = json.loads(body)
-        except json.JSONDecodeError as e:
-            self._send_error_response(400, "Bad Request", f"Invalid JSON: {e}")
-            return
-
-        if not isinstance(data, dict) or not data:
-            self._send_error_response(
-                400, "Bad Request", "Body must be a non-empty JSON object"
-            )
-            return
-
-        try:
-            self.registry.update_namespace_metadata(namespace, **data)
-        except KeyError:
-            self._send_error_response(
-                404, "Not Found", f"Namespace not found: {namespace}"
-            )
-            return
-        except ValueError as e:
-            self._send_error_response(400, "Bad Request", str(e))
-            return
-
-        # Count affected tools
-        tools_updated = sum(
-            1
-            for name in self.registry.list_tools(include_disabled=True)
-            if (t := self.registry.get_tool(name)) and t.namespace == namespace
-        )
-
-        self._send_json_response(
-            {
-                "success": True,
-                "message": f"Metadata updated for namespace '{namespace}'",
-                "tools_updated": tools_updated,
-                "updated": data,
-            }
-        )
-
-    def _handle_get_namespaces(self) -> None:
-        """Handle GET /api/namespaces - get all namespaces."""
-        # Get unique namespaces from tools (including "default" for non-namespaced)
+    @app.get("/api/namespaces")
+    def get_namespaces(request: Request) -> Response:
+        """Get all namespaces."""
+        registry = request.app.registry
         namespaces: dict[str, dict[str, Any]] = {}
-        for tool_name in self.registry.list_tools(include_disabled=True):
-            tool = self.registry.get_tool(tool_name)
+        for tool_name in registry.list_tools(include_disabled=True):
+            tool = registry.get_tool(tool_name)
             if tool:
                 ns = tool.namespace or "default"
                 if ns not in namespaces:
@@ -484,7 +370,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                         "tags": set(),
                     }
                 namespaces[ns]["tool_count"] += 1
-                if self.registry.is_enabled(tool_name):
+                if registry.is_enabled(tool_name):
                     namespaces[ns]["enabled_count"] += 1
                 else:
                     namespaces[ns]["disabled_count"] += 1
@@ -494,95 +380,123 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                     namespaces[ns]["remote_count"] += 1
                 namespaces[ns]["tags"].update(tool.metadata.all_tags)
 
-        # Convert sets to sorted lists for JSON serialization
         for ns_data in namespaces.values():
             ns_data["tags"] = sorted(ns_data["tags"])
 
-        # Sort: "default" first, then alphabetical
         result = sorted(
             namespaces.values(),
             key=lambda x: "" if x["name"] == "default" else x["name"],
         )
-        self._send_json_response({"namespaces": result})
+        return _json_response({"namespaces": result})
 
-    def _handle_enable_namespace(self, namespace: str) -> None:
-        """Handle POST /api/namespaces/{ns}/enable - enable all tools in namespace.
+    @app.post("/api/namespaces/<name>/enable")
+    def enable_namespace(request: Request, name: str) -> Response:
+        """Enable all tools in namespace."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
+        registry.enable(name)
 
-        Args:
-            namespace: Namespace to enable.
-        """
-        # Enable the namespace itself (removes namespace-level disable)
-        self.registry.enable(namespace)
-
-        # Also enable individual tools in the namespace
         enabled_count = 0
-        for tool_name in self.registry.list_tools(include_disabled=True):
-            tool = self.registry.get_tool(tool_name)
-            if tool and tool.namespace == namespace:
-                self.registry.enable(tool_name)
+        for tool_name in registry.list_tools(include_disabled=True):
+            tool = registry.get_tool(tool_name)
+            if tool and tool.namespace == name:
+                registry.enable(tool_name)
                 enabled_count += 1
 
-        self._send_json_response(
+        return _json_response(
             {
                 "success": True,
-                "message": f"Namespace '{namespace}' enabled",
+                "message": f"Namespace '{name}' enabled",
                 "tools_enabled": enabled_count,
             }
         )
 
-    def _handle_disable_namespace(self, namespace: str, body: bytes) -> None:
-        """Handle POST /api/namespaces/{ns}/disable - disable all tools in namespace.
+    @app.post("/api/namespaces/<name>/disable")
+    def disable_namespace(request: Request, name: str) -> Response:
+        """Disable all tools in namespace."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
 
-        Args:
-            namespace: Namespace to disable.
-            body: Request body containing optional reason.
-        """
         reason = ""
-        if body:
+        if request.body:
             try:
-                data = json.loads(body)
+                data = request.json()
                 reason = data.get("reason", "")
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, ValueError):
                 pass
 
-        # Disable at namespace level (affects all tools in namespace)
-        self.registry.disable(namespace, reason)
+        registry.disable(name, reason)
 
-        # Count affected tools
         affected_count = 0
-        for tool_name in self.registry.list_tools(include_disabled=True):
-            tool = self.registry.get_tool(tool_name)
-            if tool and tool.namespace == namespace:
+        for tool_name in registry.list_tools(include_disabled=True):
+            tool = registry.get_tool(tool_name)
+            if tool and tool.namespace == name:
                 affected_count += 1
 
-        self._send_json_response(
+        return _json_response(
             {
                 "success": True,
-                "message": f"Namespace '{namespace}' disabled",
+                "message": f"Namespace '{name}' disabled",
                 "tools_affected": affected_count,
                 "reason": reason,
             }
         )
 
-    def _handle_get_logs(self, query: dict[str, list[str]]) -> None:
-        """Handle GET /api/logs - get execution logs.
+    @app.patch("/api/namespaces/<name>/metadata")
+    def update_namespace_metadata(request: Request, name: str) -> Response:
+        """Update namespace metadata."""
+        registry = request.app.registry
+        name = urllib.parse.unquote(name)
 
-        Args:
-            query: Query parameters for filtering.
-        """
-        log = self.registry.get_execution_log()
+        if not request.body:
+            return _error_response(400, "Bad Request", "Request body is required")
+
+        try:
+            data = request.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            return _error_response(400, "Bad Request", f"Invalid JSON: {e}")
+
+        if not isinstance(data, dict) or not data:
+            return _error_response(
+                400, "Bad Request", "Body must be a non-empty JSON object"
+            )
+
+        try:
+            registry.update_namespace_metadata(name, **data)
+        except KeyError:
+            return _error_response(404, "Not Found", f"Namespace not found: {name}")
+        except ValueError as e:
+            return _error_response(400, "Bad Request", str(e))
+
+        tools_updated = sum(
+            1
+            for tn in registry.list_tools(include_disabled=True)
+            if (t := registry.get_tool(tn)) and t.namespace == name
+        )
+
+        return _json_response(
+            {
+                "success": True,
+                "message": f"Metadata updated for namespace '{name}'",
+                "tools_updated": tools_updated,
+                "updated": data,
+            }
+        )
+
+    @app.get("/api/logs")
+    def get_logs(request: Request) -> Response:
+        """Get execution logs."""
+        registry = request.app.registry
+        log = registry.get_execution_log()
         if log is None:
-            self._send_error_response(
+            return _error_response(
                 400, "Logging Disabled", "Execution logging is not enabled"
             )
-            return
 
-        # Parse query parameters
-        limit = int(query.get("limit", ["100"])[0])
-        tool_name = query.get("tool_name", [None])[0]
-        status_str = query.get("status", [None])[0]
+        limit = int(request.query_params.get("limit", ["100"])[0])
+        tool_name = request.query_params.get("tool_name", [None])[0]
+        status_str = request.query_params.get("status", [None])[0]
 
-        # Import ExecutionStatus for filtering
         from .execution_log import ExecutionStatus
 
         status = None
@@ -593,90 +507,85 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                 pass
 
         entries = log.get_entries(limit=limit, tool_name=tool_name, status=status)
-
-        # Convert entries to dicts
         entries_data = [asdict(entry) for entry in entries]
 
-        self._send_json_response({"entries": entries_data, "count": len(entries_data)})
+        return _json_response({"entries": entries_data, "count": len(entries_data)})
 
-    def _handle_get_log_stats(self) -> None:
-        """Handle GET /api/logs/stats - get execution statistics."""
-        log = self.registry.get_execution_log()
+    @app.get("/api/logs/stats")
+    def get_log_stats(request: Request) -> Response:
+        """Get execution statistics."""
+        registry = request.app.registry
+        log = registry.get_execution_log()
         if log is None:
-            self._send_error_response(
+            return _error_response(
                 400, "Logging Disabled", "Execution logging is not enabled"
             )
-            return
 
         stats = log.get_stats()
-        self._send_json_response(stats)
+        return _json_response(stats)
 
-    def _handle_clear_logs(self) -> None:
-        """Handle DELETE /api/logs - clear execution logs."""
-        log = self.registry.get_execution_log()
+    @app.delete("/api/logs")
+    def clear_logs(request: Request) -> Response:
+        """Clear execution logs."""
+        registry = request.app.registry
+        log = registry.get_execution_log()
         if log is None:
-            self._send_error_response(
+            return _error_response(
                 400, "Logging Disabled", "Execution logging is not enabled"
             )
-            return
 
         cleared = log.clear()
-        self._send_json_response(
+        return _json_response(
             {"success": True, "message": f"Cleared {cleared} log entries"}
         )
 
-    def _handle_export_state(self) -> None:
-        """Handle GET /api/state - export current state."""
-        # Export disabled tools/namespaces
+    @app.get("/api/state")
+    def export_state(request: Request) -> Response:
+        """Export current state."""
+        registry = request.app.registry
         state = {
-            "disabled": dict(self.registry._disabled),
-            "tools": self.registry.list_tools(include_disabled=True),
+            "disabled": dict(registry._disabled),
+            "tools": registry.list_tools(include_disabled=True),
         }
-        self._send_json_response(state)
+        return _json_response(state)
 
-    def _handle_import_state(self, body: bytes) -> None:
-        """Handle POST /api/state - import/restore state.
-
-        Args:
-            body: Request body containing state to restore.
-        """
-        if not body:
-            self._send_error_response(400, "Bad Request", "Request body is required")
-            return
+    @app.post("/api/state")
+    def import_state(request: Request) -> Response:
+        """Import/restore state."""
+        if not request.body:
+            return _error_response(400, "Bad Request", "Request body is required")
 
         try:
-            state = json.loads(body)
-        except json.JSONDecodeError as e:
-            self._send_error_response(400, "Bad Request", f"Invalid JSON: {e}")
-            return
+            state = request.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            return _error_response(400, "Bad Request", f"Invalid JSON: {e}")
 
-        # Restore disabled state
+        registry = request.app.registry
         if "disabled" in state:
-            # Clear current disabled state
-            self.registry._disabled.clear()
-            # Restore from state
-            for name, reason in state["disabled"].items():
-                self.registry.disable(name, reason)
+            registry._disabled.clear()
+            for n, reason in state["disabled"].items():
+                registry.disable(n, reason)
 
-        self._send_json_response(
+        return _json_response(
             {"success": True, "message": "State restored successfully"}
         )
 
-    def _handle_get_permissions(self) -> None:
-        """Handle GET /api/permissions - get permission policy info."""
-        policy = self.registry.get_permission_policy()
-        handler = self.registry.get_permission_handler()
+    @app.get("/api/permissions")
+    def get_permissions(request: Request) -> Response:
+        """Get permission policy info."""
+        registry = request.app.registry
+        policy = registry.get_permission_policy()
+        handler = registry.get_permission_handler()
 
         if policy is None:
-            self._send_json_response(
+            return _json_response(
                 {
                     "has_policy": False,
-                    "fallback": self.registry.permission_fallback.value,
+                    "fallback": registry.permission_fallback.value,
                     "has_handler": handler is not None,
                     "rules": [],
                 }
             )
-            return
 
         rules = [
             {
@@ -687,7 +596,7 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             for rule in policy.rules
         ]
 
-        self._send_json_response(
+        return _json_response(
             {
                 "has_policy": True,
                 "fallback": policy.fallback.value,
@@ -695,11 +604,3 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
                 "rules": rules,
             }
         )
-
-    def _get_admin_ui_html(self) -> str:
-        """Get the admin panel HTML UI.
-
-        Returns:
-            HTML string for the admin panel.
-        """
-        return ADMIN_HTML

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -9,14 +9,16 @@ import json
 import urllib.parse
 from dataclasses import asdict
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
-from .._vendor.httpserver import App, HTTPException, Request, Response
+from .._vendor.httpserver import HTTPException, Request, Response
 
 from .static import ADMIN_HTML
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
+
+    from .server import AdminApp
 
 
 # ============== CORS Constants ==============
@@ -26,6 +28,16 @@ _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
 }
+
+
+# ============== Request Helpers ==============
+
+
+def _app(request: Request) -> "AdminApp":
+    """Get the typed AdminApp from a request."""
+    from .server import AdminApp
+
+    return cast(AdminApp, request.app)
 
 
 # ============== Response Helpers ==============
@@ -134,12 +146,12 @@ def _evaluate_tool_permission(
 # ============== Route Setup ==============
 
 
-def setup_routes(app: App) -> None:
+def setup_routes(app: "AdminApp") -> None:
     """Register all middleware and routes on the app.
 
     Args:
-        app: The httpserver App instance. Must have ``registry``, ``auth``,
-            and ``serve_ui`` attributes attached before calling this.
+        app: The AdminApp instance with ``registry``, ``auth``,
+            and ``serve_ui`` attributes.
     """
 
     # -- Middleware --
@@ -154,7 +166,7 @@ def setup_routes(app: App) -> None:
     @app.before_request
     def auth_check(request: Request) -> Response | None:
         """Check authentication token if auth is enabled."""
-        auth = request.app.auth
+        auth = _app(request).auth
         if auth is None:
             return None
 
@@ -202,7 +214,7 @@ def setup_routes(app: App) -> None:
     @app.get("/")
     def handle_root(request: Request) -> Response:
         """Serve UI or API documentation."""
-        if request.app.serve_ui:
+        if _app(request).serve_ui:
             return Response(
                 body=ADMIN_HTML,
                 status_code=200,
@@ -235,7 +247,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/tools")
     def get_tools(request: Request) -> Response:
         """Get all tools status."""
-        registry = request.app.registry
+        registry = _app(request).registry
         tools_status = registry.get_tools_status()
         for tool_status in tools_status:
             tool_status["permission"] = _evaluate_tool_permission(
@@ -246,7 +258,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/tools/<name>")
     def get_tool(request: Request, name: str) -> Response:
         """Get single tool details."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
         tool = registry.get_tool(name)
         if tool is None:
@@ -283,7 +295,7 @@ def setup_routes(app: App) -> None:
     @app.post("/api/tools/<name>/enable")
     def enable_tool(request: Request, name: str) -> Response:
         """Enable a tool."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
         if name not in registry:
             return _error_response(404, "Not Found", f"Tool not found: {name}")
@@ -294,7 +306,7 @@ def setup_routes(app: App) -> None:
     @app.post("/api/tools/<name>/disable")
     def disable_tool(request: Request, name: str) -> Response:
         """Disable a tool."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
         if name not in registry:
             return _error_response(404, "Not Found", f"Tool not found: {name}")
@@ -319,7 +331,7 @@ def setup_routes(app: App) -> None:
     @app.patch("/api/tools/<name>/metadata")
     def update_tool_metadata(request: Request, name: str) -> Response:
         """Update tool metadata."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
 
         if not request.body:
@@ -353,7 +365,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/namespaces")
     def get_namespaces(request: Request) -> Response:
         """Get all namespaces."""
-        registry = request.app.registry
+        registry = _app(request).registry
         namespaces: dict[str, dict[str, Any]] = {}
         for tool_name in registry.list_tools(include_disabled=True):
             tool = registry.get_tool(tool_name)
@@ -392,7 +404,7 @@ def setup_routes(app: App) -> None:
     @app.post("/api/namespaces/<name>/enable")
     def enable_namespace(request: Request, name: str) -> Response:
         """Enable all tools in namespace."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
         registry.enable(name)
 
@@ -414,7 +426,7 @@ def setup_routes(app: App) -> None:
     @app.post("/api/namespaces/<name>/disable")
     def disable_namespace(request: Request, name: str) -> Response:
         """Disable all tools in namespace."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
 
         reason = ""
@@ -445,7 +457,7 @@ def setup_routes(app: App) -> None:
     @app.patch("/api/namespaces/<name>/metadata")
     def update_namespace_metadata(request: Request, name: str) -> Response:
         """Update namespace metadata."""
-        registry = request.app.registry
+        registry = _app(request).registry
         name = urllib.parse.unquote(name)
 
         if not request.body:
@@ -486,7 +498,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/logs")
     def get_logs(request: Request) -> Response:
         """Get execution logs."""
-        registry = request.app.registry
+        registry = _app(request).registry
         log = registry.get_execution_log()
         if log is None:
             return _error_response(
@@ -514,7 +526,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/logs/stats")
     def get_log_stats(request: Request) -> Response:
         """Get execution statistics."""
-        registry = request.app.registry
+        registry = _app(request).registry
         log = registry.get_execution_log()
         if log is None:
             return _error_response(
@@ -527,7 +539,7 @@ def setup_routes(app: App) -> None:
     @app.delete("/api/logs")
     def clear_logs(request: Request) -> Response:
         """Clear execution logs."""
-        registry = request.app.registry
+        registry = _app(request).registry
         log = registry.get_execution_log()
         if log is None:
             return _error_response(
@@ -542,7 +554,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/state")
     def export_state(request: Request) -> Response:
         """Export current state."""
-        registry = request.app.registry
+        registry = _app(request).registry
         state = {
             "disabled": dict(registry._disabled),
             "tools": registry.list_tools(include_disabled=True),
@@ -560,7 +572,7 @@ def setup_routes(app: App) -> None:
         except (json.JSONDecodeError, ValueError) as e:
             return _error_response(400, "Bad Request", f"Invalid JSON: {e}")
 
-        registry = request.app.registry
+        registry = _app(request).registry
         if "disabled" in state:
             registry._disabled.clear()
             for n, reason in state["disabled"].items():
@@ -573,7 +585,7 @@ def setup_routes(app: App) -> None:
     @app.get("/api/permissions")
     def get_permissions(request: Request) -> Response:
         """Get permission policy info."""
-        registry = request.app.registry
+        registry = _app(request).registry
         policy = registry.get_permission_policy()
         handler = registry.get_permission_handler()
 

--- a/src/toolregistry/admin/server.py
+++ b/src/toolregistry/admin/server.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from .._vendor.httpserver import App
 from .auth import TokenAuth
-from .handlers import setup_routes
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
@@ -36,6 +35,20 @@ class AdminInfo:
     port: int
     url: str
     token: str | None
+
+
+class AdminApp(App):
+    """App subclass with typed admin-specific attributes.
+
+    Attributes:
+        registry: The ToolRegistry instance to manage.
+        auth: Optional TokenAuth instance for authentication.
+        serve_ui: Whether to serve the admin UI at root path.
+    """
+
+    registry: "ToolRegistry"
+    auth: TokenAuth | None
+    serve_ui: bool
 
 
 class AdminServer:
@@ -100,7 +113,7 @@ class AdminServer:
         else:
             self._auth = None
 
-        self._app: App | None = None
+        self._app: AdminApp | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._started = threading.Event()
@@ -149,12 +162,14 @@ class AdminServer:
         self._port = actual_port
 
         # Create app and attach context
-        self._app = App()
-        self._app.registry = self._registry  # type: ignore[attr-defined]
-        self._app.auth = self._auth  # type: ignore[attr-defined]
-        self._app.serve_ui = self._serve_ui  # type: ignore[attr-defined]
+        self._app = AdminApp()
+        self._app.registry = self._registry
+        self._app.auth = self._auth
+        self._app.serve_ui = self._serve_ui
 
         # Register routes and middleware
+        from .handlers import setup_routes
+
         setup_routes(self._app)
 
         # Start server in background thread
@@ -203,6 +218,7 @@ class AdminServer:
         Replicates App._serve() logic but omits signal handler
         registration, which would fail in a non-main thread.
         """
+        assert self._app is not None
         app = self._app
         app._shutdown_event = asyncio.Event()
 

--- a/src/toolregistry/admin/server.py
+++ b/src/toolregistry/admin/server.py
@@ -1,18 +1,19 @@
 """HTTP server for admin panel.
 
 This module provides the AdminServer class for running the admin panel
-as a background HTTP server.
+as an async HTTP server in a background thread.
 """
 
+import asyncio
 import logging
 import socket
 import threading
 from dataclasses import dataclass
-from http.server import HTTPServer
 from typing import TYPE_CHECKING
 
+from .._vendor.httpserver import App
 from .auth import TokenAuth
-from .handlers import AdminRequestHandler
+from .handlers import setup_routes
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
@@ -40,8 +41,9 @@ class AdminInfo:
 class AdminServer:
     """Admin panel HTTP server.
 
-    This class manages an HTTP server that provides a REST API and optional
-    web UI for managing the ToolRegistry.
+    This class manages an async HTTP server that provides a REST API and
+    optional web UI for managing the ToolRegistry. The server runs in a
+    background thread with its own asyncio event loop.
 
     Attributes:
         registry: The ToolRegistry instance to manage.
@@ -98,7 +100,8 @@ class AdminServer:
         else:
             self._auth = None
 
-        self._server: HTTPServer | None = None
+        self._app: App | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._started = threading.Event()
 
@@ -138,26 +141,23 @@ class AdminServer:
         Raises:
             RuntimeError: If the server is already running.
         """
-        if self._server is not None:
+        if self._app is not None:
             raise RuntimeError("Server is already running")
 
         # Find available port
         actual_port = self.find_available_port(self._host, self._port)
         self._port = actual_port
 
-        # Create handler class with registry and auth
-        handler_class = type(
-            "BoundAdminRequestHandler",
-            (AdminRequestHandler,),
-            {
-                "registry": self._registry,
-                "auth": self._auth,
-                "serve_ui": self._serve_ui,
-            },
-        )
+        # Create app and attach context
+        self._app = App()
+        self._app.registry = self._registry  # type: ignore[attr-defined]
+        self._app.auth = self._auth  # type: ignore[attr-defined]
+        self._app.serve_ui = self._serve_ui  # type: ignore[attr-defined]
 
-        # Create and start server
-        self._server = HTTPServer((self._host, self._port), handler_class)
+        # Register routes and middleware
+        setup_routes(self._app)
+
+        # Start server in background thread
         self._thread = threading.Thread(target=self._run_server, daemon=True)
         self._thread.start()
 
@@ -184,26 +184,67 @@ class AdminServer:
         return info
 
     def _run_server(self) -> None:
-        """Run the server (called in background thread)."""
+        """Run the async server in a background thread.
+
+        Creates a new asyncio event loop and runs the server coroutine.
+        The loop is cleaned up when the server shuts down.
+        """
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._async_serve())
+        finally:
+            self._loop.close()
+            self._loop = None
+
+    async def _async_serve(self) -> None:
+        """Async server coroutine.
+
+        Replicates App._serve() logic but omits signal handler
+        registration, which would fail in a non-main thread.
+        """
+        app = self._app
+        app._shutdown_event = asyncio.Event()
+
+        server = await asyncio.start_server(
+            app._handle_connection,
+            self._host,
+            self._port,
+        )
+
+        app._server = server
+        addrs = (
+            server.sockets[0].getsockname()
+            if server.sockets
+            else (self._host, self._port)
+        )
+        app.host = addrs[0]
+        app.port = addrs[1]
+
+        # Signal that the server is ready
         self._started.set()
-        if self._server:
-            self._server.serve_forever()
+
+        async with server:
+            await app._shutdown_event.wait()
 
     def stop(self) -> None:
         """Stop the server.
 
         This method is safe to call even if the server is not running.
+        Uses ``loop.call_soon_threadsafe`` to safely trigger the asyncio
+        shutdown event from the main thread.
         """
-        if self._server is not None:
-            self._server.shutdown()
-            self._server.server_close()
-            self._server = None
-            self._started.clear()
-            logger.info("Admin server stopped")
+        if self._app is not None and self._loop is not None:
+            if self._app._shutdown_event is not None:
+                self._loop.call_soon_threadsafe(self._app._shutdown_event.set)
 
         if self._thread is not None:
             self._thread.join(timeout=5.0)
             self._thread = None
+
+        self._app = None
+        self._started.clear()
+        logger.info("Admin server stopped")
 
     def is_running(self) -> bool:
         """Check if server is running.
@@ -211,7 +252,7 @@ class AdminServer:
         Returns:
             True if the server is running, False otherwise.
         """
-        return self._server is not None and self._started.is_set()
+        return self._app is not None and self._started.is_set()
 
     def get_info(self) -> AdminInfo | None:
         """Get server info if running.


### PR DESCRIPTION
## Summary

- Replace stdlib `http.server` with zerodep's async `httpserver` module (vendored via `zerodep add httpserver`)
- Decorator-based routing (`@app.get`, `@app.post`, etc.) replaces manual string-matching in `do_GET`/`do_POST`/`do_PATCH`/`do_DELETE`
- `before_request`/`after_request` middleware for unified auth and CORS handling
- `asyncio.new_event_loop()` in background thread replaces `HTTPServer.serve_forever()` thread
- `AdminRequestHandler` class removed (internal implementation detail, replaced by `setup_routes(app)`)
- `TokenAuth` simplified to pure token management — HTTP enforcement moved to middleware

## Test plan

- [x] All 51 existing tests pass (`pytest tests/test_admin_server.py`)
- [ ] CI checks pass