### PR TITLE
refactor: replace httpx with zerodep httpclient in core

### DIFF
--- a/examples/openapi_related/cicada_openapi_calculator_example.py
+++ b/examples/openapi_related/cicada_openapi_calculator_example.py
@@ -6,7 +6,7 @@ from cicada.core.utils import cprint
 from dotenv import load_dotenv
 
 from toolregistry import ToolRegistry
-from toolregistry.integrations.openapi import HttpxClientConfig, load_openapi_spec
+from toolregistry.integrations.openapi import HttpClientConfig, load_openapi_spec
 
 load_dotenv()
 
@@ -26,7 +26,7 @@ llm = MultiModalModel(
 )
 
 base_url = OPENAPI_SERVER_URL
-client_config = HttpxClientConfig(
+client_config = HttpClientConfig(
     base_url=base_url,
     headers={"Authorization": f"Bearer {OPENAPI_BEARER_TOKENS}"}
     if OPENAPI_BEARER_TOKENS

--- a/examples/openapi_related/openai_openapi_calculator_example.py
+++ b/examples/openapi_related/openai_openapi_calculator_example.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 from toolregistry import ToolRegistry
-from toolregistry.integrations.openapi import HttpxClientConfig, load_openapi_spec
+from toolregistry.integrations.openapi import HttpClientConfig, load_openapi_spec
 
 # Load environment variables from .env file
 load_dotenv()
@@ -70,7 +70,7 @@ messages = [
 ]
 if __name__ == "__main__":
     base_url = OPENAPI_SERVER_URL
-    client_config = HttpxClientConfig(
+    client_config = HttpClientConfig(
         base_url=base_url,
         headers={"Authorization": f"Bearer {OPENAPI_BEARER_TOKENS}"}
         if OPENAPI_BEARER_TOKENS

--- a/examples/openapi_related/test_openapi_calculator.py
+++ b/examples/openapi_related/test_openapi_calculator.py
@@ -1,12 +1,12 @@
 import asyncio
 
-from toolregistry.integrations.openapi import HttpxClientConfig, load_openapi_spec
+from toolregistry.integrations.openapi import HttpClientConfig, load_openapi_spec
 from toolregistry.tool_registry import ToolRegistry
 
 base_url = "http://localhost:8000"
 openapi_spec = load_openapi_spec(base_url)
 
-client_config = HttpxClientConfig(base_url=base_url)
+client_config = HttpClientConfig(base_url=base_url)
 
 # Initialize the ToolRegistry and register OpenAPI tools synchronously
 registry = ToolRegistry()

--- a/examples/tool_use_examples/openai_toolregistry_mixed_math.py
+++ b/examples/tool_use_examples/openai_toolregistry_mixed_math.py
@@ -7,7 +7,7 @@ from openai import OpenAI
 
 from toolregistry import ToolRegistry
 from toolregistry.integrations.openapi import (
-    HttpxClientConfig,
+    HttpClientConfig,
     load_openapi_spec_async,
 )
 
@@ -22,7 +22,7 @@ print("================ OpenAPI ================")
 
 
 async def async_register():
-    client_config = HttpxClientConfig(base_url=openapi_spec_url)
+    client_config = HttpClientConfig(base_url=openapi_spec_url)
     openapi_spec = await load_openapi_spec_async(openapi_spec_url)
 
     await openapi_registry.register_from_openapi_async(

--- a/examples/tool_use_examples/openai_toolregistry_openapi_math.py
+++ b/examples/tool_use_examples/openai_toolregistry_openapi_math.py
@@ -7,7 +7,7 @@ from openai import OpenAI
 
 from toolregistry import ToolRegistry
 from toolregistry.integrations.openapi import (
-    HttpxClientConfig,
+    HttpClientConfig,
     load_openapi_spec,
     load_openapi_spec_async,
 )
@@ -24,7 +24,7 @@ registry = ToolRegistry()
 
 spec_url = f"http://localhost:{PORT}"
 
-client_config = HttpxClientConfig(base_url=spec_url)
+client_config = HttpClientConfig(base_url=spec_url)
 openapi_spec = load_openapi_spec(spec_url)
 
 registry.register_from_openapi(client_config, openapi_spec, namespace=True)
@@ -32,7 +32,7 @@ pprint(registry)
 
 
 async def async_register():
-    client_config = HttpxClientConfig(base_url=spec_url)
+    client_config = HttpClientConfig(base_url=spec_url)
     openapi_spec = await load_openapi_spec_async(spec_url)
 
     await registry.register_from_openapi_async(

--- a/examples/tool_use_examples/test_toolregistry_concurrency.py
+++ b/examples/tool_use_examples/test_toolregistry_concurrency.py
@@ -8,7 +8,7 @@ import time
 from typing import Any
 
 from toolregistry import ToolRegistry
-from toolregistry.integrations.openapi import HttpxClientConfig, load_openapi_spec
+from toolregistry.integrations.openapi import HttpClientConfig, load_openapi_spec
 from toolregistry.types import (
     ChatCompletionMessageToolCall,
     Function,
@@ -166,7 +166,7 @@ def main():
 
     OPENAPI_PORT = os.getenv("OPENAPI_PORT", 8000)
 
-    client_config = HttpxClientConfig(base_url=f"http://localhost:{OPENAPI_PORT}")
+    client_config = HttpClientConfig(base_url=f"http://localhost:{OPENAPI_PORT}")
     openapi_spec = load_openapi_spec(f"http://localhost:{OPENAPI_PORT}")
 
     registry.register_from_openapi(client_config, openapi_spec, namespace=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,11 @@ classifiers = [
 dependencies = [
     "pydantic>=2.7.2,<3.0.0",
     "cloudpickle>=3.0.0",
-    "httpx>=0.28.1",
     "llm-rosetta>=0.5.1,<0.6.0",
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.0.0,<2.0.0"]
+mcp = ["mcp>=1.0.0,<2.0.0", "httpx>=0.28.1"]
 openapi = [
     "PyYAML>=6.0.2",  # safe load both json and yaml
     "jsonref>=1.1.0", # deref $ref in openapi spec

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 
 from ..events import ChangeEvent, ChangeEventType
 from ..tool import Tool
-from ..utils import HttpxClientConfig, normalize_tool_name
+from ..utils import HttpClientConfig, normalize_tool_name
 
 if TYPE_CHECKING:
     from ..tool_registry import ToolRegistry
@@ -171,7 +171,7 @@ class RegistrationMixin:
 
     def register_from_openapi(
         self,
-        client: HttpxClientConfig,
+        client: HttpClientConfig,
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
@@ -180,7 +180,7 @@ class RegistrationMixin:
         """Registers tools from OpenAPI specification synchronously.
 
         Args:
-            client (HttpxClientConfig): The httpx client config instance.
+            client (HttpClientConfig): The httpx client config instance.
             openapi_spec (Dict[str, Any]): Parsed OpenAPI specification dictionary.
             namespace (Union[bool, str]): Specifies namespace usage:
                 - ``False``: No namespace is applied.
@@ -201,7 +201,7 @@ class RegistrationMixin:
 
     async def register_from_openapi_async(
         self,
-        client: HttpxClientConfig,
+        client: HttpClientConfig,
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
@@ -210,7 +210,7 @@ class RegistrationMixin:
         """Registers tools from OpenAPI specification asynchronously.
 
         Args:
-            client (HttpxClientConfig): The httpx client config instance.
+            client (HttpClientConfig): The httpx client config instance.
             openapi_spec (Dict[str, Any]): Parsed OpenAPI specification dictionary.
             namespace (Union[bool, str]): Specifies namespace usage:
                 - ``False``: No namespace is applied.

--- a/src/toolregistry/_vendor/httpclient.py
+++ b/src/toolregistry/_vendor/httpclient.py
@@ -1,0 +1,2599 @@
+# /// zerodep
+# version = "0.4.0"
+# deps = []
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+
+"""Zero-dependency sync + async HTTP REST client.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Sync (http.client) and async (asyncio streams) HTTP/1.1 client
+for REST API consumption. Thread-safe by design.
+
+Sync usage::
+
+    response = get("https://httpbin.org/get")
+    response.json()
+
+Async usage::
+
+    response = await async_get("https://httpbin.org/get")
+    response.json()
+
+Session usage::
+
+    with Client() as client:
+        r = client.get("https://httpbin.org/get")
+
+    async with AsyncClient() as client:
+        r = await client.get("https://httpbin.org/get")
+"""
+
+# ── Imports ──
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import http.client
+import json as _json
+import logging
+import os
+import socket
+import ssl
+import struct
+import threading
+import time
+import warnings
+import zlib
+from collections.abc import AsyncIterator, Iterator
+from typing import IO, Any
+from urllib.parse import quote, urlencode, urlparse
+
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_MAX_REDIRECTS",
+    "DEFAULT_USER_AGENT",
+    "DEFAULT_POOL_SIZE",
+    "DEFAULT_POOL_IDLE_TIMEOUT",
+    # Exceptions
+    "HttpClientError",
+    "HTTPError",
+    "TooManyRedirects",
+    "HttpConnectionError",
+    "HttpTimeoutError",
+    "Socks5Error",
+    # Response classes
+    "Response",
+    "StreamingResponse",
+    # Auth
+    "Auth",
+    "BasicAuth",
+    "DigestAuth",
+    # Sync convenience functions
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    # Async convenience functions
+    "async_get",
+    "async_post",
+    "async_put",
+    "async_patch",
+    "async_delete",
+    "async_head",
+    "async_options",
+    # Client classes
+    "Client",
+    "AsyncClient",
+]
+
+# ── Constants / Defaults ──
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_REDIRECTS = 10
+DEFAULT_USER_AGENT = "zerodep-http/0.1"
+DEFAULT_POOL_SIZE = 10
+DEFAULT_POOL_IDLE_TIMEOUT = 60.0
+
+
+# ── Exceptions ──
+
+
+class HttpClientError(Exception):
+    """Base exception for all httpclient operations."""
+
+
+class HTTPError(HttpClientError):
+    """Raised on non-2xx status when raise_for_status() is called."""
+
+    def __init__(self, status_code: int, body: str, url: str) -> None:
+        self.status_code = status_code
+        self.body = body
+        self.url = url
+        super().__init__(f"HTTP {status_code} for {url}")
+
+
+class TooManyRedirects(HTTPError):
+    """Raised when redirect limit is exceeded."""
+
+    def __init__(self, url: str, max_redirects: int) -> None:
+        super().__init__(0, "", url)
+        self.max_redirects = max_redirects
+        Exception.__init__(self, f"Too many redirects (>{max_redirects}) for {url}")
+
+
+class HttpConnectionError(HttpClientError):
+    """Raised on connection failures.
+
+    Attributes:
+        host: Remote hostname that the connection targeted.
+        port: Remote port number.
+        message: Human-readable error description.
+    """
+
+    def __init__(self, message: str, *, host: str = "", port: int = 0) -> None:
+        self.host = host
+        self.port = port
+        self.message = message
+        super().__init__(message)
+
+
+class HttpTimeoutError(HttpClientError):
+    """Raised on request timeout.
+
+    Attributes:
+        url: The URL that timed out.
+        timeout: The timeout value in seconds that was exceeded.
+        message: Human-readable error description.
+    """
+
+    def __init__(self, message: str, *, url: str = "", timeout: float = 0.0) -> None:
+        self.url = url
+        self.timeout = timeout
+        self.message = message
+        super().__init__(message)
+
+
+# Backward-compatible aliases (deprecated: prefer HttpConnectionError/HttpTimeoutError)
+ConnectionError = HttpConnectionError  # noqa: A001
+TimeoutError = HttpTimeoutError  # noqa: A001
+
+
+class Socks5Error(HttpConnectionError):
+    """Raised on SOCKS5 proxy handshake failures."""
+
+
+# ── Data Models (Response) ──
+
+
+class Response:
+    """HTTP response object.
+
+    Attributes:
+        status_code: HTTP status code.
+        headers: Response headers as dict (last value wins for duplicates).
+        content: Raw response body as bytes.
+        url: Final URL after redirects.
+    """
+
+    __slots__ = ("status_code", "headers", "content", "url", "_text", "_json")
+
+    def __init__(
+        self,
+        status_code: int,
+        headers: dict[str, str],
+        content: bytes,
+        url: str,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+        self.url = url
+        self._text: str | None = None
+        self._json: Any = None
+
+    @property
+    def text(self) -> str:
+        """Decode response body as text."""
+        if self._text is None:
+            encoding = self._guess_encoding()
+            self._text = self.content.decode(encoding, errors="replace")
+        return self._text
+
+    def json(self) -> Any:
+        """Parse response body as JSON."""
+        if self._json is None:
+            self._json = _json.loads(self.content)
+        return self._json
+
+    @property
+    def ok(self) -> bool:
+        """True if status_code is 2xx."""
+        return 200 <= self.status_code < 300
+
+    def raise_for_status(self) -> None:
+        """Raise HTTPError if status is not 2xx."""
+        if not self.ok:
+            raise HTTPError(self.status_code, self.text, self.url)
+
+    def _guess_encoding(self) -> str:
+        return _guess_encoding_from_headers(self.headers)
+
+    # ── Context managers (no-op, body is already fully read) ──
+
+    def __enter__(self) -> Response:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> Response:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """No-op close for a fully-read response."""
+
+    async def aclose(self) -> None:
+        """No-op async close for a fully-read response."""
+
+    def __repr__(self) -> str:
+        return f"<Response [{self.status_code}]>"
+
+
+def _guess_encoding_from_headers(headers: dict[str, str]) -> str:
+    """Extract charset from Content-Type header, default utf-8."""
+    ct = headers.get("content-type", "")
+    for part in ct.split(";"):
+        part = part.strip()
+        if part.startswith("charset="):
+            return part[8:].strip().strip('"')
+    return "utf-8"
+
+
+# ── Auth (BasicAuth, DigestAuth) ──
+
+
+class Auth:
+    """Base class for HTTP authentication."""
+
+    def auth_headers(self, method: str, url: str) -> dict[str, str]:
+        """Return authorization headers.
+
+        Args:
+            method: HTTP method.
+            url: Request URL.
+
+        Returns:
+            Dict of headers to add to the request.
+        """
+        raise NotImplementedError
+
+
+class BasicAuth(Auth):
+    """HTTP Basic authentication."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self._username = username
+        self._password = password
+
+    def auth_headers(self, method: str, url: str) -> dict[str, str]:
+        """Return Basic Authorization header."""
+        credentials = f"{self._username}:{self._password}".encode()
+        return {"Authorization": "Basic " + base64.b64encode(credentials).decode()}
+
+
+class DigestAuth(Auth):
+    """HTTP Digest authentication."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self._username = username
+        self._password = password
+        self._nc = 0
+
+    def auth_headers(self, method: str, url: str) -> dict[str, str]:
+        """Not usable without a server challenge."""
+        raise NotImplementedError("DigestAuth requires a server challenge")
+
+    def auth_headers_from_challenge(
+        self, method: str, path: str, challenge: str
+    ) -> dict[str, str]:
+        """Compute Digest auth headers from a WWW-Authenticate challenge.
+
+        Args:
+            method: HTTP method.
+            path: Request path (URI).
+            challenge: The WWW-Authenticate header value.
+
+        Returns:
+            Dict with the Authorization header.
+        """
+        params = _parse_digest_challenge(challenge)
+        realm = params.get("realm", "")
+        nonce = params.get("nonce", "")
+        qop = params.get("qop", "")
+        opaque = params.get("opaque", "")
+        algorithm = params.get("algorithm", "MD5").upper()
+
+        self._nc += 1
+        nc_hex = f"{self._nc:08x}"
+        cnonce = os.urandom(16).hex()
+
+        if algorithm == "SHA-256":
+            hash_fn = hashlib.sha256
+        else:
+            hash_fn = hashlib.md5
+
+        ha1 = hash_fn(f"{self._username}:{realm}:{self._password}".encode()).hexdigest()
+        ha2 = hash_fn(f"{method}:{path}".encode()).hexdigest()
+
+        if qop == "auth":
+            response = hash_fn(
+                f"{ha1}:{nonce}:{nc_hex}:{cnonce}:{qop}:{ha2}".encode()
+            ).hexdigest()
+        else:
+            response = hash_fn(f"{ha1}:{nonce}:{ha2}".encode()).hexdigest()
+
+        header = (
+            f'Digest username="{self._username}", realm="{realm}", '
+            f'nonce="{nonce}", uri="{path}", response="{response}"'
+        )
+        if qop:
+            header += f', qop={qop}, nc={nc_hex}, cnonce="{cnonce}"'
+        if opaque:
+            header += f', opaque="{opaque}"'
+        header += f", algorithm={algorithm}"
+
+        return {"Authorization": header}
+
+
+def _normalize_auth(
+    auth: tuple[str, str] | Auth | None,
+) -> Auth | None:
+    """Convert auth parameter to an Auth instance.
+
+    Args:
+        auth: A (username, password) tuple, an Auth subclass, or None.
+
+    Returns:
+        An Auth instance or None.
+    """
+    if auth is None:
+        return None
+    if isinstance(auth, tuple):
+        return BasicAuth(str(auth[0]), str(auth[1]))
+    return auth
+
+
+def _parse_digest_challenge(header_value: str) -> dict[str, str]:
+    """Parse a Digest WWW-Authenticate challenge into a dict.
+
+    Args:
+        header_value: The full WWW-Authenticate header value.
+
+    Returns:
+        Dict of challenge parameters.
+    """
+    if header_value.lower().startswith("digest "):
+        header_value = header_value[7:]
+    result: dict[str, str] = {}
+    import re
+
+    for match in re.finditer(r'(\w+)=(?:"([^"]*)"|([\w\-]+))', header_value):
+        key = match.group(1)
+        value = match.group(2) if match.group(2) is not None else match.group(3)
+        result[key] = value
+    return result
+
+
+# ── Compression / Encoding helpers ──
+
+
+def _decompress_body(body: bytes, encoding: str) -> bytes:
+    """Decompress a response body based on Content-Encoding.
+
+    Args:
+        body: The raw response body bytes.
+        encoding: The Content-Encoding value.
+
+    Returns:
+        Decompressed bytes, or original body if encoding is unsupported.
+    """
+    if encoding in ("gzip", "x-gzip"):
+        return zlib.decompress(body, 16 + zlib.MAX_WBITS)
+    if encoding == "deflate":
+        try:
+            return zlib.decompress(body, -zlib.MAX_WBITS)
+        except zlib.error:
+            return zlib.decompress(body)
+    return body
+
+
+def _make_decompressor(encoding: str) -> zlib._Decompress | None:
+    """Create a streaming decompressor for the given encoding.
+
+    Args:
+        encoding: The Content-Encoding value.
+
+    Returns:
+        A zlib.decompressobj or None if encoding is unsupported.
+    """
+    if encoding in ("gzip", "x-gzip"):
+        return zlib.decompressobj(16 + zlib.MAX_WBITS)
+    if encoding == "deflate":
+        return zlib.decompressobj(-zlib.MAX_WBITS)
+    return None
+
+
+# ── Streaming Response (state machine) ──
+
+
+class StreamingResponse:
+    """HTTP streaming response -- holds the connection open.
+
+    Use as a context manager to ensure cleanup::
+
+        with get(url, stream=True) as r:
+            for chunk in r.iter_bytes():
+                process(chunk)
+
+        async with await async_get(url, stream=True) as r:
+            async for line in r.aiter_lines():
+                handle(line)
+    """
+
+    __slots__ = (
+        "status_code",
+        "headers",
+        "url",
+        "_encoding",
+        "_decompressor",
+        "_sync_resp",
+        "_sync_conn",
+        "_async_reader",
+        "_async_writer",
+        "_async_timeout",
+        "_is_chunked",
+        "_content_length",
+        "_bytes_remaining",
+        "_closed",
+    )
+
+    status_code: int
+    headers: dict[str, str]
+    url: str
+    _encoding: str
+    _decompressor: zlib._Decompress | None
+    _sync_resp: http.client.HTTPResponse | None
+    _sync_conn: http.client.HTTPConnection | None
+    _async_reader: asyncio.StreamReader | None
+    _async_writer: asyncio.StreamWriter | None
+    _async_timeout: float | None
+    _is_chunked: bool
+    _content_length: int | None
+    _bytes_remaining: int | None
+    _closed: bool
+
+    def __init__(self) -> None:
+        raise TypeError("Use _from_sync() or _from_async()")
+
+    @classmethod
+    def _from_sync(
+        cls,
+        status_code: int,
+        headers: dict[str, str],
+        url: str,
+        resp: http.client.HTTPResponse,
+        conn: http.client.HTTPConnection,
+        content_encoding: str = "",
+    ) -> "StreamingResponse":
+        obj = object.__new__(cls)
+        obj.status_code = status_code
+        obj.headers = headers
+        obj.url = url
+        obj._encoding = _guess_encoding_from_headers(headers)
+        obj._decompressor = (
+            _make_decompressor(content_encoding) if content_encoding else None
+        )
+        obj._sync_resp = resp
+        obj._sync_conn = conn
+        obj._async_reader = None
+        obj._async_writer = None
+        obj._async_timeout = None
+        obj._is_chunked = False
+        obj._content_length = None
+        obj._bytes_remaining = None
+        obj._closed = False
+        return obj
+
+    @classmethod
+    def _from_async(
+        cls,
+        status_code: int,
+        headers: dict[str, str],
+        url: str,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        is_chunked: bool,
+        content_length: int | None,
+        timeout: float,
+        content_encoding: str = "",
+    ) -> "StreamingResponse":
+        obj = object.__new__(cls)
+        obj.status_code = status_code
+        obj.headers = headers
+        obj.url = url
+        obj._encoding = _guess_encoding_from_headers(headers)
+        obj._decompressor = (
+            _make_decompressor(content_encoding) if content_encoding else None
+        )
+        obj._sync_resp = None
+        obj._sync_conn = None
+        obj._async_reader = reader
+        obj._async_writer = writer
+        obj._async_timeout = timeout
+        obj._is_chunked = is_chunked
+        obj._content_length = content_length
+        obj._bytes_remaining = content_length
+        obj._closed = False
+        return obj
+
+    @property
+    def ok(self) -> bool:
+        """True if status_code is 2xx."""
+        return 200 <= self.status_code < 300
+
+    def raise_for_status(self) -> None:
+        """Raise HTTPError if status is not 2xx."""
+        if not self.ok:
+            raise HTTPError(self.status_code, "", self.url)
+
+    # ── Sync iteration ──
+
+    def iter_bytes(self, chunk_size: int = 4096) -> Iterator[bytes]:
+        """Yield response body in chunks."""
+        if self._sync_resp is None:
+            raise RuntimeError("iter_bytes() on async response")
+        try:
+            while True:
+                chunk = self._sync_resp.read(chunk_size)
+                if not chunk:
+                    break
+                if self._decompressor:
+                    chunk = self._decompressor.decompress(chunk)
+                yield chunk
+            if self._decompressor:
+                remaining = self._decompressor.flush()
+                if remaining:
+                    yield remaining
+        except (OSError, http.client.HTTPException) as exc:
+            raise HttpConnectionError(str(exc)) from exc
+
+    def iter_lines(self) -> Iterator[str]:
+        """Yield response body line by line (decoded)."""
+        if self._sync_resp is None:
+            raise RuntimeError("iter_lines() on async response")
+        try:
+            while True:
+                line = self._sync_resp.readline()
+                if not line:
+                    break
+                yield line.decode(self._encoding, errors="replace").rstrip("\r\n")
+        except (OSError, http.client.HTTPException) as exc:
+            raise HttpConnectionError(str(exc)) from exc
+
+    def read(self) -> bytes:
+        """Consume entire stream into bytes."""
+        return b"".join(self.iter_bytes())
+
+    # ── Async iteration ──
+
+    async def aiter_bytes(self, chunk_size: int = 4096) -> AsyncIterator[bytes]:
+        """Async yield response body in chunks."""
+        if self._async_reader is None:
+            raise RuntimeError("aiter_bytes() on sync response")
+        try:
+            raw_iter = self._select_raw_iterator(chunk_size)
+            async for chunk in raw_iter:
+                if self._decompressor:
+                    chunk = self._decompressor.decompress(chunk)
+                yield chunk
+            if self._decompressor:
+                remaining = self._decompressor.flush()
+                if remaining:
+                    yield remaining
+        except asyncio.TimeoutError:
+            raise HttpTimeoutError(
+                f"Streaming read timed out for {self.url}",
+                url=self.url,
+                timeout=self._async_timeout or 0.0,
+            )
+        except OSError as exc:
+            raise HttpConnectionError(str(exc)) from exc
+
+    async def _select_raw_iterator(self, chunk_size: int) -> AsyncIterator[bytes]:
+        """Select and yield from the appropriate raw byte iterator."""
+        if self._is_chunked:
+            async for chunk in self._aiter_chunked():
+                yield chunk
+        elif self._bytes_remaining is not None:
+            async for chunk in self._aiter_fixed_length(chunk_size):
+                yield chunk
+        else:
+            async for chunk in self._aiter_until_eof(chunk_size):
+                yield chunk
+
+    async def _aiter_fixed_length(self, chunk_size: int) -> AsyncIterator[bytes]:
+        """Read a known-length response body in chunks."""
+        assert self._async_reader is not None
+        while self._bytes_remaining is not None and self._bytes_remaining > 0:
+            to_read = min(chunk_size, self._bytes_remaining)
+            data = await asyncio.wait_for(
+                self._async_reader.read(to_read),
+                timeout=self._async_timeout,
+            )
+            if not data:
+                break
+            self._bytes_remaining -= len(data)
+            yield data
+
+    async def _aiter_until_eof(self, chunk_size: int) -> AsyncIterator[bytes]:
+        """Read response body until EOF in chunks."""
+        assert self._async_reader is not None
+        while True:
+            data = await asyncio.wait_for(
+                self._async_reader.read(chunk_size),
+                timeout=self._async_timeout,
+            )
+            if not data:
+                break
+            yield data
+
+    async def _aiter_chunked(self) -> AsyncIterator[bytes]:
+        """Decode chunked transfer encoding from async reader."""
+        assert self._async_reader is not None  # guaranteed by aiter_bytes guard
+        reader = self._async_reader
+        timeout = self._async_timeout
+        while True:
+            size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+            size_str = size_line.decode("latin-1").split(";")[0].strip()
+            if not size_str:
+                break
+            chunk_size = int(size_str, 16)
+            if chunk_size == 0:
+                await asyncio.wait_for(
+                    reader.readline(), timeout=timeout
+                )  # trailing \r\n
+                break
+            data = await asyncio.wait_for(
+                reader.readexactly(chunk_size), timeout=timeout
+            )
+            await asyncio.wait_for(reader.readline(), timeout=timeout)  # trailing \r\n
+            yield data
+
+    async def aiter_lines(self) -> AsyncIterator[str]:
+        """Async yield response body line by line (decoded)."""
+        buf = ""
+        async for chunk in self.aiter_bytes():
+            buf += chunk.decode(self._encoding, errors="replace")
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                yield line.rstrip("\r")
+        if buf:
+            yield buf.rstrip("\r")
+
+    async def aread(self) -> bytes:
+        """Async consume entire stream into bytes."""
+        parts = []
+        async for chunk in self.aiter_bytes():
+            parts.append(chunk)
+        return b"".join(parts)
+
+    # ── Context managers ──
+
+    def __enter__(self) -> "StreamingResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "StreamingResponse":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    def close(self) -> None:
+        """Close the underlying sync connection."""
+        if self._closed:
+            return
+        self._closed = True
+        # Tier 2: best-effort observable -- active streaming resource
+        if self._sync_resp is not None:
+            try:
+                self._sync_resp.close()
+            except Exception:
+                logger.debug(
+                    "failed to close sync response for %s",
+                    self.url,
+                    exc_info=True,
+                )
+        if self._sync_conn is not None:
+            try:
+                self._sync_conn.close()
+            except Exception:
+                logger.debug(
+                    "failed to close sync connection for %s",
+                    self.url,
+                    exc_info=True,
+                )
+
+    async def aclose(self) -> None:
+        """Close the underlying async connection."""
+        if self._closed:
+            return
+        self._closed = True
+        # Tier 2: best-effort observable -- active streaming resource
+        if self._async_writer is not None:
+            try:
+                self._async_writer.close()
+                await self._async_writer.wait_closed()
+            except Exception:
+                logger.debug(
+                    "failed to close async writer for %s",
+                    self.url,
+                    exc_info=True,
+                )
+
+    def __del__(self) -> None:
+        if not self._closed:
+            warnings.warn(
+                f"Unclosed StreamingResponse for {self.url}",
+                ResourceWarning,
+                stacklevel=2,
+            )
+            self.close()
+
+    def __repr__(self) -> str:
+        return f"<StreamingResponse [{self.status_code}]>"
+
+
+# ── Connection Pools (Sync + Async) ──
+
+
+class _SyncConnectionPool:
+    """Thread-safe connection pool for sync HTTP connections.
+
+    Pool lifecycle rules:
+        - A connection CAN be returned to the pool when a non-streaming
+          request completes successfully AND the server did not send a
+          ``Connection: close`` header.
+        - A connection MUST be discarded (not returned) when:
+          (a) an error occurred during the request/response cycle,
+          (b) the server sent ``Connection: close``,
+          (c) the request used a proxy (proxy connections are not pooled),
+          (d) streaming mode is active (the connection is owned by
+              StreamingResponse until it is closed/consumed).
+        - Streaming responses bypass the pool entirely: the connection is
+          handed to StreamingResponse, which closes it on ``close()`` or
+          ``__del__``.  The connection is never returned to the pool.
+    """
+
+    def __init__(self, pool_size: int = DEFAULT_POOL_SIZE) -> None:
+        self._pool: dict[
+            tuple[str, int, bool],
+            list[tuple[http.client.HTTPConnection, float]],
+        ] = {}
+        self._pool_size = pool_size
+        self._lock = threading.Lock()
+
+    def acquire(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        timeout: float,
+        verify: bool,
+    ) -> http.client.HTTPConnection | None:
+        """Acquire a connection from the pool if available.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            timeout: Connection timeout.
+            verify: Whether to verify TLS certificates.
+
+        Returns:
+            A reusable connection or None.
+        """
+        key = (host, port, is_https)
+        now = time.monotonic()
+        with self._lock:
+            conns = self._pool.get(key, [])
+            while conns:
+                conn, timestamp = conns.pop()
+                if now - timestamp > DEFAULT_POOL_IDLE_TIMEOUT:
+                    # Tier 3: best-effort silent -- stale connection eviction
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    continue
+                if conn.sock is not None and conn.sock.fileno() != -1:
+                    return conn
+                # Tier 3: best-effort silent -- dead connection eviction
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        return None
+
+    def release(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        conn: http.client.HTTPConnection,
+    ) -> None:
+        """Return a connection to the pool.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            conn: The connection to return.
+        """
+        key = (host, port, is_https)
+        with self._lock:
+            conns = self._pool.setdefault(key, [])
+            if len(conns) < self._pool_size:
+                conns.append((conn, time.monotonic()))
+            else:
+                # Tier 3: best-effort silent -- pool overflow discard
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+    def close_all(self) -> None:
+        """Close all pooled connections."""
+        with self._lock:
+            for conns in self._pool.values():
+                for conn, _ in conns:
+                    # Tier 3: best-effort silent -- bulk shutdown
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+            self._pool.clear()
+
+
+class _AsyncConnectionPool:
+    """Async connection pool for async HTTP connections.
+
+    Pool lifecycle rules:
+        - A connection CAN be returned to the pool when a non-streaming
+          request completes successfully AND the server did not send a
+          ``Connection: close`` header.
+        - A connection MUST be discarded (not returned) when:
+          (a) an error occurred during the request/response cycle,
+          (b) the server sent ``Connection: close``,
+          (c) the request used a proxy (proxy connections are not pooled),
+          (d) streaming mode is active (the connection is owned by
+              StreamingResponse until it is closed/consumed).
+        - Streaming responses bypass the pool entirely: the reader/writer
+          pair is handed to StreamingResponse, which closes it on
+          ``aclose()`` or ``__del__``.  The pair is never returned to
+          the pool.
+    """
+
+    def __init__(self, pool_size: int = DEFAULT_POOL_SIZE) -> None:
+        self._pool: dict[
+            tuple[str, int, bool],
+            list[
+                tuple[
+                    asyncio.StreamReader,
+                    asyncio.StreamWriter,
+                    float,
+                ]
+            ],
+        ] = {}
+        self._pool_size = pool_size
+        self._lock = asyncio.Lock()
+
+    async def acquire(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        timeout: float,
+        verify: bool,
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter] | None:
+        """Acquire a connection from the pool if available.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            timeout: Connection timeout.
+            verify: Whether to verify TLS certificates.
+
+        Returns:
+            A (reader, writer) tuple or None.
+        """
+        key = (host, port, is_https)
+        now = time.monotonic()
+        async with self._lock:
+            conns = self._pool.get(key, [])
+            while conns:
+                reader, writer, timestamp = conns.pop()
+                if now - timestamp > DEFAULT_POOL_IDLE_TIMEOUT:
+                    # Tier 3: best-effort silent -- stale connection eviction
+                    try:
+                        writer.close()
+                        await writer.wait_closed()
+                    except Exception:
+                        pass
+                    continue
+                if not reader.at_eof():
+                    return reader, writer
+                # Tier 3: best-effort silent -- dead connection eviction
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+        return None
+
+    async def release(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Return a connection to the pool.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            reader: The stream reader.
+            writer: The stream writer.
+        """
+        key = (host, port, is_https)
+        async with self._lock:
+            conns = self._pool.setdefault(key, [])
+            if len(conns) < self._pool_size:
+                conns.append((reader, writer, time.monotonic()))
+            else:
+                # Tier 3: best-effort silent -- pool overflow discard
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+
+    async def close_all(self) -> None:
+        """Close all pooled connections."""
+        async with self._lock:
+            for conns in self._pool.values():
+                for _, writer, _ in conns:
+                    # Tier 3: best-effort silent -- bulk shutdown
+                    try:
+                        writer.close()
+                        await writer.wait_closed()
+                    except Exception:
+                        pass
+            self._pool.clear()
+
+
+# ── Transport (request execution) ──
+
+# -- Proxy helpers --
+
+
+def _parse_proxy(proxy: str) -> tuple[str, int, str | None, str | None]:
+    """Parse a proxy URL into components.
+
+    Args:
+        proxy: Proxy URL (e.g. "http://user:pass@host:port").
+
+    Returns:
+        Tuple of (hostname, port, username_or_None, password_or_None).
+    """
+    parsed = urlparse(proxy)
+    hostname = parsed.hostname or ""
+    scheme = (parsed.scheme or "").lower()
+    default_port = 1080 if scheme.startswith("socks") else 8080
+    port = parsed.port or default_port
+    username = parsed.username or None
+    password = parsed.password or None
+    return hostname, port, username, password
+
+
+def _proxy_auth_header(username: str, password: str) -> str:
+    """Build a Proxy-Authorization Basic header value.
+
+    Args:
+        username: Proxy username.
+        password: Proxy password.
+
+    Returns:
+        The header value string.
+    """
+    credentials = f"{username}:{password}".encode()
+    return "Basic " + base64.b64encode(credentials).decode()
+
+
+# -- SOCKS5 helpers --
+
+_SOCKS5_VER = 0x05
+_SOCKS5_AUTH_VER = 0x01
+_SOCKS5_CMD_CONNECT = 0x01
+_SOCKS5_ATYPE_IPV4 = 0x01
+_SOCKS5_ATYPE_DOMAIN = 0x03
+_SOCKS5_ATYPE_IPV6 = 0x04
+_SOCKS5_METHOD_NO_AUTH = 0x00
+_SOCKS5_METHOD_USERPASS = 0x02
+_SOCKS5_METHOD_NO_ACCEPTABLE = 0xFF
+
+_SOCKS5_ERRORS: dict[int, str] = {
+    0x01: "general SOCKS server failure",
+    0x02: "connection not allowed by ruleset",
+    0x03: "network unreachable",
+    0x04: "host unreachable",
+    0x05: "connection refused by destination",
+    0x06: "TTL expired",
+    0x07: "command not supported",
+    0x08: "address type not supported",
+}
+
+
+def _is_socks_proxy(proxy: str | None) -> bool:
+    """Return True if proxy URL uses the socks5:// scheme."""
+    return proxy is not None and proxy.lower().startswith("socks5://")
+
+
+def _socks5_recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly *n* bytes from *sock*, raising on premature close."""
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise Socks5Error("SOCKS5 proxy closed connection unexpectedly")
+        data += chunk
+    return data
+
+
+def _socks5_handshake_sync(
+    sock: socket.socket,
+    host: str,
+    port: int,
+    username: str | None = None,
+    password: str | None = None,
+) -> None:
+    """Perform the SOCKS5 handshake (RFC 1928 + RFC 1929) over *sock*."""
+    # Phase 1: method negotiation
+    if username and password:
+        sock.sendall(
+            struct.pack("BBB", _SOCKS5_VER, 2, _SOCKS5_METHOD_NO_AUTH)
+            + struct.pack("B", _SOCKS5_METHOD_USERPASS)
+        )
+    else:
+        sock.sendall(struct.pack("BBB", _SOCKS5_VER, 1, _SOCKS5_METHOD_NO_AUTH))
+
+    ver, method = struct.unpack("BB", _socks5_recv_exact(sock, 2))
+    if ver != _SOCKS5_VER:
+        raise Socks5Error(f"Unexpected SOCKS version: {ver}")
+    if method == _SOCKS5_METHOD_NO_ACCEPTABLE:
+        raise Socks5Error("SOCKS5 proxy: no acceptable authentication method")
+
+    # Phase 2: username/password auth (RFC 1929)
+    if method == _SOCKS5_METHOD_USERPASS:
+        if not username or not password:
+            raise Socks5Error(
+                "SOCKS5 proxy requires authentication but no credentials provided"
+            )
+        uname = username.encode()
+        passwd = password.encode()
+        sock.sendall(
+            struct.pack("BB", _SOCKS5_AUTH_VER, len(uname))
+            + uname
+            + struct.pack("B", len(passwd))
+            + passwd
+        )
+        auth_ver, status = struct.unpack("BB", _socks5_recv_exact(sock, 2))
+        if status != 0x00:
+            raise Socks5Error("SOCKS5 authentication failed")
+
+    # Phase 3: connect request
+    host_bytes = host.encode()
+    if len(host_bytes) > 255:
+        raise Socks5Error(f"SOCKS5 target hostname too long: {len(host_bytes)} bytes")
+    sock.sendall(
+        struct.pack(
+            "BBBB", _SOCKS5_VER, _SOCKS5_CMD_CONNECT, 0x00, _SOCKS5_ATYPE_DOMAIN
+        )
+        + struct.pack("B", len(host_bytes))
+        + host_bytes
+        + struct.pack("!H", port)
+    )
+
+    # Parse reply
+    ver, reply, _rsv, atype = struct.unpack("BBBB", _socks5_recv_exact(sock, 4))
+    if reply != 0x00:
+        msg = _SOCKS5_ERRORS.get(reply, f"unknown error 0x{reply:02x}")
+        raise Socks5Error(f"SOCKS5 connect failed: {msg}")
+
+    # Consume bind address
+    if atype == _SOCKS5_ATYPE_IPV4:
+        _socks5_recv_exact(sock, 4)
+    elif atype == _SOCKS5_ATYPE_IPV6:
+        _socks5_recv_exact(sock, 16)
+    elif atype == _SOCKS5_ATYPE_DOMAIN:
+        addr_len = struct.unpack("B", _socks5_recv_exact(sock, 1))[0]
+        _socks5_recv_exact(sock, addr_len)
+    # Consume bind port
+    _socks5_recv_exact(sock, 2)
+
+
+async def _socks5_handshake_async(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    host: str,
+    port: int,
+    timeout: float,
+    username: str | None = None,
+    password: str | None = None,
+) -> None:
+    """Perform the SOCKS5 handshake (RFC 1928 + RFC 1929) asynchronously."""
+    try:
+        # Phase 1: method negotiation
+        if username and password:
+            writer.write(
+                struct.pack("BBB", _SOCKS5_VER, 2, _SOCKS5_METHOD_NO_AUTH)
+                + struct.pack("B", _SOCKS5_METHOD_USERPASS)
+            )
+        else:
+            writer.write(struct.pack("BBB", _SOCKS5_VER, 1, _SOCKS5_METHOD_NO_AUTH))
+        await asyncio.wait_for(writer.drain(), timeout=timeout)
+
+        data = await asyncio.wait_for(reader.readexactly(2), timeout=timeout)
+        ver, method = struct.unpack("BB", data)
+        if ver != _SOCKS5_VER:
+            raise Socks5Error(f"Unexpected SOCKS version: {ver}")
+        if method == _SOCKS5_METHOD_NO_ACCEPTABLE:
+            raise Socks5Error("SOCKS5 proxy: no acceptable authentication method")
+
+        # Phase 2: username/password auth (RFC 1929)
+        if method == _SOCKS5_METHOD_USERPASS:
+            if not username or not password:
+                raise Socks5Error(
+                    "SOCKS5 proxy requires authentication but no credentials provided"
+                )
+            uname = username.encode()
+            passwd = password.encode()
+            writer.write(
+                struct.pack("BB", _SOCKS5_AUTH_VER, len(uname))
+                + uname
+                + struct.pack("B", len(passwd))
+                + passwd
+            )
+            await asyncio.wait_for(writer.drain(), timeout=timeout)
+            data = await asyncio.wait_for(reader.readexactly(2), timeout=timeout)
+            _auth_ver, status = struct.unpack("BB", data)
+            if status != 0x00:
+                raise Socks5Error("SOCKS5 authentication failed")
+
+        # Phase 3: connect request
+        host_bytes = host.encode()
+        if len(host_bytes) > 255:
+            raise Socks5Error(
+                f"SOCKS5 target hostname too long: {len(host_bytes)} bytes"
+            )
+        writer.write(
+            struct.pack(
+                "BBBB", _SOCKS5_VER, _SOCKS5_CMD_CONNECT, 0x00, _SOCKS5_ATYPE_DOMAIN
+            )
+            + struct.pack("B", len(host_bytes))
+            + host_bytes
+            + struct.pack("!H", port)
+        )
+        await asyncio.wait_for(writer.drain(), timeout=timeout)
+
+        # Parse reply
+        data = await asyncio.wait_for(reader.readexactly(4), timeout=timeout)
+        ver, reply, _rsv, atype = struct.unpack("BBBB", data)
+        if reply != 0x00:
+            msg = _SOCKS5_ERRORS.get(reply, f"unknown error 0x{reply:02x}")
+            raise Socks5Error(f"SOCKS5 connect failed: {msg}")
+
+        # Consume bind address
+        if atype == _SOCKS5_ATYPE_IPV4:
+            await asyncio.wait_for(reader.readexactly(4), timeout=timeout)
+        elif atype == _SOCKS5_ATYPE_IPV6:
+            await asyncio.wait_for(reader.readexactly(16), timeout=timeout)
+        elif atype == _SOCKS5_ATYPE_DOMAIN:
+            data = await asyncio.wait_for(reader.readexactly(1), timeout=timeout)
+            addr_len = struct.unpack("B", data)[0]
+            await asyncio.wait_for(reader.readexactly(addr_len), timeout=timeout)
+        # Consume bind port
+        await asyncio.wait_for(reader.readexactly(2), timeout=timeout)
+
+    except asyncio.IncompleteReadError as exc:
+        raise Socks5Error("SOCKS5 proxy closed connection unexpectedly") from exc
+
+
+# -- URL helpers --
+
+
+def _build_url(url: str, params: dict[str, Any] | None = None) -> str:
+    """Append query parameters to URL."""
+    if not params:
+        return url
+    sep = "&" if "?" in url else "?"
+    encoded = urlencode(
+        {k: v for k, v in params.items() if v is not None}, quote_via=quote
+    )
+    return f"{url}{sep}{encoded}"
+
+
+def _parse_url(url: str) -> tuple[str, str, int, str, bool]:
+    """Parse URL into (scheme, host, port, path, is_https)."""
+    parsed = urlparse(url)
+    is_https = parsed.scheme == "https"
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if is_https else 80)
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return parsed.scheme, host, port, path, is_https
+
+
+# -- Shared request preparation helpers --
+
+
+def _prepare_request(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None,
+    data: bytes | str | dict[str, str] | None,
+    json_data: Any,
+    files: dict[str, Any] | list[tuple[str, Any]] | None,
+    params: dict[str, Any] | None,
+    auth: tuple[str, str] | Auth | None,
+) -> tuple[str, bytes | None, dict[str, str], Auth | None]:
+    """Build URL, encode body, assemble headers, and normalize auth.
+
+    Shared by _sync_request and _async_request (Phases 1-3).
+
+    Returns:
+        (final_url, body_bytes, request_headers, auth_object).
+    """
+    url = _build_url(url, params)
+    body, content_type = _prepare_body(data, json_data, files)
+
+    req_headers: dict[str, str] = {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Accept-Encoding": "gzip, deflate",
+    }
+    if content_type:
+        req_headers["Content-Type"] = content_type
+    if body is not None:
+        req_headers["Content-Length"] = str(len(body))
+    req_headers.update(headers or {})
+
+    auth_obj = _normalize_auth(auth)
+    if isinstance(auth_obj, BasicAuth):
+        req_headers.update(auth_obj.auth_headers(method, url))
+
+    return url, body, req_headers, auth_obj
+
+
+def _compute_redirect(
+    status: int,
+    method: str,
+    body: bytes | None,
+    req_headers: dict[str, str],
+    resp_headers: dict[str, str],
+    scheme: str,
+    host: str,
+    port: int,
+    url: str,
+    redirects: int,
+    max_redirects: int,
+) -> tuple[str, str, bytes | None]:
+    """Compute redirect target and adjust method/body.
+
+    Raises:
+        TooManyRedirects: If redirect limit exceeded.
+
+    Returns:
+        (new_url, new_method, new_body).
+    """
+    redirects_now = redirects + 1
+    if redirects_now > max_redirects:
+        raise TooManyRedirects(url, max_redirects)
+    location = resp_headers["location"]
+    if location.startswith("/"):
+        new_url = f"{scheme}://{host}:{port}{location}"
+    else:
+        new_url = location
+    new_method = method
+    new_body = body
+    if status == 303 or (status in (301, 302) and method == "POST"):
+        new_method = "GET"
+        new_body = None
+        req_headers.pop("Content-Type", None)
+        req_headers.pop("Content-Length", None)
+    return new_url, new_method, new_body
+
+
+def _is_redirect(status: int, resp_headers: dict[str, str]) -> bool:
+    """Check whether the response is a redirect with a location header."""
+    return status in (301, 302, 303, 307, 308) and "location" in resp_headers
+
+
+def _should_attempt_digest(
+    auth_obj: Auth | None,
+    status: int,
+    resp_headers: dict[str, str],
+    digest_attempted: bool,
+) -> bool:
+    """Return True if a Digest auth retry should be attempted."""
+    return (
+        isinstance(auth_obj, DigestAuth)
+        and status == 401
+        and not digest_attempted
+        and resp_headers.get("www-authenticate", "").lower().startswith("digest")
+    )
+
+
+def _make_ssl_context(verify: bool) -> ssl.SSLContext:
+    """Create an SSL context based on verification setting."""
+    if verify:
+        return ssl.create_default_context()
+    return ssl._create_unverified_context()
+
+
+# -- Sync transport helpers --
+
+
+def _sync_connect_via_proxy(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str,
+    req_headers: dict[str, str],
+    url: str,
+) -> tuple[http.client.HTTPConnection, str]:
+    """Establish a sync connection through an HTTP proxy.
+
+    For plain HTTP, connects to the proxy directly.
+    For HTTPS, opens a CONNECT tunnel and wraps with TLS.
+
+    Returns:
+        (connection, request_path).
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    if not is_https:
+        conn = http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
+        if proxy_user and proxy_pass:
+            req_headers["Proxy-Authorization"] = _proxy_auth_header(
+                proxy_user, proxy_pass
+            )
+        # For HTTP proxies, the full URL is used as the request path
+        return conn, url
+
+    # CONNECT tunnel for HTTPS through proxy
+    tunnel_conn = http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
+    connect_headers: dict[str, str] = {"Host": f"{host}:{port}"}
+    if proxy_user and proxy_pass:
+        connect_headers["Proxy-Authorization"] = _proxy_auth_header(
+            proxy_user, proxy_pass
+        )
+    tunnel_conn.request("CONNECT", f"{host}:{port}", headers=connect_headers)
+    tunnel_resp = tunnel_conn.getresponse()
+    if tunnel_resp.status != 200:
+        tunnel_conn.close()
+        raise HttpConnectionError(
+            f"CONNECT tunnel failed: {tunnel_resp.status}",
+            host=host,
+            port=port,
+        )
+    tunnel_resp.read()
+    sock = tunnel_conn.sock
+    ctx = _make_ssl_context(verify)
+    wrapped = ctx.wrap_socket(sock, server_hostname=host)
+    conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    conn.sock = wrapped
+    return conn, path
+
+
+def _sync_connect_via_socks5(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str,
+) -> tuple[http.client.HTTPConnection, str]:
+    """Establish a sync connection through a SOCKS5 proxy.
+
+    Creates a SOCKS5 tunnel to the target, optionally wrapping with TLS.
+
+    Returns:
+        (connection, request_path).
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    sock = socket.create_connection((proxy_host, proxy_port), timeout=timeout)
+    try:
+        _socks5_handshake_sync(sock, host, port, proxy_user, proxy_pass)
+    except Exception:
+        sock.close()
+        raise
+
+    if is_https:
+        ctx = _make_ssl_context(verify)
+        sock = ctx.wrap_socket(sock, server_hostname=host)
+        conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    else:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    conn.sock = sock
+    return conn, path
+
+
+def _sync_acquire_connection(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str | None,
+    _pool: _SyncConnectionPool | None,
+    req_headers: dict[str, str],
+    url: str,
+) -> tuple[http.client.HTTPConnection, str]:
+    """Acquire a sync HTTP connection via proxy, pool, or direct creation.
+
+    Returns:
+        (connection, request_path).
+    """
+    if proxy:
+        if _is_socks_proxy(proxy):
+            return _sync_connect_via_socks5(
+                host, port, path, is_https, timeout, verify, proxy
+            )
+        return _sync_connect_via_proxy(
+            host, port, path, is_https, timeout, verify, proxy, req_headers, url
+        )
+
+    if _pool:
+        pooled_conn = _pool.acquire(host, port, is_https, timeout, verify)
+        if pooled_conn is not None:
+            req_headers["Connection"] = "keep-alive"
+            return pooled_conn, path
+
+    # Direct connection
+    if is_https:
+        ctx = _make_ssl_context(verify)
+        conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    else:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    return conn, path
+
+
+def _sync_release_or_close(
+    close_conn: bool,
+    _pool: _SyncConnectionPool | None,
+    proxy: str | None,
+    stream: bool,
+    resp_headers: dict[str, str],
+    host: str,
+    port: int,
+    is_https: bool,
+    conn: http.client.HTTPConnection,
+) -> None:
+    """Release a sync connection back to the pool or close it.
+
+    Pool reuse decision: a connection is returned to the pool
+    only when ALL of the following hold:
+      - close_conn is True (not handed off to streaming)
+      - a pool is active (_pool is not None)
+      - the request did not use a proxy
+      - the request is not streaming
+      - the server did not send "Connection: close"
+    Otherwise the connection is closed immediately.
+    """
+    if not close_conn:
+        return
+    if (
+        _pool
+        and not proxy
+        and not stream
+        and resp_headers.get("connection", "").lower() != "close"
+    ):
+        _pool.release(host, port, is_https, conn)
+    else:
+        conn.close()
+
+
+def _build_sync_response(
+    status: int,
+    resp_headers: dict[str, str],
+    url: str,
+    resp: http.client.HTTPResponse,
+    conn: http.client.HTTPConnection,
+    stream: bool,
+) -> tuple[Response | StreamingResponse, bool]:
+    """Build a final sync response (streaming or buffered).
+
+    Returns:
+        (response, close_conn) -- close_conn is False when streaming.
+    """
+    content_encoding = resp_headers.get("content-encoding", "")
+    if stream:
+        return StreamingResponse._from_sync(
+            status,
+            resp_headers,
+            url,
+            resp,
+            conn,
+            content_encoding=content_encoding,
+        ), False
+
+    resp_body = resp.read()
+    if content_encoding:
+        resp_body = _decompress_body(resp_body, content_encoding)
+    return Response(status, resp_headers, resp_body, url), True
+
+
+def _wrap_sync_errors(
+    exc: Exception,
+    host: str,
+    port: int,
+    url: str,
+    timeout: float,
+) -> HttpClientError:
+    """Translate low-level sync exceptions into httpclient exceptions."""
+    if isinstance(exc, (HttpTimeoutError, HttpConnectionError, TooManyRedirects)):
+        return exc
+    if isinstance(exc, (OSError, http.client.HTTPException)):
+        return HttpConnectionError(
+            f"Connection to {host}:{port} failed: {exc}",
+            host=host,
+            port=port,
+        )
+    if "timed out" in str(exc).lower():
+        msg = f"Request to {url} timed out after {timeout}s"
+        return HttpTimeoutError(msg, url=url, timeout=timeout)
+    return exc  # type: ignore[return-value]
+
+
+# -- Sync transport --
+
+
+def _sync_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: bytes | str | dict[str, str] | None = None,
+    json: Any = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    verify: bool = True,
+    stream: bool = False,
+    auth: tuple[str, str] | Auth | None = None,
+    proxy: str | None = None,
+    _pool: _SyncConnectionPool | None = None,
+) -> Response | StreamingResponse:
+    """Perform a synchronous HTTP request.
+
+    Phase structure (mirrors _async_request):
+        1-3. Request preparation (URL, body, headers, auth)
+        4. Redirect loop:
+           a. URL parsing + connection acquisition
+           b. Send request + read response
+           c. Handle redirects / digest auth / response construction
+           d. Connection lifecycle (pool release or close)
+    """
+    url, body, req_headers, auth_obj = _prepare_request(
+        method, url, headers, data, json, files, params, auth
+    )
+
+    redirects = 0
+    _digest_attempted = False
+    while True:
+        scheme, host, port, path, is_https = _parse_url(url)
+        close_conn = True
+        resp_headers: dict[str, str] = {}
+        try:
+            conn, request_path = _sync_acquire_connection(
+                host,
+                port,
+                path,
+                is_https,
+                timeout,
+                verify,
+                proxy,
+                _pool,
+                req_headers,
+                url,
+            )
+            if _pool and not proxy:
+                req_headers.setdefault("Connection", "keep-alive")
+
+            try:
+                conn.request(method, request_path, body=body, headers=req_headers)
+                resp = conn.getresponse()
+                resp_headers = {k.lower(): v for k, v in resp.getheaders()}
+                status = resp.status
+
+                if _is_redirect(status, resp_headers):
+                    resp.read()
+                    url, method, body = _compute_redirect(
+                        status,
+                        method,
+                        body,
+                        req_headers,
+                        resp_headers,
+                        scheme,
+                        host,
+                        port,
+                        url,
+                        redirects,
+                        max_redirects,
+                    )
+                    redirects += 1
+                    continue
+
+                if _should_attempt_digest(
+                    auth_obj, status, resp_headers, _digest_attempted
+                ):
+                    resp.read()
+                    www_auth = resp_headers["www-authenticate"]
+                    req_headers.update(
+                        auth_obj.auth_headers_from_challenge(method, path, www_auth)
+                    )
+                    _digest_attempted = True
+                    conn.close()
+                    continue
+
+                result, close_conn = _build_sync_response(
+                    status,
+                    resp_headers,
+                    url,
+                    resp,
+                    conn,
+                    stream,
+                )
+                return result
+            finally:
+                _sync_release_or_close(
+                    close_conn,
+                    _pool,
+                    proxy,
+                    stream,
+                    resp_headers,
+                    host,
+                    port,
+                    is_https,
+                    conn,
+                )
+        except Exception as exc:
+            wrapped = _wrap_sync_errors(exc, host, port, url, timeout)
+            if wrapped is exc:
+                raise
+            raise wrapped from exc
+
+
+# -- Async transport helpers --
+
+
+async def _async_read_response_headers(
+    reader: asyncio.StreamReader,
+    timeout: float,
+) -> tuple[int, dict[str, str]]:
+    """Read HTTP status line and headers from an asyncio StreamReader.
+
+    Does NOT consume the body -- the reader is left positioned at the
+    start of the response body.
+
+    Returns:
+        (status_code, headers_dict).
+    """
+    # Status line: "HTTP/1.1 200 OK\r\n"
+    status_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    status_str = status_line.decode("latin-1").rstrip("\r\n")
+    parts = status_str.split(" ", 2)
+    if len(parts) < 2:
+        raise HttpConnectionError(f"Malformed status line: {status_str}")
+    status_code = int(parts[1])
+
+    # Headers until empty line
+    headers: dict[str, str] = {}
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        decoded = line.decode("latin-1").rstrip("\r\n")
+        if not decoded:
+            break
+        if ":" in decoded:
+            k, v = decoded.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+
+    return status_code, headers
+
+
+async def _async_read_chunked_body(
+    reader: asyncio.StreamReader,
+    timeout: float,
+) -> bytes:
+    """Read a chunked transfer-encoded body from an asyncio StreamReader."""
+    parts: list[bytes] = []
+    while True:
+        size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        size_str = size_line.decode("latin-1").split(";")[0].strip()
+        if not size_str:
+            break
+        chunk_size = int(size_str, 16)
+        if chunk_size == 0:
+            await asyncio.wait_for(reader.readline(), timeout=timeout)  # trailing \r\n
+            break
+        data = await asyncio.wait_for(reader.readexactly(chunk_size), timeout=timeout)
+        await asyncio.wait_for(reader.readline(), timeout=timeout)  # trailing \r\n
+        parts.append(data)
+    return b"".join(parts)
+
+
+async def _async_read_body(
+    reader: asyncio.StreamReader,
+    headers: dict[str, str],
+    timeout: float,
+) -> bytes:
+    """Read the response body based on Content-Length or Transfer-Encoding.
+
+    Falls back to reading until EOF when neither header is present.
+    """
+    te = headers.get("transfer-encoding", "")
+    if te.lower() == "chunked":
+        return await _async_read_chunked_body(reader, timeout)
+
+    cl = headers.get("content-length")
+    if cl is not None:
+        length = int(cl)
+        if length == 0:
+            return b""
+        return await asyncio.wait_for(reader.readexactly(length), timeout=timeout)
+
+    # No Content-Length, no chunked -- read until EOF
+    return await asyncio.wait_for(reader.read(), timeout=timeout)
+
+
+# -- Async connection helpers --
+
+
+async def _async_connect_via_proxy_plain(
+    host: str,
+    port: int,
+    timeout: float,
+    proxy: str,
+    req_headers: dict[str, str],
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, str]:
+    """Connect to a plain HTTP target through a proxy.
+
+    Returns:
+        (reader, writer, request_path) where request_path is the full URL.
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(proxy_host, proxy_port),
+        timeout=timeout,
+    )
+    request_path = f"http://{host}:{port}/"  # will be overridden by caller
+    if proxy_user and proxy_pass:
+        req_headers["Proxy-Authorization"] = _proxy_auth_header(proxy_user, proxy_pass)
+    return reader, writer, request_path
+
+
+async def _async_connect_via_proxy_tunnel(
+    host: str,
+    port: int,
+    timeout: float,
+    verify: bool,
+    proxy: str,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Open a CONNECT tunnel through a proxy and upgrade to TLS.
+
+    Returns:
+        (reader, writer) with TLS already established.
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    proxy_reader, proxy_writer = await asyncio.wait_for(
+        asyncio.open_connection(proxy_host, proxy_port),
+        timeout=timeout,
+    )
+    connect_line = f"CONNECT {host}:{port} HTTP/1.1\r\n"
+    connect_headers = f"Host: {host}:{port}\r\n"
+    if proxy_user and proxy_pass:
+        connect_headers += (
+            f"Proxy-Authorization: {_proxy_auth_header(proxy_user, proxy_pass)}\r\n"
+        )
+    connect_headers += "\r\n"
+    proxy_writer.write((connect_line + connect_headers).encode("latin-1"))
+    await asyncio.wait_for(proxy_writer.drain(), timeout=timeout)
+    tunnel_status, _ = await _async_read_response_headers(proxy_reader, timeout)
+    if tunnel_status != 200:
+        proxy_writer.close()
+        # Tier 3: best-effort silent -- proxy tunnel teardown
+        try:
+            await proxy_writer.wait_closed()
+        except Exception:
+            pass
+        raise HttpConnectionError(
+            f"CONNECT tunnel failed: {tunnel_status}",
+            host=host,
+            port=port,
+        )
+    # Upgrade to TLS over the tunnel
+    ctx = _make_ssl_context(verify)
+    loop = asyncio.get_event_loop()
+    transport = proxy_writer.transport
+    new_transport = await loop.start_tls(
+        transport, transport.get_protocol(), ctx, server_hostname=host
+    )
+    proxy_writer._transport = new_transport  # type: ignore[attr-defined]
+    return proxy_reader, proxy_writer
+
+
+async def _async_connect_via_socks5(
+    host: str,
+    port: int,
+    timeout: float,
+    verify: bool,
+    is_https: bool,
+    proxy: str,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Open a SOCKS5 tunnel and optionally upgrade to TLS.
+
+    Returns:
+        (reader, writer) with TLS already established if target is HTTPS.
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(proxy_host, proxy_port),
+        timeout=timeout,
+    )
+    try:
+        await _socks5_handshake_async(
+            reader, writer, host, port, timeout, proxy_user, proxy_pass
+        )
+    except Exception:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+        raise
+
+    if is_https:
+        ctx = _make_ssl_context(verify)
+        loop = asyncio.get_event_loop()
+        transport = writer.transport
+        new_transport = await loop.start_tls(
+            transport, transport.get_protocol(), ctx, server_hostname=host
+        )
+        writer._transport = new_transport  # type: ignore[attr-defined]
+
+    return reader, writer
+
+
+async def _async_acquire_connection(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str | None,
+    _pool: _AsyncConnectionPool | None,
+    req_headers: dict[str, str],
+    url: str,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, str]:
+    """Acquire an async connection via proxy, pool, or direct creation.
+
+    Wraps connection errors into HttpConnectionError / HttpTimeoutError.
+
+    Returns:
+        (reader, writer, request_path).
+    """
+    try:
+        if proxy:
+            if _is_socks_proxy(proxy):
+                reader, writer = await _async_connect_via_socks5(
+                    host, port, timeout, verify, is_https, proxy
+                )
+                return reader, writer, path
+            if not is_https:
+                proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+                reader, writer = await asyncio.wait_for(
+                    asyncio.open_connection(proxy_host, proxy_port),
+                    timeout=timeout,
+                )
+                if proxy_user and proxy_pass:
+                    req_headers["Proxy-Authorization"] = _proxy_auth_header(
+                        proxy_user, proxy_pass
+                    )
+                return reader, writer, url
+            reader, writer = await _async_connect_via_proxy_tunnel(
+                host, port, timeout, verify, proxy
+            )
+            return reader, writer, path
+
+        if _pool:
+            result = await _pool.acquire(host, port, is_https, timeout, verify)
+            if result is not None:
+                reader, writer = result
+                req_headers["Connection"] = "keep-alive"
+                return reader, writer, path
+
+        # Direct connection
+        ctx = _make_ssl_context(verify) if is_https else None
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port, ssl=ctx),
+            timeout=timeout,
+        )
+        return reader, writer, path
+    except asyncio.TimeoutError:
+        msg = f"Connection to {host}:{port} timed out after {timeout}s"
+        raise HttpTimeoutError(msg, url=url, timeout=timeout)
+    except OSError as exc:
+        raise HttpConnectionError(
+            f"Connection to {host}:{port} failed: {exc}",
+            host=host,
+            port=port,
+        ) from exc
+
+
+def _build_raw_http_request(
+    method: str,
+    request_path: str,
+    host: str,
+    req_headers: dict[str, str],
+    use_pool: bool,
+    use_proxy: bool,
+) -> bytes:
+    """Construct raw HTTP/1.1 request bytes for async transport.
+
+    Args:
+        method: HTTP method.
+        request_path: The request path or full URL (for proxy).
+        host: Target hostname.
+        req_headers: Request headers dict.
+        use_pool: Whether connection pooling is active.
+        use_proxy: Whether a proxy is being used.
+
+    Returns:
+        Encoded HTTP/1.1 request bytes (without body).
+    """
+    request_line = f"{method} {request_path} HTTP/1.1\r\n"
+    header_lines = f"Host: {host}\r\n"
+    for k, v in req_headers.items():
+        header_lines += f"{k}: {v}\r\n"
+    if not use_pool or use_proxy:
+        header_lines += "Connection: close\r\n"
+    header_lines += "\r\n"
+    return (request_line + header_lines).encode("latin-1")
+
+
+async def _async_release_or_close(
+    close_writer: bool,
+    _pool: _AsyncConnectionPool | None,
+    proxy: str | None,
+    stream: bool,
+    resp_headers: dict[str, str],
+    host: str,
+    port: int,
+    is_https: bool,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Release an async connection back to the pool or close it.
+
+    Pool reuse decision: a connection is returned to the pool
+    only when ALL of the following hold:
+      - close_writer is True (not handed off to streaming)
+      - a pool is active (_pool is not None)
+      - the request did not use a proxy
+      - the request is not streaming
+      - the server did not send "Connection: close"
+    Otherwise the connection is closed immediately.
+    """
+    if not close_writer:
+        return
+    if (
+        _pool
+        and not proxy
+        and not stream
+        and resp_headers.get("connection", "").lower() != "close"
+    ):
+        await _pool.release(host, port, is_https, reader, writer)
+    else:
+        writer.close()
+        # Tier 3: best-effort silent -- wait_closed on direct close
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+async def _async_close_writer_silent(writer: asyncio.StreamWriter) -> None:
+    """Close an async writer, ignoring errors on wait_closed."""
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+
+
+def _build_async_streaming_response(
+    status: int,
+    resp_headers: dict[str, str],
+    url: str,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    timeout: float,
+) -> StreamingResponse:
+    """Build an async StreamingResponse from response metadata."""
+    content_encoding = resp_headers.get("content-encoding", "")
+    te = resp_headers.get("transfer-encoding", "")
+    is_chunked = te.lower() == "chunked"
+    cl = resp_headers.get("content-length")
+    content_length = int(cl) if cl else None
+    return StreamingResponse._from_async(
+        status,
+        resp_headers,
+        url,
+        reader,
+        writer,
+        is_chunked,
+        content_length,
+        timeout,
+        content_encoding=content_encoding,
+    )
+
+
+# -- Async transport --
+
+
+async def _async_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: bytes | str | dict[str, str] | None = None,
+    json: Any = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    verify: bool = True,
+    stream: bool = False,
+    auth: tuple[str, str] | Auth | None = None,
+    proxy: str | None = None,
+    _pool: _AsyncConnectionPool | None = None,
+) -> Response | StreamingResponse:
+    """Perform an asynchronous HTTP request using asyncio streams.
+
+    Phase structure (mirrors _sync_request):
+        1-3. Request preparation (URL, body, headers, auth)
+        4. Redirect loop:
+           a. URL parsing + connection acquisition
+           b. Send raw HTTP/1.1 request + read response headers
+           c. Handle redirects / digest auth / response construction
+           d. Connection lifecycle (pool release or close)
+    """
+    url, body, req_headers, auth_obj = _prepare_request(
+        method, url, headers, data, json, files, params, auth
+    )
+
+    redirects = 0
+    _digest_attempted = False
+    while True:
+        scheme, host, port, path, is_https = _parse_url(url)
+
+        reader, writer, request_path = await _async_acquire_connection(
+            host, port, path, is_https, timeout, verify, proxy, _pool, req_headers, url
+        )
+        if _pool and not proxy:
+            req_headers.setdefault("Connection", "keep-alive")
+
+        close_writer = True
+        resp_headers: dict[str, str] = {}
+        try:
+            raw_request = _build_raw_http_request(
+                method,
+                request_path,
+                host,
+                req_headers,
+                use_pool=bool(_pool),
+                use_proxy=bool(proxy),
+            )
+            writer.write(raw_request)
+            if body:
+                writer.write(body)
+            await asyncio.wait_for(writer.drain(), timeout=timeout)
+
+            status, resp_headers = await _async_read_response_headers(reader, timeout)
+
+            if _is_redirect(status, resp_headers):
+                await _async_read_body(reader, resp_headers, timeout)
+                url, method, body = _compute_redirect(
+                    status,
+                    method,
+                    body,
+                    req_headers,
+                    resp_headers,
+                    scheme,
+                    host,
+                    port,
+                    url,
+                    redirects,
+                    max_redirects,
+                )
+                redirects += 1
+                continue
+
+            if _should_attempt_digest(
+                auth_obj, status, resp_headers, _digest_attempted
+            ):
+                await _async_read_body(reader, resp_headers, timeout)
+                www_auth = resp_headers["www-authenticate"]
+                req_headers.update(
+                    auth_obj.auth_headers_from_challenge(method, path, www_auth)
+                )
+                _digest_attempted = True
+                await _async_close_writer_silent(writer)
+                close_writer = False
+                continue
+
+            if stream:
+                close_writer = False
+                return _build_async_streaming_response(
+                    status,
+                    resp_headers,
+                    url,
+                    reader,
+                    writer,
+                    timeout,
+                )
+
+            content_encoding = resp_headers.get("content-encoding", "")
+            resp_body = await _async_read_body(reader, resp_headers, timeout)
+            if content_encoding:
+                resp_body = _decompress_body(resp_body, content_encoding)
+            return Response(status, resp_headers, resp_body, url)
+        except asyncio.TimeoutError:
+            raise HttpTimeoutError(
+                f"Request to {url} timed out after {timeout}s",
+                url=url,
+                timeout=timeout,
+            )
+        finally:
+            await _async_release_or_close(
+                close_writer,
+                _pool,
+                proxy,
+                stream,
+                resp_headers,
+                host,
+                port,
+                is_https,
+                reader,
+                writer,
+            )
+
+
+# ── Request Building helpers (multipart, headers) ──
+
+
+def _prepare_body(
+    data: bytes | str | dict[str, str] | None = None,
+    json: Any = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+) -> tuple[bytes | None, str | None]:
+    """Prepare request body and content-type header.
+
+    Priority: json > files > data.
+    When files is provided and data is a dict, data fields are included
+    as text parts in the multipart body.
+
+    Returns:
+        (body_bytes, content_type) tuple.
+    """
+    if json is not None:
+        return _json.dumps(json, ensure_ascii=False).encode("utf-8"), "application/json"
+    if files is not None:
+        form_data = data if isinstance(data, dict) else None
+        return _encode_multipart(form_data, files)
+    if isinstance(data, str):
+        return data.encode("utf-8"), "application/x-www-form-urlencoded"
+    if isinstance(data, bytes):
+        return data, "application/octet-stream"
+    return None, None
+
+
+def _read_file_content(value: bytes | IO[bytes]) -> bytes:
+    """Read bytes from a file object or return bytes as-is."""
+    if isinstance(value, bytes):
+        return value
+    return value.read()
+
+
+def _get_filename(value: bytes | IO[bytes]) -> str:
+    """Extract filename from a file object, or return a default."""
+    if isinstance(value, bytes):
+        return "upload"
+    name = getattr(value, "name", None)
+    if name:
+        return os.path.basename(name)
+    return "upload"
+
+
+def _normalize_file_value(
+    value: Any,
+) -> tuple[str, bytes, str]:
+    """Normalize a files parameter value to (filename, content, content_type).
+
+    Accepted formats:
+        bytes / file object      -> ("upload"/basename, content, octet-stream)
+        (filename, content)      -> (filename, content, octet-stream)
+        (filename, content, ct)  -> (filename, content, ct)
+    """
+    if isinstance(value, (bytes, IO)) or hasattr(value, "read"):
+        fn = _get_filename(value)
+        ct = "application/octet-stream"
+        return fn, _read_file_content(value), ct
+    if isinstance(value, (tuple, list)):
+        if len(value) == 2:
+            fname, content = value
+            return fname, _read_file_content(content), "application/octet-stream"
+        if len(value) == 3:
+            fname, content, ct = value
+            return fname, _read_file_content(content), ct
+    raise ValueError(f"Invalid file value format: {type(value)}")
+
+
+def _encode_multipart(
+    data: dict[str, str] | None,
+    files: dict[str, Any] | list[tuple[str, Any]],
+) -> tuple[bytes, str]:
+    """Encode multipart/form-data body.
+
+    Args:
+        data: Optional form fields to include as text parts.
+        files: File fields as dict or list of (name, value) tuples.
+
+    Returns:
+        (body_bytes, content_type_with_boundary).
+    """
+    boundary = os.urandom(16).hex()
+    parts: list[bytes] = []
+
+    # Encode form data fields
+    if data:
+        for name, value in data.items():
+            part = (
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="{name}"\r\n'
+                f"\r\n"
+                f"{value}\r\n"
+            )
+            parts.append(part.encode("utf-8"))
+
+    # Encode file fields
+    items: list[tuple[str, Any]]
+    if isinstance(files, dict):
+        items = list(files.items())
+    else:
+        items = list(files)
+
+    for name, value in items:
+        filename, content, content_type = _normalize_file_value(value)
+        header = (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+            f"Content-Type: {content_type}\r\n"
+            f"\r\n"
+        )
+        parts.append(header.encode("utf-8") + content + b"\r\n")
+
+    # Final boundary
+    parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+
+    body = b"".join(parts)
+    content_type = f"multipart/form-data; boundary={boundary}"
+    return body, content_type
+
+
+def _merge_headers(
+    base: dict[str, str] | None,
+    extra: dict[str, str] | None,
+) -> dict[str, str]:
+    """Merge header dicts (case-insensitive merge, last wins)."""
+    merged: dict[str, str] = {}
+    for h in (base, extra):
+        if h:
+            for k, v in h.items():
+                merged[k] = v
+    return merged
+
+
+# ── Public API functions (get, post, put, etc.) ──
+
+# -- Sync convenience functions --
+
+
+def get(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a GET request."""
+    return _sync_request("GET", url, **kwargs)
+
+
+def post(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a POST request."""
+    return _sync_request("POST", url, **kwargs)
+
+
+def put(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a PUT request."""
+    return _sync_request("PUT", url, **kwargs)
+
+
+def patch(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a PATCH request."""
+    return _sync_request("PATCH", url, **kwargs)
+
+
+def delete(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a DELETE request."""
+    return _sync_request("DELETE", url, **kwargs)
+
+
+def head(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a HEAD request."""
+    return _sync_request("HEAD", url, **kwargs)
+
+
+def options(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an OPTIONS request."""
+    return _sync_request("OPTIONS", url, **kwargs)
+
+
+# -- Async convenience functions --
+
+
+async def async_get(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async GET request."""
+    return await _async_request("GET", url, **kwargs)
+
+
+async def async_post(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async POST request."""
+    return await _async_request("POST", url, **kwargs)
+
+
+async def async_put(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async PUT request."""
+    return await _async_request("PUT", url, **kwargs)
+
+
+async def async_patch(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async PATCH request."""
+    return await _async_request("PATCH", url, **kwargs)
+
+
+async def async_delete(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async DELETE request."""
+    return await _async_request("DELETE", url, **kwargs)
+
+
+async def async_head(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async HEAD request."""
+    return await _async_request("HEAD", url, **kwargs)
+
+
+async def async_options(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async OPTIONS request."""
+    return await _async_request("OPTIONS", url, **kwargs)
+
+
+# ── Client classes (Client, AsyncClient) ──
+
+
+class Client:
+    """Synchronous HTTP client session with connection pooling.
+
+    Thread-safe: uses a threading.Lock internally.
+
+    Usage::
+
+        with Client(headers={"Authorization": "Bearer token"}) as c:
+            r = c.get("https://api.example.com/data")
+    """
+
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        verify: bool = True,
+        auth: tuple[str, str] | Auth | None = None,
+        proxy: str | None = None,
+        pool_size: int = DEFAULT_POOL_SIZE,
+    ) -> None:
+        self._base_headers = headers or {}
+        self._timeout = timeout
+        self._max_redirects = max_redirects
+        self._verify = verify
+        self._auth = auth
+        self._proxy = proxy
+        self._pool = _SyncConnectionPool(pool_size)
+        self._lock = threading.Lock()
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> Response | StreamingResponse:
+        """Send an HTTP request."""
+        kwargs.setdefault("timeout", self._timeout)
+        kwargs.setdefault("max_redirects", self._max_redirects)
+        kwargs.setdefault("verify", self._verify)
+        kwargs.setdefault("auth", self._auth)
+        kwargs.setdefault("proxy", self._proxy)
+        kwargs["_pool"] = self._pool
+        kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
+        if kwargs.get("stream"):
+            return _sync_request(method, url, **kwargs)
+        with self._lock:
+            return _sync_request(method, url, **kwargs)
+
+    def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("POST", url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("PUT", url, **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("PATCH", url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("DELETE", url, **kwargs)
+
+    def head(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("HEAD", url, **kwargs)
+
+    def options(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("OPTIONS", url, **kwargs)
+
+    def close(self) -> None:
+        """Close all pooled connections."""
+        self._pool.close_all()
+
+    def __enter__(self) -> Client:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self._pool.close_all()
+
+
+class AsyncClient:
+    """Asynchronous HTTP client session with connection pooling.
+
+    Safe to use from a single asyncio task; for concurrent requests
+    from the same client, use asyncio.Lock internally.
+
+    Usage::
+
+        async with AsyncClient(headers={"Authorization": "Bearer token"}) as c:
+            r = await c.get("https://api.example.com/data")
+    """
+
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        verify: bool = True,
+        auth: tuple[str, str] | Auth | None = None,
+        proxy: str | None = None,
+        pool_size: int = DEFAULT_POOL_SIZE,
+    ) -> None:
+        self._base_headers = headers or {}
+        self._timeout = timeout
+        self._max_redirects = max_redirects
+        self._verify = verify
+        self._auth = auth
+        self._proxy = proxy
+        self._pool = _AsyncConnectionPool(pool_size)
+        self._lock = asyncio.Lock()
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> Response | StreamingResponse:
+        """Send an async HTTP request."""
+        kwargs.setdefault("timeout", self._timeout)
+        kwargs.setdefault("max_redirects", self._max_redirects)
+        kwargs.setdefault("verify", self._verify)
+        kwargs.setdefault("auth", self._auth)
+        kwargs.setdefault("proxy", self._proxy)
+        kwargs["_pool"] = self._pool
+        kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
+        if kwargs.get("stream"):
+            return await _async_request(method, url, **kwargs)
+        async with self._lock:
+            return await _async_request(method, url, **kwargs)
+
+    async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("GET", url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("POST", url, **kwargs)
+
+    async def put(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("PUT", url, **kwargs)
+
+    async def patch(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("PATCH", url, **kwargs)
+
+    async def delete(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("DELETE", url, **kwargs)
+
+    async def head(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("HEAD", url, **kwargs)
+
+    async def options(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("OPTIONS", url, **kwargs)
+
+    async def aclose(self) -> None:
+        """Close all pooled connections."""
+        await self._pool.close_all()
+
+    async def __aenter__(self) -> AsyncClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self._pool.close_all()

--- a/src/toolregistry/integrations/openapi/__init__.py
+++ b/src/toolregistry/integrations/openapi/__init__.py
@@ -1,4 +1,4 @@
-from ...utils import HttpxClientConfig
+from ...utils import HttpClientConfig, HttpxClientConfig
 from .integration import OpenAPIIntegration, OpenAPITool, OpenAPIToolWrapper
 from .utils import load_openapi_spec, load_openapi_spec_async
 
@@ -7,7 +7,8 @@ __all__ = [
     "OpenAPITool",
     "OpenAPIToolWrapper",
     # Helpers and utilities for OpenAPI integration.
-    "HttpxClientConfig",
+    "HttpClientConfig",
+    "HttpxClientConfig",  # deprecated alias
     "load_openapi_spec",
     "load_openapi_spec_async",
 ]

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -4,14 +4,14 @@ from typing import Any
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
-from ...utils import HttpxClientConfig, normalize_tool_name
+from ...utils import HttpClientConfig, normalize_tool_name
 
 
 class OpenAPIToolWrapper(BaseToolWrapper):
     """Wrapper class that provides both synchronous and asynchronous methods for OpenAPI tool calls.
 
     Args:
-        client_config (HttpxClientConfig): Configuration for the HTTP client.
+        client_config (HttpClientConfig): Configuration for the HTTP client.
         name (str): The name of the tool.
         method (str): The HTTP method (e.g., "get", "post").
         path (str): The API endpoint path.
@@ -21,7 +21,7 @@ class OpenAPIToolWrapper(BaseToolWrapper):
 
     def __init__(
         self,
-        client_config: HttpxClientConfig,
+        client_config: HttpClientConfig,
         name: str,
         method: str,
         path: str,
@@ -111,7 +111,7 @@ class OpenAPITool(Tool):
     @classmethod
     def from_openapi_spec(
         cls,
-        client_config: HttpxClientConfig,
+        client_config: HttpClientConfig,
         path: str,
         method: str,
         spec: dict[str, Any],
@@ -121,7 +121,7 @@ class OpenAPITool(Tool):
         """Create an OpenAPITool instance from an OpenAPI specification.
 
         Args:
-            client_config (HttpxClientConfig): Configuration for HTTP client.
+            client_config (HttpClientConfig): Configuration for HTTP client.
             path (str): API endpoint path.
             method (str): HTTP method.
             spec (Dict[str, Any]): The OpenAPI operation specification.
@@ -198,11 +198,11 @@ class OpenAPIIntegration:
 
     def __init__(self, registry: ToolRegistry) -> None:
         self.registry: ToolRegistry = registry
-        self._client_configs: list[HttpxClientConfig] = []
+        self._client_configs: list[HttpClientConfig] = []
 
     async def register_openapi_tools_async(
         self,
-        client_config: HttpxClientConfig,
+        client_config: HttpClientConfig,
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
@@ -210,7 +210,7 @@ class OpenAPIIntegration:
         """Asynchronously register all tools defined in an OpenAPI specification.
 
         Args:
-            client_config (HttpxClientConfig): Configuration for the HTTP client.
+            client_config (HttpClientConfig): Configuration for the HTTP client.
             openapi_spec (Dict[str, Any]): The OpenAPI specification dictionary.
             namespace (Union[bool, str]): Whether to prefix tool names with a namespace.
                 - If ``False``, no namespace is used.
@@ -254,7 +254,7 @@ class OpenAPIIntegration:
 
     def register_openapi_tools(
         self,
-        client_config: HttpxClientConfig,
+        client_config: HttpClientConfig,
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
@@ -262,7 +262,7 @@ class OpenAPIIntegration:
         """Synchronously register all tools defined in an OpenAPI specification.
 
         Args:
-            client_config (HttpxClientConfig): Configuration for the HTTP client.
+            client_config (HttpClientConfig): Configuration for the HTTP client.
             openapi_spec (Dict[str, Any]): The OpenAPI specification dictionary.
             namespace (Union[bool, str]): Whether to prefix tool names with a namespace.
                 - If ``False``, no namespace is used.

--- a/src/toolregistry/integrations/openapi/utils.py
+++ b/src/toolregistry/integrations/openapi/utils.py
@@ -2,9 +2,15 @@ import asyncio
 from typing import Any
 from urllib.parse import urlparse
 
-import httpx
 import jsonref
 import yaml
+
+from ..._vendor.httpclient import (
+    AsyncClient,
+    Client,
+    HttpClientError,
+    HTTPError,
+)
 
 
 def extract_base_url_from_specs(openapi_spec: dict[str, Any]) -> str | None:
@@ -58,27 +64,27 @@ def determine_urls(url: str) -> dict[str, Any]:
             return {"found": True, "schema_url": base_url, "base_api_url": base_api_url}
 
     # Test appending endpoints to base URL
-    with httpx.Client(timeout=5.0) as client:
+    with Client(timeout=5.0) as client:
         for endpoint in common_endpoints:
             full_url = f"{base_url}{endpoint}"
             try:
                 response = client.get(full_url)
                 if response.status_code == 200:
-                    content_type = response.headers.get("Content-Type", "").lower()
+                    content_type = response.headers.get("content-type", "").lower()
                     if "json" in content_type or "yaml" in content_type:
                         return {
                             "found": True,
                             "schema_url": full_url,
                             "base_api_url": base_url,
                         }
-            except httpx.RequestError:
+            except HttpClientError:
                 continue
 
     return {"found": False, "base_api_url": base_url}
 
 
 async def load_openapi_spec_async(uri: str) -> dict[str, Any]:
-    """Async version of load_openapi_spec using httpx.AsyncClient.
+    """Async version of load_openapi_spec using AsyncClient.
 
     Args:
         uri (str): URL or file path pointing to an OpenAPI specification.
@@ -103,7 +109,7 @@ async def load_openapi_spec_async(uri: str) -> dict[str, Any]:
             uri = results["schema_url"] if results["found"] else uri
 
             # timeout for network requests (e.g., 10 seconds)
-            async with httpx.AsyncClient(timeout=10) as client:
+            async with AsyncClient(timeout=10) as client:
                 response = await client.get(uri)
                 response.raise_for_status()
                 openapi_spec_content = response.content
@@ -121,12 +127,10 @@ async def load_openapi_spec_async(uri: str) -> dict[str, Any]:
 
     except yaml.YAMLError as e:
         raise ValueError(f"Failed to parse OpenAPI content: {e}")
-    except httpx.RequestError as e:
+    except HTTPError as e:
+        raise ValueError(f"HTTP error: {e.status_code} for {e.url}")
+    except HttpClientError as e:
         raise ValueError(f"Network error when fetching URI: {e}")
-    except httpx.HTTPStatusError as e:
-        raise ValueError(
-            f"HTTP error: {e.response.status_code} {e.response.reason_phrase}"
-        )
     except FileNotFoundError as e:
         raise FileNotFoundError(f"Invalid file path: {e}")
     except Exception as e:

--- a/src/toolregistry/integrations/openapi/utils.py
+++ b/src/toolregistry/integrations/openapi/utils.py
@@ -10,6 +10,7 @@ from ..._vendor.httpclient import (
     Client,
     HttpClientError,
     HTTPError,
+    Response,
 )
 
 
@@ -111,6 +112,7 @@ async def load_openapi_spec_async(uri: str) -> dict[str, Any]:
             # timeout for network requests (e.g., 10 seconds)
             async with AsyncClient(timeout=10) as client:
                 response = await client.get(uri)
+                assert isinstance(response, Response)
                 response.raise_for_status()
                 openapi_spec_content = response.content
 

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -1,81 +1,179 @@
 import re
-from typing import Literal, overload
+import warnings
+from typing import Any, Literal, overload
 
-import httpx
+from ._vendor.httpclient import AsyncClient, Client
 
 
-class HttpxClientConfig:
+class _BaseUrlClient:
+    """Sync HTTP client wrapper that prepends base_url to relative URLs."""
+
+    def __init__(self, client: Client, base_url: str) -> None:
+        self._client = client
+        self._base_url = base_url
+
+    def _url(self, path: str) -> str:
+        if path.startswith(("http://", "https://")):
+            return path
+        return self._base_url + path
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        return self._client.get(self._url(url), **kwargs)
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        return self._client.request(method, self._url(url), **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        return self._client.post(self._url(url), **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> Any:
+        return self._client.put(self._url(url), **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> Any:
+        return self._client.patch(self._url(url), **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> Any:
+        return self._client.delete(self._url(url), **kwargs)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "_BaseUrlClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class _BaseUrlAsyncClient:
+    """Async HTTP client wrapper that prepends base_url to relative URLs."""
+
+    def __init__(self, client: AsyncClient, base_url: str) -> None:
+        self._client = client
+        self._base_url = base_url
+
+    def _url(self, path: str) -> str:
+        if path.startswith(("http://", "https://")):
+            return path
+        return self._base_url + path
+
+    async def get(self, url: str, **kwargs: Any) -> Any:
+        return await self._client.get(self._url(url), **kwargs)
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        return await self._client.request(method, self._url(url), **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> Any:
+        return await self._client.post(self._url(url), **kwargs)
+
+    async def put(self, url: str, **kwargs: Any) -> Any:
+        return await self._client.put(self._url(url), **kwargs)
+
+    async def patch(self, url: str, **kwargs: Any) -> Any:
+        return await self._client.patch(self._url(url), **kwargs)
+
+    async def delete(self, url: str, **kwargs: Any) -> Any:
+        return await self._client.delete(self._url(url), **kwargs)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "_BaseUrlAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+
+class HttpClientConfig:
+    """Container for HTTP client configuration.
+
+    Creates zero-dependency HTTP clients with base URL support,
+    connection pooling, and both sync/async interfaces.
+
+    Args:
+        base_url: The base URL for the API. This is required.
+        headers: Custom request headers. Default is None.
+        timeout: Request timeout in seconds. Default is 10.0.
+        auth: Basic authentication credentials (username, password). Default is None.
+        **extra_options: Additional client parameters (e.g. verify, proxy, pool_size).
+    """
+
+    # Known parameters that map directly to Client/AsyncClient constructor
+    _KNOWN_CLIENT_PARAMS = {"verify", "proxy", "pool_size", "max_redirects"}
+
     def __init__(
         self,
         base_url: str,
         headers: dict[str, str] | None = None,
         timeout: float = 10.0,
         auth: tuple[str, str] | None = None,
-        **extra_options,
+        **extra_options: Any,
     ):
-        """
-        Container for httpx client configuration.
-
-        Args:
-            base_url (str): The base URL for the API. This is required.
-            headers (Optional[Dict[str, str]]): Custom request headers. Default is None.
-            timeout (float): Request timeout in seconds. Default is 10.0.
-            auth (Optional[Tuple[str, str]]): Basic authentication credentials (username, password). Default is None.
-            extra_options (Any): Additional httpx client parameters.
-        """
         self.base_url = base_url.rstrip("/")
         self.headers = headers or {}
         self.timeout = timeout
         self.auth = auth
         self.extra_options = extra_options
-        self._sync_client: httpx.Client | None = None
-        self._async_client: httpx.AsyncClient | None = None
+        self._sync_client: _BaseUrlClient | None = None
+        self._async_client: _BaseUrlAsyncClient | None = None
+
+    def _client_kwargs(self) -> dict[str, Any]:
+        """Build kwargs dict for Client/AsyncClient constructor."""
+        kwargs: dict[str, Any] = {
+            "headers": self.headers,
+            "timeout": self.timeout,
+            "auth": self.auth,
+        }
+        for key in self._KNOWN_CLIENT_PARAMS:
+            if key in self.extra_options:
+                kwargs[key] = self.extra_options[key]
+        return kwargs
 
     @overload
-    def to_client(self, use_async: Literal[False]) -> httpx.Client: ...
+    def to_client(self, use_async: Literal[False]) -> _BaseUrlClient: ...
 
     @overload
-    def to_client(self, use_async: Literal[True]) -> httpx.AsyncClient: ...
+    def to_client(self, use_async: Literal[True]) -> _BaseUrlAsyncClient: ...
 
     def to_client(self, use_async: bool = False):
-        """
-        Creates an httpx client instance.
+        """Create a new HTTP client instance.
 
         Args:
-            use_async (bool): Whether to create an asynchronous client. Default is False.
+            use_async: Whether to create an asynchronous client. Default is False.
 
         Returns:
-            Union[httpx.Client, httpx.AsyncClient]: An instance of httpx.Client or httpx.AsyncClient.
+            A _BaseUrlClient or _BaseUrlAsyncClient wrapping the underlying
+            zero-dependency client with base URL support.
         """
         return self._make_client(use_async=use_async)
 
     def _make_client(self, use_async: bool = False):
-        """Create a new httpx client instance.
+        """Create a new HTTP client instance.
 
         Args:
-            use_async (bool): Whether to create an asynchronous client.
+            use_async: Whether to create an asynchronous client.
 
         Returns:
-            Union[httpx.Client, httpx.AsyncClient]: A new client instance.
+            A _BaseUrlClient or _BaseUrlAsyncClient instance.
         """
-        client_class = httpx.AsyncClient if use_async else httpx.Client
-        return client_class(
-            base_url=self.base_url,
-            headers=self.headers,
-            timeout=self.timeout,
-            auth=self.auth,
-            **self.extra_options,
-        )
+        kwargs = self._client_kwargs()
+        if use_async:
+            raw = AsyncClient(**kwargs)
+            return _BaseUrlAsyncClient(raw, self.base_url)
+        else:
+            raw = Client(**kwargs)
+            return _BaseUrlClient(raw, self.base_url)
 
     @overload
     def get_persistent_client(
         self, use_async: Literal[False] = False
-    ) -> httpx.Client: ...
+    ) -> _BaseUrlClient: ...
 
     @overload
     def get_persistent_client(
         self, use_async: Literal[True] = ...
-    ) -> httpx.AsyncClient: ...
+    ) -> _BaseUrlAsyncClient: ...
 
     def get_persistent_client(self, use_async: bool = False):
         """Get or create a persistent client instance.
@@ -84,10 +182,10 @@ class HttpxClientConfig:
         multiple calls, enabling HTTP connection pooling.
 
         Args:
-            use_async (bool): Whether to return an async client.
+            use_async: Whether to return an async client.
 
         Returns:
-            Union[httpx.Client, httpx.AsyncClient]: A persistent client instance.
+            A persistent _BaseUrlClient or _BaseUrlAsyncClient instance.
         """
         if use_async:
             if self._async_client is None:
@@ -116,6 +214,21 @@ class HttpxClientConfig:
         if self._sync_client:
             self._sync_client.close()
             self._sync_client = None
+
+
+def HttpxClientConfig(*args: Any, **kwargs: Any) -> HttpClientConfig:
+    """Deprecated alias for HttpClientConfig.
+
+    .. deprecated::
+        Use ``HttpClientConfig`` instead. ``HttpxClientConfig`` will be
+        removed in a future release.
+    """
+    warnings.warn(
+        "HttpxClientConfig is deprecated, use HttpClientConfig instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return HttpClientConfig(*args, **kwargs)
 
 
 def normalize_tool_name(name: str) -> str:

--- a/tests/test_openapi_integration.py
+++ b/tests/test_openapi_integration.py
@@ -1,13 +1,14 @@
 """Tests for OpenAPI integration module."""
 
 import json
+from urllib.parse import urlparse
 
-import httpx
 import pytest
 
 pytest.importorskip("jsonref")
 
 from toolregistry import ToolRegistry  # noqa: E402
+from toolregistry._vendor.httpclient import HTTPError, Response  # noqa: E402
 from toolregistry.integrations.openapi.integration import (  # noqa: E402
     OpenAPIIntegration,
     OpenAPITool,
@@ -19,7 +20,158 @@ from toolregistry.integrations.openapi.utils import (  # noqa: E402
     load_openapi_spec,
     load_openapi_spec_async,
 )
-from toolregistry.utils import HttpxClientConfig  # noqa: E402
+from toolregistry.utils import HttpClientConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockRequest:
+    """Minimal request object for test handlers."""
+
+    def __init__(self, method: str, url: str, content: bytes = b"", params=None):
+        self.method = method
+        self.content = content
+        parsed = urlparse(url)
+        self.url = _MockUrl(url, parsed.path, params or {})
+
+
+class _MockUrl:
+    """Minimal URL object for test handlers."""
+
+    def __init__(self, full: str, path: str, params: dict):
+        self._full = full
+        self.path = path
+        self.params = params
+
+    def __str__(self):
+        return self._full
+
+
+def _mock_response(status_code: int, json_data=None, url: str = "") -> Response:
+    """Create a zerodep Response mimicking httpx.Response(status_code, json=...)."""
+    content = b""
+    headers: dict[str, str] = {}
+    if json_data is not None:
+        content = json.dumps(json_data).encode()
+        headers["content-type"] = "application/json"
+    return Response(status_code, headers, content, url)
+
+
+class _MockSyncClient:
+    """Mock sync client that dispatches to a handler function."""
+
+    def __init__(self, handler, base_url: str):
+        self._handler = handler
+        self._base_url = base_url
+
+    def _resolve(self, path: str) -> str:
+        if path.startswith(("http://", "https://")):
+            return path
+        return self._base_url + path
+
+    def _call(self, method: str, url: str, **kwargs) -> Response:
+        full_url = self._resolve(url)
+        content = b""
+        if "json" in kwargs:
+            content = json.dumps(kwargs["json"]).encode()
+        params = {}
+        if "params" in kwargs and kwargs["params"]:
+            params = {k: str(v) for k, v in kwargs["params"].items()}
+        req = _MockRequest(method, full_url, content, params)
+        return self._handler(req)
+
+    def get(self, url, **kwargs):
+        return self._call("GET", url, **kwargs)
+
+    def post(self, url, **kwargs):
+        return self._call("POST", url, **kwargs)
+
+    def put(self, url, **kwargs):
+        return self._call("PUT", url, **kwargs)
+
+    def delete(self, url, **kwargs):
+        return self._call("DELETE", url, **kwargs)
+
+    def request(self, method, url, **kwargs):
+        return self._call(method.upper(), url, **kwargs)
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class _MockAsyncClient:
+    """Mock async client that dispatches to a handler function."""
+
+    def __init__(self, handler, base_url: str):
+        self._handler = handler
+        self._base_url = base_url
+
+    def _resolve(self, path: str) -> str:
+        if path.startswith(("http://", "https://")):
+            return path
+        return self._base_url + path
+
+    async def _call(self, method: str, url: str, **kwargs) -> Response:
+        full_url = self._resolve(url)
+        content = b""
+        if "json" in kwargs:
+            content = json.dumps(kwargs["json"]).encode()
+        params = {}
+        if "params" in kwargs and kwargs["params"]:
+            params = {k: str(v) for k, v in kwargs["params"].items()}
+        req = _MockRequest(method, full_url, content, params)
+        return self._handler(req)
+
+    async def get(self, url, **kwargs):
+        return await self._call("GET", url, **kwargs)
+
+    async def post(self, url, **kwargs):
+        return await self._call("POST", url, **kwargs)
+
+    async def put(self, url, **kwargs):
+        return await self._call("PUT", url, **kwargs)
+
+    async def delete(self, url, **kwargs):
+        return await self._call("DELETE", url, **kwargs)
+
+    async def request(self, method, url, **kwargs):
+        return await self._call(method.upper(), url, **kwargs)
+
+    async def aclose(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _MockHttpClientConfig(HttpClientConfig):
+    """HttpClientConfig that returns mock clients using a handler function."""
+
+    def __init__(self, handler, base_url="http://test"):
+        super().__init__(base_url=base_url)
+        self._handler = handler
+
+    def _make_client(self, use_async=False):
+        if use_async:
+            return _MockAsyncClient(self._handler, self.base_url)
+        return _MockSyncClient(self._handler, self.base_url)
+
+
+def _make_config_with_mock(handler, base_url="http://test"):
+    """Create an HttpClientConfig backed by a mock handler."""
+    return _MockHttpClientConfig(handler, base_url=base_url)
 
 
 # ---------------------------------------------------------------------------
@@ -126,20 +278,6 @@ PETSTORE_SPEC = {
 }
 
 
-def _make_mock_transport(handler):
-    """Create a mock transport from a handler function."""
-    return httpx.MockTransport(handler)
-
-
-def _make_config_with_mock(handler, base_url="http://test"):
-    """Create an HttpxClientConfig backed by a mock transport."""
-    transport = _make_mock_transport(handler)
-    return HttpxClientConfig(
-        base_url=base_url,
-        transport=transport,
-    )
-
-
 # ===========================================================================
 # TestOpenAPIToolWrapper
 # ===========================================================================
@@ -151,9 +289,9 @@ class TestOpenAPIToolWrapper:
     def test_call_sync_get(self):
         """GET request returns JSON."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             assert request.method == "GET"
-            return httpx.Response(200, json={"pets": []})
+            return _mock_response(200, {"pets": []})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -170,11 +308,11 @@ class TestOpenAPIToolWrapper:
     def test_call_sync_post(self):
         """POST request sends JSON body."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             assert request.method == "POST"
             body = json.loads(request.content)
             assert body["name"] == "Fido"
-            return httpx.Response(201, json={"id": 1, "name": "Fido"})
+            return _mock_response(201, {"id": 1, "name": "Fido"})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -191,9 +329,9 @@ class TestOpenAPIToolWrapper:
     def test_call_sync_put(self):
         """PUT request sends JSON body."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             assert request.method == "PUT"
-            return httpx.Response(200, json={"updated": True})
+            return _mock_response(200, {"updated": True})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -210,9 +348,9 @@ class TestOpenAPIToolWrapper:
     def test_call_sync_delete(self):
         """DELETE request works."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             assert request.method == "DELETE"
-            return httpx.Response(200, json={"deleted": True})
+            return _mock_response(200, {"deleted": True})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -230,11 +368,10 @@ class TestOpenAPIToolWrapper:
     async def test_call_async_get(self):
         """Async GET request works."""
 
-        async def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={"async": True})
+        def handler(request):
+            return _mock_response(200, {"async": True})
 
-        transport = httpx.MockTransport(handler)
-        config = HttpxClientConfig(base_url="http://test", transport=transport)
+        config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
             client_config=config,
             name="list_pets",
@@ -250,12 +387,11 @@ class TestOpenAPIToolWrapper:
     async def test_call_async_post(self):
         """Async POST request sends JSON body."""
 
-        async def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             body = json.loads(request.content)
-            return httpx.Response(201, json={"name": body["name"]})
+            return _mock_response(201, {"name": body["name"]})
 
-        transport = httpx.MockTransport(handler)
-        config = HttpxClientConfig(base_url="http://test", transport=transport)
+        config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
             client_config=config,
             name="create_pet",
@@ -268,10 +404,10 @@ class TestOpenAPIToolWrapper:
         assert result["name"] == "Buddy"
 
     def test_call_sync_http_error(self):
-        """HTTP error raises HTTPStatusError."""
+        """HTTP error raises HTTPError."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(404, json={"error": "not found"})
+        def handler(request):
+            return _mock_response(404, {"error": "not found"})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -282,14 +418,14 @@ class TestOpenAPIToolWrapper:
             params=None,
             persistent=True,
         )
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(HTTPError):
             wrapper.call_sync()
 
     def test_call_sync_server_error(self):
-        """500 error raises HTTPStatusError."""
+        """500 error raises HTTPError."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(500, json={"error": "internal"})
+        def handler(request):
+            return _mock_response(500, {"error": "internal"})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -300,14 +436,14 @@ class TestOpenAPIToolWrapper:
             params=None,
             persistent=True,
         )
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(HTTPError):
             wrapper.call_sync()
 
     def test_call_sync_no_name_raises(self):
         """Calling with empty name raises ValueError."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={})
+        def handler(request):
+            return _mock_response(200, {})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -324,8 +460,8 @@ class TestOpenAPIToolWrapper:
     def test_non_persistent_client(self):
         """Non-persistent mode creates a new client per call."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={"ok": True})
+        def handler(request):
+            return _mock_response(200, {"ok": True})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -343,9 +479,9 @@ class TestOpenAPIToolWrapper:
         """GET request passes kwargs as query params."""
         captured = {}
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             captured["params"] = dict(request.url.params)
-            return httpx.Response(200, json={"ok": True})
+            return _mock_response(200, {"ok": True})
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -362,9 +498,11 @@ class TestOpenAPIToolWrapper:
 
     def test_process_args_positional(self):
         """Positional args are mapped to param names."""
+        captured = {}
 
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=dict(request.url.params))
+        def handler(request):
+            captured["params"] = dict(request.url.params)
+            return _mock_response(200, captured["params"])
 
         config = _make_config_with_mock(handler)
         wrapper = OpenAPIToolWrapper(
@@ -388,7 +526,7 @@ class TestOpenAPITool:
     """Tests for OpenAPITool.from_openapi_spec()."""
 
     def _make_tool(self, path="/pets", method="get", spec=None, **kwargs):
-        config = HttpxClientConfig(base_url="http://test")
+        config = HttpClientConfig(base_url="http://test")
         if spec is None:
             spec = PETSTORE_SPEC["paths"]["/pets"]["get"]
         return OpenAPITool.from_openapi_spec(
@@ -467,8 +605,6 @@ class TestOpenAPITool:
         """Operation with no parameters has no user-defined properties."""
         spec = {"operationId": "health_check", "parameters": []}
         tool = self._make_tool(spec=spec)
-        # The tool may have injected params (e.g. 'thought' from think_augment)
-        # but should have no user-defined params from the spec
         assert tool.parameters["required"] == []
 
 
@@ -480,16 +616,13 @@ class TestOpenAPITool:
 class TestOpenAPIIntegration:
     """Tests for OpenAPIIntegration."""
 
+    def _ok_handler(self, request):
+        return _mock_response(200, {"ok": True})
+
     def test_register_tools_from_spec(self):
         """Registers all tools from an OpenAPI spec."""
         registry = ToolRegistry(name="test")
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={"ok": True})
-
-        config = HttpxClientConfig(
-            base_url="http://test", transport=httpx.MockTransport(handler)
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC)
 
@@ -503,10 +636,7 @@ class TestOpenAPIIntegration:
     def test_register_with_namespace_string(self):
         """Namespace string is applied to all tools."""
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test",
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC, namespace="pet_api")
 
@@ -516,10 +646,7 @@ class TestOpenAPIIntegration:
     def test_register_with_namespace_true(self):
         """namespace=True derives from info.title."""
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test",
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC, namespace=True)
 
@@ -530,10 +657,7 @@ class TestOpenAPIIntegration:
     def test_register_with_namespace_false(self):
         """namespace=False means no prefix."""
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test",
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC, namespace=False)
 
@@ -554,10 +678,7 @@ class TestOpenAPIIntegration:
             },
         }
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test",
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, spec)
 
@@ -569,10 +690,7 @@ class TestOpenAPIIntegration:
     def test_close_cleans_up(self):
         """close() clears client configs."""
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test",
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC)
         assert len(integration._client_configs) == 1
@@ -582,13 +700,7 @@ class TestOpenAPIIntegration:
     async def test_register_async(self):
         """Async registration works."""
         registry = ToolRegistry(name="test")
-
-        async def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={"ok": True})
-
-        config = HttpxClientConfig(
-            base_url="http://test", transport=httpx.MockTransport(handler)
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         await integration.register_openapi_tools_async(config, PETSTORE_SPEC)
 
@@ -599,10 +711,7 @@ class TestOpenAPIIntegration:
     async def test_close_async(self):
         """Async close works."""
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test",
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
-        )
+        config = _make_config_with_mock(self._ok_handler)
         integration = OpenAPIIntegration(registry)
         await integration.register_openapi_tools_async(config, PETSTORE_SPEC)
         await integration.close_async()
@@ -620,15 +729,13 @@ class TestOpenAPIToolEndToEnd:
     def test_register_and_call_get(self):
         """Register tools and call a GET tool through the registry."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             if request.url.path == "/pets":
-                return httpx.Response(200, json=[{"id": 1, "name": "Fido"}])
-            return httpx.Response(404)
+                return _mock_response(200, [{"id": 1, "name": "Fido"}])
+            return _mock_response(404)
 
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test", transport=httpx.MockTransport(handler)
-        )
+        config = _make_config_with_mock(handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC)
 
@@ -641,16 +748,14 @@ class TestOpenAPIToolEndToEnd:
     def test_register_and_call_post(self):
         """Register tools and call a POST tool through the registry."""
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request):
             if request.method == "POST" and request.url.path == "/pets":
                 body = json.loads(request.content)
-                return httpx.Response(201, json={"id": 2, "name": body["name"]})
-            return httpx.Response(404)
+                return _mock_response(201, {"id": 2, "name": body["name"]})
+            return _mock_response(404)
 
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test", transport=httpx.MockTransport(handler)
-        )
+        config = _make_config_with_mock(handler)
         integration = OpenAPIIntegration(registry)
         integration.register_openapi_tools(config, PETSTORE_SPEC)
 
@@ -663,13 +768,11 @@ class TestOpenAPIToolEndToEnd:
     async def test_register_and_call_async(self):
         """Register tools and call asynchronously through the registry."""
 
-        async def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=[{"id": 1, "name": "Max"}])
+        def handler(request):
+            return _mock_response(200, [{"id": 1, "name": "Max"}])
 
         registry = ToolRegistry(name="test")
-        config = HttpxClientConfig(
-            base_url="http://test", transport=httpx.MockTransport(handler)
-        )
+        config = _make_config_with_mock(handler)
         integration = OpenAPIIntegration(registry)
         await integration.register_openapi_tools_async(config, PETSTORE_SPEC)
 

--- a/tests/test_persistent_connection.py
+++ b/tests/test_persistent_connection.py
@@ -1,6 +1,6 @@
 """Tests for persistent connection support in MCP and OpenAPI integrations.
 
-Covers MCPConnectionManager, HttpxClientConfig persistent clients,
+Covers MCPConnectionManager, HttpClientConfig persistent clients,
 ToolRegistry lifecycle (close / context manager), and backward compat.
 """
 
@@ -14,7 +14,7 @@ import pytest
 
 from toolregistry import ToolRegistry
 from toolregistry.integrations.mcp.connection import MCPConnectionManager
-from toolregistry.utils import HttpxClientConfig
+from toolregistry.utils import HttpClientConfig
 
 _SERVER_SCRIPT = str(Path(__file__).parent / "_mcp_test_server.py")
 
@@ -176,15 +176,15 @@ class TestMCPConnectionManagerHttp:
 
 
 # ---------------------------------------------------------------------------
-# HttpxClientConfig persistent client tests
+# HttpClientConfig persistent client tests
 # ---------------------------------------------------------------------------
 
 
-class TestHttpxClientConfigPersistent:
-    """Tests for HttpxClientConfig persistent client methods."""
+class TestHttpClientConfigPersistent:
+    """Tests for HttpClientConfig persistent client methods."""
 
     def test_get_persistent_client_sync(self):
-        config = HttpxClientConfig(base_url="http://localhost:9999")
+        config = HttpClientConfig(base_url="http://localhost:9999")
         client1 = config.get_persistent_client(use_async=False)
         client2 = config.get_persistent_client(use_async=False)
         assert client1 is client2
@@ -192,14 +192,14 @@ class TestHttpxClientConfigPersistent:
 
     @pytest.mark.asyncio
     async def test_get_persistent_client_async(self):
-        config = HttpxClientConfig(base_url="http://localhost:9999")
+        config = HttpClientConfig(base_url="http://localhost:9999")
         client1 = config.get_persistent_client(use_async=True)
         client2 = config.get_persistent_client(use_async=True)
         assert client1 is client2
         await config.close_async()
 
     def test_close_sync(self):
-        config = HttpxClientConfig(base_url="http://localhost:9999")
+        config = HttpClientConfig(base_url="http://localhost:9999")
         _ = config.get_persistent_client(use_async=False)
         assert config._sync_client is not None
         config.close()
@@ -207,7 +207,7 @@ class TestHttpxClientConfigPersistent:
 
     @pytest.mark.asyncio
     async def test_close_async(self):
-        config = HttpxClientConfig(base_url="http://localhost:9999")
+        config = HttpClientConfig(base_url="http://localhost:9999")
         _ = config.get_persistent_client(use_async=True)
         _ = config.get_persistent_client(use_async=False)
         assert config._async_client is not None
@@ -218,7 +218,7 @@ class TestHttpxClientConfigPersistent:
 
     def test_to_client_still_works(self):
         """to_client() should still create fresh clients (backward compat)."""
-        config = HttpxClientConfig(base_url="http://localhost:9999")
+        config = HttpClientConfig(base_url="http://localhost:9999")
         client1 = config.to_client(use_async=False)
         client2 = config.to_client(use_async=False)
         assert client1 is not client2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,15 @@
 """Unit tests for the utils module."""
 
-import httpx
+from toolregistry._vendor.httpclient import AsyncClient, Client
+from toolregistry.utils import HttpClientConfig, HttpxClientConfig, normalize_tool_name
 
-from toolregistry.utils import HttpxClientConfig, normalize_tool_name
 
-
-class TestHttpxClientConfig:
-    """Test cases for the HttpxClientConfig class."""
+class TestHttpClientConfig:
+    """Test cases for the HttpClientConfig class."""
 
     def test_initialization_with_minimal_params(self):
-        """Test HttpxClientConfig initialization with minimal parameters."""
-        config = HttpxClientConfig(base_url="https://api.example.com")
+        """Test HttpClientConfig initialization with minimal parameters."""
+        config = HttpClientConfig(base_url="https://api.example.com")
 
         assert config.base_url == "https://api.example.com"
         assert config.headers == {}
@@ -19,12 +18,12 @@ class TestHttpxClientConfig:
         assert config.extra_options == {}
 
     def test_initialization_with_all_params(self):
-        """Test HttpxClientConfig initialization with all parameters."""
+        """Test HttpClientConfig initialization with all parameters."""
         headers = {"Authorization": "Bearer token"}
         auth = ("username", "password")
-        extra_options = {"verify": False, "follow_redirects": True}
+        extra_options = {"verify": False, "max_redirects": 10}
 
-        config = HttpxClientConfig(
+        config = HttpClientConfig(
             base_url="https://api.example.com/",
             headers=headers,
             timeout=30.0,
@@ -40,25 +39,25 @@ class TestHttpxClientConfig:
 
     def test_base_url_trailing_slash_removal(self):
         """Test that trailing slash is removed from base_url."""
-        config = HttpxClientConfig(base_url="https://api.example.com/")
+        config = HttpClientConfig(base_url="https://api.example.com/")
 
         assert config.base_url == "https://api.example.com"
 
     def test_base_url_multiple_trailing_slashes(self):
         """Test that multiple trailing slashes are removed."""
-        config = HttpxClientConfig(base_url="https://api.example.com///")
+        config = HttpClientConfig(base_url="https://api.example.com///")
 
         assert config.base_url == "https://api.example.com"
 
     def test_headers_default_to_empty_dict(self):
         """Test that headers default to empty dict when None."""
-        config = HttpxClientConfig(base_url="https://api.example.com", headers=None)
+        config = HttpClientConfig(base_url="https://api.example.com", headers=None)
 
         assert config.headers == {}
 
     def test_to_client_sync(self):
-        """Test creating synchronous httpx client."""
-        config = HttpxClientConfig(
+        """Test creating synchronous client."""
+        config = HttpClientConfig(
             base_url="https://api.example.com",
             headers={"Content-Type": "application/json"},
             timeout=20.0,
@@ -68,15 +67,14 @@ class TestHttpxClientConfig:
 
         client = config.to_client(use_async=False)
 
-        assert isinstance(client, httpx.Client)
-        assert str(client.base_url) == "https://api.example.com"
-        assert client.headers["Content-Type"] == "application/json"
-        assert client.timeout == httpx.Timeout(20.0)
-        assert isinstance(client.auth, httpx.BasicAuth)
+        assert hasattr(client, "get")
+        assert hasattr(client, "request")
+        assert hasattr(client, "close")
+        assert isinstance(client._client, Client)
 
     def test_to_client_async(self):
-        """Test creating asynchronous httpx client."""
-        config = HttpxClientConfig(
+        """Test creating asynchronous client."""
+        config = HttpClientConfig(
             base_url="https://api.example.com",
             headers={"Content-Type": "application/json"},
             timeout=20.0,
@@ -86,47 +84,71 @@ class TestHttpxClientConfig:
 
         client = config.to_client(use_async=True)
 
-        assert isinstance(client, httpx.AsyncClient)
-        assert str(client.base_url) == "https://api.example.com"
-        assert client.headers["Content-Type"] == "application/json"
-        assert client.timeout == httpx.Timeout(20.0)
-        assert isinstance(client.auth, httpx.BasicAuth)
+        assert hasattr(client, "get")
+        assert hasattr(client, "request")
+        assert hasattr(client, "aclose")
+        assert isinstance(client._client, AsyncClient)
 
     def test_to_client_default_sync(self):
         """Test that to_client defaults to synchronous client."""
-        config = HttpxClientConfig(base_url="https://api.example.com")
+        config = HttpClientConfig(base_url="https://api.example.com")
 
         client = config.to_client()
 
-        assert isinstance(client, httpx.Client)
+        assert isinstance(client._client, Client)
 
     def test_to_client_with_extra_options(self):
         """Test creating client with extra options."""
-        config = HttpxClientConfig(
+        config = HttpClientConfig(
             base_url="https://api.example.com",
             verify=False,
-            follow_redirects=True,
             max_redirects=10,
         )
 
         client = config.to_client()
 
-        assert client.is_closed is False  # Client should be created successfully
+        assert client is not None  # Client should be created successfully
+
+    def test_base_url_prepended_to_relative_path(self):
+        """Test that base_url is prepended to relative paths."""
+        config = HttpClientConfig(base_url="https://api.example.com")
+        client = config.to_client(use_async=False)
+
+        assert client._url("/api/test") == "https://api.example.com/api/test"
+
+    def test_absolute_url_not_modified(self):
+        """Test that absolute URLs are passed through unchanged."""
+        config = HttpClientConfig(base_url="https://api.example.com")
+        client = config.to_client(use_async=False)
+
+        assert client._url("https://other.com/test") == "https://other.com/test"
+
+    def test_deprecated_alias(self):
+        """Test that HttpxClientConfig emits deprecation warning."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            config = HttpxClientConfig(base_url="https://api.example.com")
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "HttpxClientConfig" in str(w[0].message)
+            assert isinstance(config, HttpClientConfig)
 
 
-class TestHttpxClientConfigPersistentExtended:
+class TestHttpClientConfigPersistentExtended:
     """Additional tests for persistent client methods (supplements test_persistent_connection.py)."""
 
     def test_persistent_client_initial_state(self):
         """Test that persistent clients are initially None."""
-        config = HttpxClientConfig(base_url="https://api.example.com")
+        config = HttpClientConfig(base_url="https://api.example.com")
 
         assert config._sync_client is None
         assert config._async_client is None
 
     def test_to_client_creates_fresh_instances(self):
         """Test that to_client always creates fresh (non-persistent) instances."""
-        config = HttpxClientConfig(base_url="https://api.example.com")
+        config = HttpClientConfig(base_url="https://api.example.com")
         client1 = config.to_client(use_async=False)
         client2 = config.to_client(use_async=False)
 


### PR DESCRIPTION
## Summary

- Vendor `httpclient.py` from zerodep project into `_vendor/`, replacing `httpx` as the HTTP client for core functionality
- Rename `HttpxClientConfig` → `HttpClientConfig` (old name kept as deprecated alias with `DeprecationWarning`)
- Add `_BaseUrlClient` / `_BaseUrlAsyncClient` wrappers that prepend `base_url` to relative paths (zerodep httpclient has no `base_url` parameter unlike httpx)
- Replace httpx usage in `integrations/openapi/utils.py` with zerodep `Client` / `AsyncClient`
- Move `httpx` from core `dependencies` to `[mcp]` optional extras in `pyproject.toml`
- `httpx` remains in `integrations/mcp/client.py` since the mcp SDK requires it
- Rewrite OpenAPI integration tests to use mock client classes instead of `httpx.MockTransport`
- Update all examples to use `HttpClientConfig`

## Motivation

Reduces core dependency count — httpx is a substantial dependency that pulls in httpcore, h11, etc. The zerodep httpclient provides the same sync+async HTTP capabilities with zero external dependencies, aligning with the project's minimal-dependency philosophy.

## Test plan

- [x] All 852 tests pass (`pytest tests/ -x`)
- [x] `ruff check --fix` clean
- [x] `ruff format` clean
- [ ] Verify downstream `toolregistry-server` works with the new `HttpClientConfig` (it only uses `base_url` + `headers`)