### PR TITLE
refactor: rename executor ExecutionStatus to HandleStatus

### DIFF
--- a/src/toolregistry/executor/__init__.py
+++ b/src/toolregistry/executor/__init__.py
@@ -10,7 +10,7 @@ from ._thread_backend import ThreadBackend
 from ._types import (
     CancelledError,
     ExecutionContext,
-    ExecutionStatus,
+    HandleStatus,
     ProgressReport,
 )
 
@@ -18,7 +18,7 @@ __all__ = [
     # Types
     "CancelledError",
     "ExecutionContext",
-    "ExecutionStatus",
+    "HandleStatus",
     "ProgressReport",
     # Protocol + ABC
     "ExecutionBackend",

--- a/src/toolregistry/executor/_process_backend.py
+++ b/src/toolregistry/executor/_process_backend.py
@@ -15,7 +15,7 @@ import cloudpickle
 
 from ._helpers import make_sync_wrapper
 from ._protocol import ExecutionHandle
-from ._types import ExecutionStatus, ProgressReport
+from ._types import HandleStatus, ProgressReport
 
 
 def _process_worker(
@@ -69,17 +69,17 @@ class ProcessExecutionHandle(ExecutionHandle):
     def cancel(self) -> bool:
         return self._future.cancel()
 
-    def status(self) -> ExecutionStatus:
+    def status(self) -> HandleStatus:
         if self._future.cancelled():
-            return ExecutionStatus.CANCELLED
+            return HandleStatus.CANCELLED
         if self._future.running():
-            return ExecutionStatus.RUNNING
+            return HandleStatus.RUNNING
         if self._future.done():
             exc = self._future.exception(timeout=0)
             if exc is not None:
-                return ExecutionStatus.FAILED
-            return ExecutionStatus.COMPLETED
-        return ExecutionStatus.PENDING
+                return HandleStatus.FAILED
+            return HandleStatus.COMPLETED
+        return HandleStatus.PENDING
 
     def result(self, timeout: float | None = None) -> Any:
         effective_timeout = timeout if timeout is not None else self._timeout

--- a/src/toolregistry/executor/_protocol.py
+++ b/src/toolregistry/executor/_protocol.py
@@ -6,7 +6,7 @@ import abc
 from typing import Any, Protocol, runtime_checkable
 from collections.abc import Callable
 
-from ._types import ExecutionStatus, ProgressReport
+from ._types import HandleStatus, ProgressReport
 
 
 class ExecutionHandle(abc.ABC):
@@ -22,7 +22,7 @@ class ExecutionHandle(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def status(self) -> ExecutionStatus:
+    def status(self) -> HandleStatus:
         """Return the current execution status."""
         ...
 

--- a/src/toolregistry/executor/_thread_backend.py
+++ b/src/toolregistry/executor/_thread_backend.py
@@ -14,7 +14,7 @@ from ._protocol import ExecutionHandle
 from ._types import (
     CancelledError,
     ExecutionContext,
-    ExecutionStatus,
+    HandleStatus,
     ProgressReport,
 )
 
@@ -49,19 +49,19 @@ class ThreadExecutionHandle(ExecutionHandle):
             self._ctx._request_cancel()
         return cancelled or (self._ctx is not None)
 
-    def status(self) -> ExecutionStatus:
+    def status(self) -> HandleStatus:
         if self._future.cancelled():
-            return ExecutionStatus.CANCELLED
+            return HandleStatus.CANCELLED
         if self._future.running():
-            return ExecutionStatus.RUNNING
+            return HandleStatus.RUNNING
         if self._future.done():
             exc = self._future.exception(timeout=0)
             if isinstance(exc, CancelledError):
-                return ExecutionStatus.CANCELLED
+                return HandleStatus.CANCELLED
             if exc is not None:
-                return ExecutionStatus.FAILED
-            return ExecutionStatus.COMPLETED
-        return ExecutionStatus.PENDING
+                return HandleStatus.FAILED
+            return HandleStatus.COMPLETED
+        return HandleStatus.PENDING
 
     def result(self, timeout: float | None = None) -> Any:
         effective_timeout = timeout if timeout is not None else self._timeout

--- a/src/toolregistry/executor/_types.py
+++ b/src/toolregistry/executor/_types.py
@@ -9,8 +9,8 @@ from typing import Any
 from collections.abc import Callable
 
 
-class ExecutionStatus(str, enum.Enum):
-    """Lifecycle status of a single execution."""
+class HandleStatus(str, enum.Enum):
+    """Lifecycle status of a single execution handle."""
 
     PENDING = "pending"
     RUNNING = "running"

--- a/tests/test_executor/test_process_backend.py
+++ b/tests/test_executor/test_process_backend.py
@@ -3,7 +3,7 @@
 import pytest
 
 from toolregistry.executor import (
-    ExecutionStatus,
+    HandleStatus,
     ProcessPoolBackend,
 )
 
@@ -24,7 +24,7 @@ class TestProcessPoolBackend:
         try:
             handle = backend.submit(_add, {"x": 3, "y": 4})
             assert handle.result(timeout=10) == 7
-            assert handle.status() == ExecutionStatus.COMPLETED
+            assert handle.status() == HandleStatus.COMPLETED
         finally:
             backend.shutdown()
 
@@ -46,7 +46,7 @@ class TestProcessPoolBackend:
             handle = backend.submit(_fail, {})
             with pytest.raises(ValueError, match="process boom"):
                 handle.result(timeout=10)
-            assert handle.status() == ExecutionStatus.FAILED
+            assert handle.status() == HandleStatus.FAILED
         finally:
             backend.shutdown()
 

--- a/tests/test_executor/test_thread_backend.py
+++ b/tests/test_executor/test_thread_backend.py
@@ -7,7 +7,7 @@ import pytest
 
 from toolregistry.executor import (
     ExecutionContext,
-    ExecutionStatus,
+    HandleStatus,
     ThreadBackend,
 )
 
@@ -22,7 +22,7 @@ class TestThreadBackend:
 
             handle = backend.submit(add, {"x": 3, "y": 4})
             assert handle.result() == 7
-            assert handle.status() == ExecutionStatus.COMPLETED
+            assert handle.status() == HandleStatus.COMPLETED
         finally:
             backend.shutdown()
 
@@ -79,7 +79,7 @@ class TestThreadBackend:
             handle = backend.submit(fail, {})
             with pytest.raises(ValueError, match="boom"):
                 handle.result(timeout=2)
-            assert handle.status() == ExecutionStatus.FAILED
+            assert handle.status() == HandleStatus.FAILED
         finally:
             backend.shutdown()
 

--- a/tests/test_executor/test_types.py
+++ b/tests/test_executor/test_types.py
@@ -5,21 +5,21 @@ import pytest
 from toolregistry.executor import (
     CancelledError,
     ExecutionContext,
-    ExecutionStatus,
+    HandleStatus,
     ProgressReport,
 )
 
 
-class TestExecutionStatus:
+class TestHandleStatus:
     def test_enum_values(self):
-        assert ExecutionStatus.PENDING == "pending"
-        assert ExecutionStatus.RUNNING == "running"
-        assert ExecutionStatus.COMPLETED == "completed"
-        assert ExecutionStatus.FAILED == "failed"
-        assert ExecutionStatus.CANCELLED == "cancelled"
+        assert HandleStatus.PENDING == "pending"
+        assert HandleStatus.RUNNING == "running"
+        assert HandleStatus.COMPLETED == "completed"
+        assert HandleStatus.FAILED == "failed"
+        assert HandleStatus.CANCELLED == "cancelled"
 
     def test_is_str_enum(self):
-        assert isinstance(ExecutionStatus.PENDING, str)
+        assert isinstance(HandleStatus.PENDING, str)
 
 
 class TestProgressReport:


### PR DESCRIPTION
## Summary

- Rename `ExecutionStatus` in `executor/` to `HandleStatus` to disambiguate from `admin.ExecutionStatus`
- The two enums model different concepts:
  - **`HandleStatus`** (executor): runtime lifecycle — `PENDING → RUNNING → COMPLETED/FAILED/CANCELLED`
  - **`ExecutionStatus`** (admin): final outcome logging — `SUCCESS/ERROR/DISABLED`
- Pure rename, no behavior change

## Files changed (8)

- `executor/_types.py` — class definition
- `executor/__init__.py` — re-export
- `executor/_protocol.py` — abstract method return type
- `executor/_process_backend.py` — implementation
- `executor/_thread_backend.py` — implementation
- `tests/test_executor/test_types.py`
- `tests/test_executor/test_thread_backend.py`
- `tests/test_executor/test_process_backend.py`

## Test plan

- [x] 852 tests pass
- [x] ruff / ty / complexipy all pass