### PR TITLE
ci: add pre-commit with ruff, split lint+test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,29 @@ on:
     branches: [master]
 
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Run pre-commit checks
+        uses: pre-commit/action@v3.0.1
+
+      - name: Install dependencies for ty
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Type check with ty
+        run: ty check src/
+
+  test:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -22,16 +42,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,test,mcp]"
-          pip install ruff ty websockets
-
-      - name: Lint with ruff
-        run: ruff check
-
-      - name: Check formatting with ruff
-        run: ruff format --check
-
-      - name: Type check with ty
-        run: ty check src/
 
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # TODO: enable after fixing existing type errors in tests/
+  # - repo: local
+  #   hooks:
+  #     - id: ty
+  #       name: ty check
+  #       entry: ty check src/
+  #       language: system
+  #       pass_filenames: false
+  #       require_serial: true
+  #       types: [python]
+
+  # TODO: enable after fixing existing complexity issues in src/
+  # - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+  #   rev: v4.2.0
+  #   hooks:
+  #     - id: complexipy
+  #       exclude: (_vendor|examples)/

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,25 @@ all: lint test build
 # Linting & Type Checking
 # ──────────────────────────────────────────────
 
-# Run ty type checker
+# Run all linting and type checking
 lint:
+	@echo "Running ruff check..."
+	ruff check
+	@echo "Running ruff format check..."
+	ruff format --check
 	@echo "Running ty check..."
-	ty check
-	@echo "Type check complete."
+	ty check src/
+	@echo "Running complexipy..."
+	complexipy .
+	@echo "All checks passed."
+
+# Auto-fix and format
+fmt:
+	@echo "Running ruff fix..."
+	ruff check --fix
+	@echo "Running ruff format..."
+	ruff format
+	@echo "Format complete."
 
 # ──────────────────────────────────────────────
 # Testing
@@ -54,7 +68,8 @@ help:
 	@echo "Available targets:"
 	@echo ""
 	@echo "Development:"
-	@echo "  lint    - Run ty type checker"
+	@echo "  lint    - Run ruff, ty, and complexipy checks"
+	@echo "  fmt     - Auto-fix and format with ruff"
 	@echo "  test    - Run tests with pytest"
 	@echo ""
 	@echo "Package targets:"
@@ -65,4 +80,4 @@ help:
 	@echo "Composite targets:"
 	@echo "  all     - Run lint, test, and build (default)"
 
-.PHONY: all lint test build push clean help
+.PHONY: all lint fmt test build push clean help


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with ruff check + ruff format hooks (pin v0.15.6)
- CI lint job uses `pre-commit/action@v3.0.1` for ruff, ty check stays separate
- Split single `lint-and-test` job into parallel `lint` and `test` jobs
- Remove manual `pip install ruff ty websockets` — ruff version now locked in pre-commit config
- Makefile: expand `lint` target (ruff + ty + complexipy), add `fmt` target

ty and complexipy hooks are commented out as TODO, pending follow-up PRs to fix existing issues.

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [ ] CI lint job passes with pre-commit/action
- [ ] CI test job passes independently