### PR TITLE
refactor(#129): separate Tool.run() exception handling from LLM error formatting

### DIFF
--- a/src/toolregistry/admin/execution_log.py
+++ b/src/toolregistry/admin/execution_log.py
@@ -18,6 +18,7 @@ class ExecutionStatus(str, Enum):
 
     SUCCESS = "success"
     ERROR = "error"
+    TIMEOUT = "timeout"
     DISABLED = "disabled"
 
 
@@ -32,11 +33,13 @@ class ExecutionLogEntry:
         id: Unique identifier (UUID) for this log entry.
         tool_name: Name of the executed tool.
         timestamp: When the execution occurred.
-        status: Execution status (success, error, or disabled).
+        status: Execution status (success, error, timeout, or disabled).
         duration_ms: Execution duration in milliseconds.
         arguments: Input arguments passed to the tool.
         result: Execution result (only for successful executions).
         error: Error message (only for failed executions).
+        exception_type: Qualified name of the exception class (e.g. "ValueError").
+        traceback: Formatted traceback string from the exception.
         metadata: Additional metadata about the execution.
     """
 
@@ -48,6 +51,8 @@ class ExecutionLogEntry:
     arguments: dict[str, Any]
     result: Any = None
     error: str | None = None
+    exception_type: str | None = None
+    traceback: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -59,6 +64,8 @@ class ExecutionLogEntry:
         arguments: dict[str, Any],
         result: Any = None,
         error: str | None = None,
+        exception_type: str | None = None,
+        traceback: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> "ExecutionLogEntry":
         """Create a new ExecutionLogEntry with auto-generated id and timestamp.
@@ -70,6 +77,8 @@ class ExecutionLogEntry:
             arguments: Input arguments passed to the tool.
             result: Execution result (for successful executions).
             error: Error message (for failed executions).
+            exception_type: Qualified name of the exception class.
+            traceback: Formatted traceback string.
             metadata: Additional metadata.
 
         Returns:
@@ -84,6 +93,8 @@ class ExecutionLogEntry:
             arguments=arguments,
             result=result,
             error=error,
+            exception_type=exception_type,
+            traceback=traceback,
             metadata=metadata or {},
         )
 

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -32,6 +32,7 @@ class ChangeEventType(str, Enum):
     PERMISSION_DENIED = "permission_denied"
     PERMISSION_ASKED = "permission_asked"
     METADATA_UPDATE = "metadata_update"
+    TOOL_ERROR = "tool_error"
 
 
 @dataclass(frozen=True)

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -471,6 +471,32 @@ class Tool(BaseModel):
             validated_params = model.model_dump_one_level()
         return validated_params
 
+    def run_raw(self, parameters: dict[str, Any]) -> Any:
+        """Execute tool synchronously, raising on failure.
+
+        Unlike ``run()``, this method does **not** catch exceptions — they
+        propagate to the caller, preserving full stack-trace information.
+
+        Args:
+            parameters: Input parameters for the tool.
+
+        Returns:
+            The tool execution result.
+
+        Raises:
+            Exception: Any exception raised during validation or execution.
+
+        Note:
+            Result size truncation (via ``max_result_size``) is only applied
+            when tools are executed through
+            ``ToolRegistry.execute_tool_calls()``. Direct calls return raw
+            results without truncation.
+        """
+        if not self._has_native_thought_param():
+            parameters = {k: v for k, v in parameters.items() if k != "thought"}
+        validated_params = self._validate_parameters(parameters)
+        return self.callable(**validated_params)
+
     def run(self, parameters: dict[str, Any]) -> Any:
         """Execute tool synchronously.
 
@@ -488,14 +514,58 @@ class Tool(BaseModel):
             when tools are executed through
             ``ToolRegistry.execute_tool_calls()``. Direct calls to ``run()``
             return raw results without truncation.
+
+        .. deprecated::
+            When an exception is caught, ``run()`` returns an error string.
+            This behaviour is deprecated — use ``run_raw()`` to get
+            exceptions directly. In a future version ``run()`` will raise.
         """
         try:
-            if not self._has_native_thought_param():
-                parameters = {k: v for k, v in parameters.items() if k != "thought"}
-            validated_params = self._validate_parameters(parameters)
-            return self.callable(**validated_params)
+            return self.run_raw(parameters)
         except Exception as e:
+            warnings.warn(
+                "Tool.run() caught an exception and returned an error string. "
+                "This behavior is deprecated; use Tool.run_raw() for exceptions. "
+                "In a future version, run() will also raise.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return f"Error executing {self.name}: {str(e)}"
+
+    async def arun_raw(self, parameters: dict[str, Any]) -> Any:
+        """Execute tool asynchronously, raising on failure.
+
+        Unlike ``arun()``, this method does **not** catch exceptions — they
+        propagate to the caller, preserving full stack-trace information.
+
+        Args:
+            parameters: Input parameters for the tool.
+
+        Returns:
+            The tool execution result.
+
+        Raises:
+            NotImplementedError: If async execution is unsupported.
+            Exception: Any exception raised during validation or execution.
+
+        Note:
+            Result size truncation (via ``max_result_size``) is only applied
+            when tools are executed through
+            ``ToolRegistry.execute_tool_calls()``. Direct calls return raw
+            results without truncation.
+        """
+        if not self._has_native_thought_param():
+            parameters = {k: v for k, v in parameters.items() if k != "thought"}
+        validated_params = self._validate_parameters(parameters)
+
+        if inspect.iscoroutinefunction(self.callable):
+            return await self.callable(**validated_params)
+        elif hasattr(self.callable, "__call__"):
+            return await self.callable(**validated_params)
+        raise NotImplementedError(
+            "Async execution requires either an async function (coroutine) "
+            "or a callable whose __call__ method is async or returns an awaitable object."
+        )
 
     async def arun(self, parameters: dict[str, Any]) -> Any:
         """Execute tool asynchronously.
@@ -515,21 +585,22 @@ class Tool(BaseModel):
             when tools are executed through
             ``ToolRegistry.execute_tool_calls()``. Direct calls to ``arun()``
             return raw results without truncation.
+
+        .. deprecated::
+            When an exception is caught, ``arun()`` returns an error string.
+            This behaviour is deprecated — use ``arun_raw()`` to get
+            exceptions directly. In a future version ``arun()`` will raise.
         """
         try:
-            if not self._has_native_thought_param():
-                parameters = {k: v for k, v in parameters.items() if k != "thought"}
-            validated_params = self._validate_parameters(parameters)
-
-            if inspect.iscoroutinefunction(self.callable):
-                return await self.callable(**validated_params)
-            elif hasattr(self.callable, "__call__"):
-                return await self.callable(**validated_params)
-            raise NotImplementedError(
-                "Async execution requires either an async function (coroutine) "
-                "or a callable whose __call__ method is async or returns an awaitable object."
-            )
+            return await self.arun_raw(parameters)
         except Exception as e:
+            warnings.warn(
+                "Tool.arun() caught an exception and returned an error string. "
+                "This behavior is deprecated; use Tool.arun_raw() for exceptions. "
+                "In a future version, arun() will also raise.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return f"Error executing {self.name}: {str(e)}"
 
     def update_namespace(

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -4,7 +4,9 @@ import logging
 import random
 import string
 import time
+import traceback as tb_module
 import warnings
+from dataclasses import dataclass
 from typing import Any, Literal
 from collections.abc import Callable
 
@@ -37,6 +39,21 @@ from ._mixins import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ToolError:
+    """Internal sentinel for structured error propagation.
+
+    Used by ``_collect_handle_result`` and ``_submit_tool_call`` to carry
+    exception metadata through the execution pipeline without relying on
+    string-prefix detection.
+    """
+
+    message: str
+    exception_type: str | None = None
+    traceback_str: str | None = None
+    is_timeout: bool = False
 
 
 class ToolRegistry(
@@ -467,6 +484,8 @@ class ToolRegistry(
         *,
         result: str | None = None,
         error: str | None = None,
+        exception_type: str | None = None,
+        traceback: str | None = None,
     ) -> None:
         """Append an entry to the execution log if logging is enabled.
 
@@ -477,6 +496,8 @@ class ToolRegistry(
             arguments: Tool call arguments.
             result: Optional result string.
             error: Optional error string.
+            exception_type: Optional qualified exception class name.
+            traceback: Optional formatted traceback string.
         """
         if self._execution_log is None:
             return
@@ -489,6 +510,8 @@ class ToolRegistry(
             arguments=arguments,
             result=result,
             error=error,
+            exception_type=exception_type,
+            traceback=traceback,
         )
         self._execution_log.add(entry)
 
@@ -498,7 +521,7 @@ class ToolRegistry(
         backend: Any,
         call_arguments: dict[str, dict],
         mode: str,
-    ) -> Any | str:
+    ) -> Any | _ToolError:
         """Submit a single tool call for execution.
 
         Args:
@@ -508,7 +531,7 @@ class ToolRegistry(
             mode: Current execution mode ("process" or "thread").
 
         Returns:
-            An ExecutionHandle on success, or an error string on failure.
+            An ExecutionHandle on success, or a ``_ToolError`` on failure.
         """
         function_name = tc.name
         function_args = call_arguments.get(tc.id, {})
@@ -518,7 +541,9 @@ class ToolRegistry(
         callable_func = tool_obj.callable if tool_obj else None
 
         if callable_func is None:
-            return f"Error: Tool '{function_name}' not found or callable is None"
+            return _ToolError(
+                message=f"Error: Tool '{function_name}' not found or callable is None",
+            )
 
         per_call_timeout = (
             tool_obj.metadata.timeout if tool_obj and tool_obj.metadata else None
@@ -541,26 +566,44 @@ class ToolRegistry(
                         timeout=per_call_timeout,
                     )
                 except Exception as e2:
-                    return f"Error preparing tool call {function_name}: {e2!s}"
-            return f"Error preparing tool call {function_name}: {e!s}"
+                    return _ToolError(
+                        message=f"Error preparing tool call {function_name}: {e2!s}",
+                        exception_type=type(e2).__qualname__,
+                        traceback_str=tb_module.format_exc(),
+                    )
+            return _ToolError(
+                message=f"Error preparing tool call {function_name}: {e!s}",
+                exception_type=type(e).__qualname__,
+                traceback_str=tb_module.format_exc(),
+            )
 
-    def _collect_handle_result(self, handle: Any, tool_name: str) -> str | list:
-        """Wait for a handle and return the finalized result or error string.
+    def _collect_handle_result(
+        self, handle: Any, tool_name: str
+    ) -> str | list | _ToolError:
+        """Wait for a handle and return the finalized result or a ``_ToolError``.
 
         Args:
             handle: An ExecutionHandle to collect.
             tool_name: Name of the tool (for error messages and finalization).
 
         Returns:
-            The finalized result string/list, or an error message.
+            The finalized result string/list, or a ``_ToolError`` on failure.
         """
         try:
             result = handle.result()
             return self._finalize_result(result, tool_name)
         except TimeoutError:
-            return f"Error: Tool '{tool_name}' timed out"
+            return _ToolError(
+                message=f"Error: Tool '{tool_name}' timed out",
+                exception_type="TimeoutError",
+                is_timeout=True,
+            )
         except Exception as e:
-            return f"Error executing {tool_name}: {e!s}"
+            return _ToolError(
+                message=f"Error executing {tool_name}: {e!s}",
+                exception_type=type(e).__qualname__,
+                traceback_str=tb_module.format_exc(),
+            )
 
     def execute_tool_calls(
         self,
@@ -581,7 +624,6 @@ class ToolRegistry(
             are ``str`` for normal results or ``list[ContentBlock]`` for
             multimodal results (e.g. images).
         """
-        from .admin import ExecutionStatus
         from .executor import ExecutionHandle
 
         generic_tool_calls = convert_tool_calls(tool_calls)
@@ -602,42 +644,94 @@ class ToolRegistry(
         )
 
         handles: list[tuple[Any, ExecutionHandle]] = []
+        # Map call ID → raw result (_ToolError or success value)
+        raw_results: dict[str, Any] = {}
 
         for tc in enabled_calls:
             handle_or_error = self._submit_tool_call(tc, backend, call_arguments, mode)
-            if isinstance(handle_or_error, str):
-                tool_responses[tc.id] = handle_or_error
+            if isinstance(handle_or_error, _ToolError):
+                raw_results[tc.id] = handle_or_error
+                tool_responses[tc.id] = handle_or_error.message
                 continue
 
             if has_unsafe:
-                tool_responses[tc.id] = self._collect_handle_result(
-                    handle_or_error, tc.name
+                result = self._collect_handle_result(handle_or_error, tc.name)
+                raw_results[tc.id] = result
+                tool_responses[tc.id] = (
+                    result.message if isinstance(result, _ToolError) else result
                 )
             else:
                 handles.append((tc, handle_or_error))
 
         for tc, handle in handles:
-            tool_responses[tc.id] = self._collect_handle_result(handle, tc.name)
+            result = self._collect_handle_result(handle, tc.name)
+            raw_results[tc.id] = result
+            tool_responses[tc.id] = (
+                result.message if isinstance(result, _ToolError) else result
+            )
 
-        # Log executed tool calls
-        if self._execution_log is not None:
-            end_time = time.perf_counter()
-            for tc in enabled_calls:
-                start_time = call_start_times.get(tc.id, end_time)
-                duration_ms = (end_time - start_time) * 1000
-                response = tool_responses.get(tc.id, "")
-                response_str = str(response)
-                is_error = response_str.startswith("Error")
-                self._log_entry(
-                    tc.name,
-                    ExecutionStatus.ERROR if is_error else ExecutionStatus.SUCCESS,
-                    duration_ms,
-                    call_arguments.get(tc.id, {}),
-                    result=None if is_error else response_str,
-                    error=response_str if is_error else None,
-                )
+        # Log executed tool calls and emit error events
+        self._log_tool_call_results(
+            enabled_calls, raw_results, call_start_times, call_arguments
+        )
 
         return tool_responses
+
+    def _log_tool_call_results(
+        self,
+        enabled_calls: list[Any],
+        raw_results: dict[str, Any],
+        call_start_times: dict[str, float],
+        call_arguments: dict[str, dict],
+    ) -> None:
+        """Log execution results and emit error events for completed tool calls.
+
+        Args:
+            enabled_calls: List of tool calls that were executed.
+            raw_results: Map of call ID to raw result (_ToolError or success value).
+            call_start_times: Map of call ID to start timestamp.
+            call_arguments: Map of call ID to parsed arguments.
+        """
+        from .admin import ExecutionStatus
+
+        end_time = time.perf_counter()
+        for tc in enabled_calls:
+            start_time = call_start_times.get(tc.id, end_time)
+            duration_ms = (end_time - start_time) * 1000
+            raw = raw_results.get(tc.id)
+
+            if isinstance(raw, _ToolError):
+                status = (
+                    ExecutionStatus.TIMEOUT if raw.is_timeout else ExecutionStatus.ERROR
+                )
+                self._log_entry(
+                    tc.name,
+                    status,
+                    duration_ms,
+                    call_arguments.get(tc.id, {}),
+                    error=raw.message,
+                    exception_type=raw.exception_type,
+                    traceback=raw.traceback_str,
+                )
+                self._emit_change(
+                    ChangeEvent(
+                        event_type=ChangeEventType.TOOL_ERROR,
+                        tool_name=tc.name,
+                        reason=raw.message,
+                        metadata={
+                            "exception_type": raw.exception_type,
+                            "arguments": call_arguments.get(tc.id, {}),
+                        },
+                    )
+                )
+            else:
+                self._log_entry(
+                    tc.name,
+                    ExecutionStatus.SUCCESS,
+                    duration_ms,
+                    call_arguments.get(tc.id, {}),
+                    result=str(raw) if raw is not None else None,
+                )
 
     def build_tool_call_messages(
         self,

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -165,10 +165,24 @@ class TestTool:
 
         assert result == 8
 
-    def test_run_with_invalid_parameters_returns_error_string(self, sample_tool):
-        """Test running tool with invalid parameters returns error string."""
+    def test_run_raw_with_valid_parameters(self, sample_tool):
+        """Test run_raw returns result on success."""
+        parameters = {"a": 5, "b": 3}
+        result = sample_tool.run_raw(parameters)
+
+        assert result == 8
+
+    def test_run_raw_raises_on_invalid_parameters(self, sample_tool):
+        """Test run_raw raises instead of returning error string."""
         parameters = {"invalid": "params"}
-        result = sample_tool.run(parameters)
+        with pytest.raises(Exception):
+            sample_tool.run_raw(parameters)
+
+    def test_run_with_invalid_parameters_returns_error_string(self, sample_tool):
+        """Test running tool with invalid parameters returns error string with deprecation warning."""
+        parameters = {"invalid": "params"}
+        with pytest.warns(DeprecationWarning, match="run_raw"):
+            result = sample_tool.run(parameters)
 
         assert isinstance(result, str)
         assert "Error executing" in result
@@ -183,6 +197,23 @@ class TestTool:
         assert result == 30
 
     @pytest.mark.asyncio
+    async def test_arun_raw_with_async_function(self, async_sample_function):
+        """Test arun_raw returns result on success."""
+        tool = Tool.from_function(async_sample_function)
+        parameters = {"a": 10, "b": 20}
+        result = await tool.arun_raw(parameters)
+
+        assert result == 30
+
+    @pytest.mark.asyncio
+    async def test_arun_raw_raises_on_invalid_parameters(self, async_sample_function):
+        """Test arun_raw raises instead of returning error string."""
+        tool = Tool.from_function(async_sample_function)
+        parameters = {"invalid": "params"}
+        with pytest.raises(Exception):
+            await tool.arun_raw(parameters)
+
+    @pytest.mark.asyncio
     async def test_arun_with_sync_function_returns_result_or_error(self, sample_tool):
         """Test async execution of sync tool."""
         parameters = {"a": 5, "b": 3}
@@ -195,10 +226,11 @@ class TestTool:
     async def test_arun_with_invalid_parameters_returns_error_string(
         self, async_sample_function
     ):
-        """Test async execution with invalid parameters returns error string."""
+        """Test async execution with invalid parameters returns error string with deprecation warning."""
         tool = Tool.from_function(async_sample_function)
         parameters = {"invalid": "params"}
-        result = await tool.arun(parameters)
+        with pytest.warns(DeprecationWarning, match="arun_raw"):
+            result = await tool.arun(parameters)
 
         assert isinstance(result, str)
         assert "Error executing" in result

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -771,3 +771,92 @@ class TestThinkAugmentedExecution:
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
         assert "thought" not in props
+
+
+class TestStructuredErrorHandling:
+    """Test structured error handling in execute_tool_calls."""
+
+    def _make_failing_tool_call(self, call_id="call_fail"):
+        """Create a tool call that targets a tool that raises."""
+        return ChatCompletionMessageFunctionToolCall(
+            id=call_id,
+            type="function",
+            function=Function(name="fail_tool", arguments="{}"),
+        )
+
+    def test_execute_tool_calls_logs_structured_error(self):
+        """Test that execution errors log exception_type and traceback."""
+        from toolregistry.admin import ExecutionStatus
+
+        def fail_tool() -> str:
+            """A tool that always fails."""
+            raise ValueError("something went wrong")
+
+        registry = ToolRegistry()
+        registry.register(fail_tool)
+        registry.enable_logging()
+
+        results = registry.execute_tool_calls([self._make_failing_tool_call()])
+
+        assert "Error" in results["call_fail"]
+
+        log = registry.get_execution_log()
+        entries = log.get_entries()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.status == ExecutionStatus.ERROR
+        assert entry.exception_type is not None
+        assert "ValueError" in entry.exception_type
+        assert entry.error is not None
+
+    def test_execute_tool_calls_emits_tool_error_event(self):
+        """Test that TOOL_ERROR event is emitted on tool failure."""
+        from toolregistry.events import ChangeEventType
+
+        def fail_tool() -> str:
+            """A tool that always fails."""
+            raise RuntimeError("boom")
+
+        registry = ToolRegistry()
+        registry.register(fail_tool)
+
+        events_received = []
+        registry.on_change(lambda e: events_received.append(e))
+
+        registry.execute_tool_calls([self._make_failing_tool_call()])
+
+        error_events = [
+            e for e in events_received if e.event_type == ChangeEventType.TOOL_ERROR
+        ]
+        assert len(error_events) == 1
+        assert error_events[0].tool_name == "fail_tool"
+        assert error_events[0].reason is not None
+        assert "boom" in error_events[0].reason
+        assert error_events[0].metadata.get("exception_type") is not None
+
+    def test_execute_tool_calls_success_does_not_emit_tool_error(self):
+        """Test that successful tool calls do not emit TOOL_ERROR."""
+        from toolregistry.events import ChangeEventType
+
+        def ok_tool() -> str:
+            """A tool that succeeds."""
+            return "ok"
+
+        registry = ToolRegistry()
+        registry.register(ok_tool)
+
+        events_received = []
+        registry.on_change(lambda e: events_received.append(e))
+
+        tool_call = ChatCompletionMessageFunctionToolCall(
+            id="call_ok",
+            type="function",
+            function=Function(name="ok_tool", arguments="{}"),
+        )
+        results = registry.execute_tool_calls([tool_call])
+
+        assert results["call_ok"] == "ok"
+        error_events = [
+            e for e in events_received if e.event_type == ChangeEventType.TOOL_ERROR
+        ]
+        assert len(error_events) == 0


### PR DESCRIPTION
## Summary

- Add `run_raw()`/`arun_raw()` methods to `Tool` that raise exceptions instead of catching them, giving programmatic callers access to full exception info
- Deprecate error-swallowing in `run()`/`arun()` — they now emit `DeprecationWarning` when catching, directing users to `run_raw()`
- Replace fragile `response_str.startswith("Error")` detection in `execute_tool_calls()` with a `_ToolError` sentinel dataclass
- Enrich `ExecutionLogEntry` with `exception_type` and `traceback` fields for structured error logging
- Add `TIMEOUT` status to `ExecutionStatus` enum
- Add `TOOL_ERROR` event type to `ChangeEventType`, emitted on tool execution failures
- 9 new tests covering all changes

## Test plan

- [x] `pytest tests/test_tool.py` — run_raw/arun_raw success + raises, deprecation warnings
- [x] `pytest tests/test_tool_registry.py` — structured error logging, TOOL_ERROR events, success path
- [x] Full suite `pytest tests/` — 874 passed, 1 pre-existing MCP failure (unrelated)

Closes #129