### PR TITLE
ci: enable ty type check in pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,13 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Run pre-commit checks
-        uses: pre-commit/action@v3.0.1
-
       - name: Install dependencies for ty
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Type check with ty
-        run: ty check src/
+      - name: Run pre-commit checks
+        uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,16 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # TODO: enable after fixing existing type errors in tests/
-  # - repo: local
-  #   hooks:
-  #     - id: ty
-  #       name: ty check
-  #       entry: ty check src/
-  #       language: system
-  #       pass_filenames: false
-  #       require_serial: true
-  #       types: [python]
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check
+        description: Type check src/ with ty.
+        entry: ty check src/
+        language: system
+        pass_filenames: false
+        require_serial: true
+        types: [python]
 
   # TODO: enable after fixing existing complexity issues in src/
   # - repo: https://github.com/rohaquinlop/complexipy-pre-commit


### PR DESCRIPTION
## Summary
- Enable ty local hook in `.pre-commit-config.yaml` (checks `src/` only, skipping `tests/` which have known type errors)
- CI lint job now installs deps before pre-commit so ty can resolve imports
- Removes separate `ty check src/` step — ty is now managed by pre-commit

Follows #142.

## Test plan
- [x] `pre-commit run --all-files` passes locally (ruff + ty all green)
- [ ] CI lint job passes with ty in pre-commit
- [ ] CI test job unaffected