### PR TITLE
fix(ci): add missing websockets dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,test,mcp]"
+          pip install websockets
 
       - name: Run tests
         run: python -m pytest tests/ -v


### PR DESCRIPTION
## Summary
- Add `pip install websockets` to CI test job
- Required by `mcp` package's websocket client, was previously installed alongside `ruff ty websockets` which was removed in #142

## Test plan
- [ ] CI test job passes (no more `ModuleNotFoundError: No module named 'websockets'`)