### PR TITLE
refactor: rename injected `thought` field to `toolcall_reason`

### DIFF
--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -1402,6 +1402,13 @@
                     <div class="status-indicator" id="status-indicator" title="Connected" data-i18n-title="status.connected">
                         <span class="status-dot" id="status-dot"></span>
                     </div>
+                    <button class="btn-refresh" onclick="showVersionInfo()" title="Version Info" data-i18n-title="btn.versionInfo">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <line x1="12" y1="16" x2="12" y2="12"></line>
+                            <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                        </svg>
+                    </button>
                     <button class="btn-refresh" onclick="refreshAll()" title="Refresh" data-i18n-title="btn.refresh">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <polyline points="23 4 23 10 17 10"></polyline>
@@ -1728,7 +1735,7 @@
             'col.disabled':'Disabled', 'col.tags':'Tags', 'col.actions':'Actions',
             'col.timestamp':'Timestamp', 'col.tool':'Tool', 'col.status':'Status',
             'col.duration':'Duration', 'col.ruleName':'Rule Name', 'col.result':'Result',
-            'btn.refresh':'Refresh', 'btn.clearLogs':'Clear Logs', 'btn.apply':'Apply',
+            'btn.refresh':'Refresh', 'btn.versionInfo':'Version Info', 'btn.clearLogs':'Clear Logs', 'btn.apply':'Apply',
             'btn.downloadState':'Download State', 'btn.uploadState':'Upload State',
             'btn.cancel':'Cancel', 'btn.confirm':'Confirm',
             'btn.enableAll':'Enable All', 'btn.disableAll':'Disable All',
@@ -1820,7 +1827,7 @@
             'col.disabled':'\u5df2\u7981\u7528', 'col.tags':'\u6807\u7b7e', 'col.actions':'\u64cd\u4f5c',
             'col.timestamp':'\u65f6\u95f4\u6233', 'col.tool':'\u5de5\u5177', 'col.status':'\u72b6\u6001',
             'col.duration':'\u8017\u65f6', 'col.ruleName':'\u89c4\u5219\u540d\u79f0', 'col.result':'\u7ed3\u679c',
-            'btn.refresh':'\u5237\u65b0', 'btn.clearLogs':'\u6e05\u9664\u65e5\u5fd7', 'btn.apply':'\u5e94\u7528',
+            'btn.refresh':'\u5237\u65b0', 'btn.versionInfo':'\u7248\u672c\u4fe1\u606f', 'btn.clearLogs':'\u6e05\u9664\u65e5\u5fd7', 'btn.apply':'\u5e94\u7528',
             'btn.downloadState':'\u4e0b\u8f7d\u72b6\u6001', 'btn.uploadState':'\u4e0a\u4f20\u72b6\u6001',
             'btn.cancel':'\u53d6\u6d88', 'btn.confirm':'\u786e\u8ba4',
             'btn.enableAll':'\u5168\u90e8\u542f\u7528', 'btn.disableAll':'\u5168\u90e8\u7981\u7528',
@@ -2339,7 +2346,7 @@
                         ${sourceBadge}
                         ${metaIcons}
                     </td>
-                    <td class="col-think" onclick="event.stopPropagation()">${renderMetaToggle(tool.name, 'think_augment', tool.think_augment, tool.has_native_thought)}</td>
+                    <td class="col-think" onclick="event.stopPropagation()">${renderMetaToggle(tool.name, 'think_augment', tool.think_augment, false)}</td>
                     <td class="col-defer" onclick="event.stopPropagation()">${renderMetaToggle(tool.name, 'defer', tool.defer, false)}</td>
                     <td>${permBadge}</td>
                     <td>
@@ -2516,6 +2523,7 @@
                 refreshStats();
             } catch (e) {
                 showToast(e.message, 'error');
+                refreshTools();
             }
         }
 
@@ -2609,6 +2617,8 @@
                 refreshStats();
             } catch (e) {
                 showToast(e.message, 'error');
+                refreshNamespaces();
+                refreshTools();
             }
         }
 
@@ -3074,6 +3084,20 @@
         function refreshAll() {
             const activeTab = document.querySelector('.tab.active').dataset.tab;
             switchTab(activeTab);
+        }
+
+        async function showVersionInfo() {
+            try {
+                const res = await apiFetch('/api/info');
+                const data = await res.json();
+                let lines = [];
+                for (const [pkg, ver] of Object.entries(data)) {
+                    lines.push(`${pkg}: ${ver}`);
+                }
+                alert(lines.join('\n') || 'No version info available');
+            } catch (e) {
+                alert('Failed to fetch version info');
+            }
         }
 
         // ============== Initialization ==============

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -6,6 +6,7 @@ management and monitoring.
 """
 
 import json
+import os
 import urllib.parse
 from dataclasses import asdict
 from datetime import datetime
@@ -287,12 +288,44 @@ def _get_tool(request: Request, name: str) -> Response:
     return _json_response(tool_info)
 
 
+def _check_env_requirements(
+    registry: "ToolRegistry", name: str
+) -> tuple[bool, list[str]]:
+    """Check if missing-env requirements are now satisfied.
+
+    Inspects the disable reason for a ``"Missing env: ..."`` prefix and
+    verifies whether the listed environment variables are now set.
+
+    Args:
+        registry: The ToolRegistry instance.
+        name: Tool or namespace name.
+
+    Returns:
+        A tuple of ``(satisfied, missing_vars)``.
+    """
+    reason = registry.get_disable_reason(name)
+    if not reason or not reason.startswith("Missing env:"):
+        return True, []
+    env_str = reason[len("Missing env:") :].strip()
+    env_vars = [v.strip() for v in env_str.split(",") if v.strip()]
+    missing = [v for v in env_vars if not os.environ.get(v)]
+    return len(missing) == 0, missing
+
+
 def _enable_tool(request: Request, name: str) -> Response:
     """Enable a tool."""
     registry = _app(request).registry
     name = urllib.parse.unquote(name)
     if name not in registry:
         return _error_response(404, "Not Found", f"Tool not found: {name}")
+
+    satisfied, missing = _check_env_requirements(registry, name)
+    if not satisfied:
+        return _error_response(
+            400,
+            "Bad Request",
+            f"Cannot enable '{name}': missing env vars: {', '.join(missing)}",
+        )
 
     registry.enable(name)
     return _json_response({"success": True, "message": f"Tool '{name}' enabled"})
@@ -414,22 +447,41 @@ def _enable_namespace(request: Request, name: str) -> Response:
     """Enable all tools in namespace."""
     registry = _app(request).registry
     name = urllib.parse.unquote(name)
-    registry.enable(name)
 
+    # Check env requirements on any tool in the namespace
+    skipped: list[str] = []
     enabled_count = 0
     for tool_name in registry.list_tools(include_disabled=True):
         tool = registry.get_tool(tool_name)
         if tool and tool.namespace == name:
-            registry.enable(tool_name)
-            enabled_count += 1
+            satisfied, missing = _check_env_requirements(registry, tool_name)
+            if not satisfied:
+                skipped.extend(missing)
+            else:
+                registry.enable(tool_name)
+                enabled_count += 1
 
-    return _json_response(
-        {
-            "success": True,
-            "message": f"Namespace '{name}' enabled",
-            "tools_enabled": enabled_count,
-        }
-    )
+    if skipped and enabled_count == 0:
+        # All tools blocked by missing env vars
+        unique_missing = sorted(set(skipped))
+        return _error_response(
+            400,
+            "Bad Request",
+            f"Cannot enable namespace '{name}': "
+            f"missing env vars: {', '.join(unique_missing)}",
+        )
+
+    # Enable at namespace level too (removes namespace-level disable)
+    registry.enable(name)
+
+    result: dict[str, Any] = {
+        "success": True,
+        "message": f"Namespace '{name}' enabled",
+        "tools_enabled": enabled_count,
+    }
+    if skipped:
+        result["skipped_missing_env"] = sorted(set(skipped))
+    return _json_response(result)
 
 
 def _disable_namespace(request: Request, name: str) -> Response:
@@ -761,6 +813,23 @@ def _update_config(request: Request) -> Response:
     return _json_response(result)
 
 
+# ============== Version Info ==============
+
+
+def _get_info(request: Request) -> Response:
+    """Return version information for toolregistry and optional dependencies."""
+    import toolregistry
+
+    info: dict[str, str] = {"toolregistry": toolregistry.__version__}
+    try:
+        import toolregistry_server
+
+        info["toolregistry_server"] = toolregistry_server.__version__
+    except ImportError:
+        pass
+    return _json_response(info)
+
+
 # ============== Route Setup ==============
 
 
@@ -798,3 +867,4 @@ def setup_routes(app: "AdminApp") -> None:
     app.get("/api/permissions")(_get_permissions)
     app.get("/api/config")(_get_config)
     app.put("/api/config")(_update_config)
+    app.get("/api/info")(_get_info)

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -27,16 +27,15 @@ class ToolTag(str, Enum):
     PRIVILEGED = "privileged"
 
 
-THINK_PROPERTY: dict[str, str] = {
+TOOLCALL_REASON_PROPERTY: dict[str, str] = {
     "type": "string",
-    "description": (
-        "Your step-by-step reasoning about why you chose this tool and how to use it."
-    ),
+    "description": "Why you chose this tool and what you expect from it.",
 }
 """Schema snippet injected into every tool's ``parameters.properties``
-so that LLMs can include chain-of-thought reasoning when calling a tool.
+so that LLMs can articulate the rationale for each tool call.
 
-Reference: https://arxiv.org/abs/2601.18282
+Inspired by thought-augmented tool calling (https://arxiv.org/abs/2601.18282)
+but uses a unique field name to avoid collisions with native tool parameters.
 """
 
 
@@ -112,9 +111,9 @@ class ToolMetadata(BaseModel):
     """Control thought-augmented tool calling for this tool.
 
     - ``None`` (default): follow the registry-level setting.
-    - ``True``: always inject a ``thought`` property into this tool's
-      schema, regardless of the registry setting.
-    - ``False``: never inject ``thought`` into this tool's schema.
+    - ``True``: always inject a ``toolcall_reason`` property into this
+      tool's schema, regardless of the registry setting.
+    - ``False``: never inject ``toolcall_reason`` into this tool's schema.
 
     Reference: https://arxiv.org/abs/2601.18282
     """
@@ -217,26 +216,18 @@ class Tool(BaseModel):
         return data
 
     def model_post_init(self, __context: Any) -> None:
-        """Inject ``thought`` property into the tool's parameter schema.
+        """Inject ``toolcall_reason`` property into the tool's parameter schema.
 
         Runs after every ``Tool`` (and subclass) construction, regardless
         of whether the instance was created via ``from_function()``, or
         directly (MCP, OpenAPI, LangChain integrations).
 
-        The ``thought`` field is only added when ``parameters`` already
-        contains a ``properties`` mapping and does not already define a
-        ``thought`` key (i.e. native ``thought`` parameters are preserved).
+        The ``toolcall_reason`` field is only added when ``parameters``
+        already contains a ``properties`` mapping.
         """
         props = self.parameters.get("properties")
-        if props is not None and "thought" not in props:
-            props["thought"] = THINK_PROPERTY
-
-    def _has_native_thought_param(self) -> bool:
-        """Return True if the wrapped function natively declares a ``thought`` parameter."""
-        return (
-            self.parameters_model is not None
-            and "thought" in self.parameters_model.model_fields
-        )
+        if props is not None and "toolcall_reason" not in props:
+            props["toolcall_reason"] = TOOLCALL_REASON_PROPERTY
 
     @property
     def is_async(self) -> bool:
@@ -342,20 +333,14 @@ class Tool(BaseModel):
 
         return tool
 
-    def _parameters_without_thought(self) -> dict[str, Any]:
-        """Return a shallow copy of ``parameters`` with ``thought`` removed.
-
-        Only strips ``thought`` when it was injected (i.e. the wrapped
-        function does not natively declare a ``thought`` parameter).
-        """
+    def _parameters_without_toolcall_reason(self) -> dict[str, Any]:
+        """Return a deep copy of ``parameters`` with ``toolcall_reason`` removed."""
         import copy
 
-        if self._has_native_thought_param():
-            return self.parameters
         params = copy.deepcopy(self.parameters)
         props = params.get("properties")
         if props is not None:
-            props.pop("thought", None)
+            props.pop("toolcall_reason", None)
         return params
 
     def get_schema(
@@ -373,7 +358,7 @@ class Tool(BaseModel):
         Args:
             api_format: Target API format. One of ``"openai-chat"``,
                 ``"openai-response"``, ``"anthropic"``, ``"gemini"``.
-            _think_augment: Internal override for thought injection.
+            _think_augment: Internal override for toolcall_reason injection.
                 When ``None`` (default), falls back to
                 ``self.metadata.think_augment``.  Used by
                 :meth:`ToolRegistry.get_schemas` to pass the resolved
@@ -394,12 +379,12 @@ class Tool(BaseModel):
             else self.metadata.think_augment
         )
         # None means "include" when called directly (no registry context)
-        should_include_thought = effective is not False
+        should_include_reason = effective is not False
 
         params = (
             self.parameters
-            if should_include_thought
-            else self._parameters_without_thought()
+            if should_include_reason
+            else self._parameters_without_toolcall_reason()
         )
         ir_tool = _make_ir_tool_definition(self.name, self.description, params)
 
@@ -492,8 +477,7 @@ class Tool(BaseModel):
             ``ToolRegistry.execute_tool_calls()``. Direct calls return raw
             results without truncation.
         """
-        if not self._has_native_thought_param():
-            parameters = {k: v for k, v in parameters.items() if k != "thought"}
+        parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
         validated_params = self._validate_parameters(parameters)
         return self.callable(**validated_params)
 
@@ -554,8 +538,7 @@ class Tool(BaseModel):
             ``ToolRegistry.execute_tool_calls()``. Direct calls return raw
             results without truncation.
         """
-        if not self._has_native_thought_param():
-            parameters = {k: v for k, v in parameters.items() if k != "thought"}
+        parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
         validated_params = self._validate_parameters(parameters)
 
         if inspect.iscoroutinefunction(self.callable):

--- a/src/toolregistry/tool_discovery.py
+++ b/src/toolregistry/tool_discovery.py
@@ -40,9 +40,9 @@ def _tool_name_to_text(name: str) -> str:
 
 
 def _extract_param_names(tool: Tool) -> str:
-    """Extract parameter names from a tool's JSON schema, excluding ``thought``."""
+    """Extract parameter names from a tool's JSON schema, excluding ``toolcall_reason``."""
     props = tool.parameters.get("properties", {})
-    return " ".join(k for k in props if k != "thought")
+    return " ".join(k for k in props if k != "toolcall_reason")
 
 
 def _tool_to_fields(tool: Tool) -> dict[str, str]:

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -99,10 +99,10 @@ class ToolRegistry(
                 for all tools. Individual tools can override this via
                 ``ToolMetadata.max_result_size``. None means no limit.
             think_augment: Enable thought-augmented tool calling globally.
-                When ``True``, a ``thought`` property is included in
-                every tool's schema so LLMs can emit chain-of-thought
-                reasoning alongside tool calls.  Individual tools can
-                override this via ``ToolMetadata.think_augment``.
+                When ``True``, a ``toolcall_reason`` property is
+                included in every tool's schema so LLMs can articulate
+                their rationale when calling tools.  Individual tools
+                can override this via ``ToolMetadata.think_augment``.
                 Defaults to ``False``.
             tool_discovery: Enable tool discovery on initialization.
                 When ``True``, :meth:`enable_tool_discovery` is called
@@ -207,10 +207,10 @@ class ToolRegistry(
     def enable_think_augment(self) -> None:
         """Enable thought-augmented tool calling globally.
 
-        When enabled, a ``thought`` property is included in every tool's
-        schema (via :meth:`get_schemas`) so that LLMs can emit
-        chain-of-thought reasoning alongside tool calls.  Individual
-        tools can still override this via ``ToolMetadata.think_augment``.
+        When enabled, a ``toolcall_reason`` property is included in
+        every tool's schema (via :meth:`get_schemas`) so that LLMs can
+        articulate their rationale when calling tools.  Individual tools
+        can still override this via ``ToolMetadata.think_augment``.
 
         Reference: https://arxiv.org/abs/2601.18282
         """
@@ -219,9 +219,9 @@ class ToolRegistry(
     def disable_think_augment(self) -> None:
         """Disable thought-augmented tool calling globally.
 
-        When disabled, the ``thought`` property is stripped from tool
-        schemas produced by :meth:`get_schemas`, unless a tool explicitly
-        opts in via ``ToolMetadata.think_augment = True``.
+        When disabled, the ``toolcall_reason`` property is stripped from
+        tool schemas produced by :meth:`get_schemas`, unless a tool
+        explicitly opts in via ``ToolMetadata.think_augment = True``.
         """
         self._think_augment = False
 
@@ -536,8 +536,7 @@ class ToolRegistry(
         function_name = tc.name
         function_args = call_arguments.get(tc.id, {})
         tool_obj = self.get_tool(function_name)
-        if tool_obj and not tool_obj._has_native_thought_param():
-            function_args.pop("thought", None)
+        function_args.pop("toolcall_reason", None)
         callable_func = tool_obj.callable if tool_obj else None
 
         if callable_func is None:
@@ -877,8 +876,6 @@ class ToolRegistry(
                   (e.g. transport URI, spec URL, class name)
                 - think_augment (bool | None): Think-augmented calling setting
                 - defer (bool): Whether the tool is deferred from initial prompt
-                - has_native_thought (bool): Whether the function natively
-                  declares a ``thought`` parameter
 
         Example:
             >>> registry = ToolRegistry()
@@ -896,7 +893,6 @@ class ToolRegistry(
                     "is_async": False,
                     "think_augment": None,
                     "defer": False,
-                    "has_native_thought": False
                 }
             ]
         """
@@ -918,7 +914,6 @@ class ToolRegistry(
                     "source_detail": meta.source_detail,
                     "think_augment": meta.think_augment,
                     "defer": meta.defer,
-                    "has_native_thought": tool._has_native_thought_param(),
                 }
             )
         return status_list

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -332,61 +332,65 @@ class TestTool:
 
 
 class TestThinkAugmented:
-    """Test cases for think-augmented function calling."""
+    """Test cases for think-augmented function calling (toolcall_reason)."""
 
-    def test_think_property_in_schema(self, sample_tool):
-        """Test that thought property is injected into tool schema."""
-        assert "thought" in sample_tool.parameters["properties"]
-        thought = sample_tool.parameters["properties"]["thought"]
-        assert thought["type"] == "string"
-        assert "reasoning" in thought["description"]
+    def test_toolcall_reason_in_schema(self, sample_tool):
+        """Test that toolcall_reason property is injected into tool schema."""
+        assert "toolcall_reason" in sample_tool.parameters["properties"]
+        reason = sample_tool.parameters["properties"]["toolcall_reason"]
+        assert reason["type"] == "string"
+        assert "chose" in reason["description"]
 
-    def test_think_property_in_openai_format(self, sample_tool):
-        """Test that thought appears in OpenAI format schema."""
+    def test_toolcall_reason_in_openai_format(self, sample_tool):
+        """Test that toolcall_reason appears in OpenAI format schema."""
         schema = sample_tool.get_schema("openai-chat")
         params = schema["function"]["parameters"]
-        assert "thought" in params["properties"]
+        assert "toolcall_reason" in params["properties"]
 
-    def test_think_property_in_anthropic_format(self, sample_tool):
-        """Test that thought appears in Anthropic format schema."""
+    def test_toolcall_reason_in_anthropic_format(self, sample_tool):
+        """Test that toolcall_reason appears in Anthropic format schema."""
         schema = sample_tool.get_schema("anthropic")
-        assert "thought" in schema["input_schema"]["properties"]
+        assert "toolcall_reason" in schema["input_schema"]["properties"]
 
-    def test_think_property_in_gemini_format(self, sample_tool):
-        """Test that thought appears in Gemini format schema."""
+    def test_toolcall_reason_in_gemini_format(self, sample_tool):
+        """Test that toolcall_reason appears in Gemini format schema."""
         schema = sample_tool.get_schema("gemini")
-        assert "thought" in schema["parameters"]["properties"]
+        assert "toolcall_reason" in schema["parameters"]["properties"]
 
-    def test_think_stripped_on_run(self, sample_tool):
-        """Test that thought is stripped before execution in run()."""
+    def test_toolcall_reason_stripped_on_run(self, sample_tool):
+        """Test that toolcall_reason is stripped before execution in run()."""
         result = sample_tool.run(
-            {"a": 5, "b": 3, "thought": "I need to add these numbers"}
+            {"a": 5, "b": 3, "toolcall_reason": "I need to add these numbers"}
         )
         assert result == 8
 
     @pytest.mark.asyncio
-    async def test_think_stripped_on_arun(self, async_sample_function):
-        """Test that thought is stripped before execution in arun()."""
+    async def test_toolcall_reason_stripped_on_arun(self, async_sample_function):
+        """Test that toolcall_reason is stripped before execution in arun()."""
         tool = Tool.from_function(async_sample_function)
-        result = await tool.arun({"a": 10, "b": 20, "thought": "Adding asynchronously"})
+        result = await tool.arun(
+            {"a": 10, "b": 20, "toolcall_reason": "Adding asynchronously"}
+        )
         assert result == 30
 
-    def test_think_no_override_existing(self):
-        """Test that native thought parameter is not overridden."""
+    def test_toolcall_reason_no_collision_with_native_params(self):
+        """Test that native 'thought' parameter is not affected by toolcall_reason."""
 
         def func_with_thought(thought: str, value: int) -> str:
             """A function that uses thought as a real parameter."""
             return f"{thought}: {value}"
 
         tool = Tool.from_function(func_with_thought)
-        # thought should still be in schema (native)
+        # Native 'thought' param is preserved
         assert "thought" in tool.parameters["properties"]
-        # Should NOT be stripped during execution
-        result = tool.run({"thought": "hello", "value": 42})
+        # toolcall_reason is also injected (no collision)
+        assert "toolcall_reason" in tool.parameters["properties"]
+        # Native 'thought' is passed through; toolcall_reason is stripped
+        result = tool.run({"thought": "hello", "value": 42, "toolcall_reason": "test"})
         assert result == "hello: 42"
 
-    def test_think_manual_tool_creation(self):
-        """Test that manually created Tool also gets thought injected."""
+    def test_toolcall_reason_manual_tool_creation(self):
+        """Test that manually created Tool also gets toolcall_reason injected."""
         tool = Tool(
             name="manual_tool",
             description="A manually created tool",
@@ -399,10 +403,10 @@ class TestThinkAugmented:
             },
             callable=lambda x: x * 2,
         )
-        assert "thought" in tool.parameters["properties"]
+        assert "toolcall_reason" in tool.parameters["properties"]
 
-    def test_think_empty_schema_no_inject(self):
-        """Test that thought is not injected when schema has no properties."""
+    def test_toolcall_reason_empty_schema_no_inject(self):
+        """Test that toolcall_reason is not injected when schema has no properties."""
         tool = Tool(
             name="empty_tool",
             description="Tool with empty schema",
@@ -412,62 +416,48 @@ class TestThinkAugmented:
         assert "properties" not in tool.parameters
 
     def test_think_metadata_false_strips_from_schema(self, sample_function):
-        """Test that think_augment=False strips thought from get_schema output."""
+        """Test that think_augment=False strips toolcall_reason from get_schema output."""
         tool = Tool.from_function(
             sample_function, metadata=ToolMetadata(think_augment=False)
         )
-        # Internal storage still has thought
-        assert "thought" in tool.parameters["properties"]
+        # Internal storage still has toolcall_reason
+        assert "toolcall_reason" in tool.parameters["properties"]
         # But get_schema strips it
         schema = tool.get_schema("openai-chat")
-        assert "thought" not in schema["function"]["parameters"]["properties"]
+        assert "toolcall_reason" not in schema["function"]["parameters"]["properties"]
 
     def test_think_metadata_true_includes_in_schema(self, sample_function):
-        """Test that think_augment=True always includes thought in schema."""
+        """Test that think_augment=True always includes toolcall_reason in schema."""
         tool = Tool.from_function(
             sample_function, metadata=ToolMetadata(think_augment=True)
         )
         schema = tool.get_schema("openai-chat")
-        assert "thought" in schema["function"]["parameters"]["properties"]
+        assert "toolcall_reason" in schema["function"]["parameters"]["properties"]
 
     def test_think_metadata_none_includes_by_default(self, sample_function):
-        """Test that think_augment=None (default) includes thought when called directly."""
+        """Test that think_augment=None (default) includes toolcall_reason when called directly."""
         tool = Tool.from_function(sample_function)
         assert tool.metadata.think_augment is None
         schema = tool.get_schema("openai-chat")
-        assert "thought" in schema["function"]["parameters"]["properties"]
+        assert "toolcall_reason" in schema["function"]["parameters"]["properties"]
 
     def test_think_override_false_strips(self, sample_function):
-        """Test _think_augment=False override strips thought from output."""
+        """Test _think_augment=False override strips toolcall_reason from output."""
         tool = Tool.from_function(sample_function)
         schema = tool.get_schema("openai-chat", _think_augment=False)
-        assert "thought" not in schema["function"]["parameters"]["properties"]
+        assert "toolcall_reason" not in schema["function"]["parameters"]["properties"]
 
     def test_think_override_true_includes(self, sample_function):
-        """Test _think_augment=True override includes thought in output."""
+        """Test _think_augment=True override includes toolcall_reason in output."""
         tool = Tool.from_function(
             sample_function, metadata=ToolMetadata(think_augment=False)
         )
         # Per-tool says False, but override says True
         schema = tool.get_schema("openai-chat", _think_augment=True)
-        assert "thought" in schema["function"]["parameters"]["properties"]
+        assert "toolcall_reason" in schema["function"]["parameters"]["properties"]
 
-    def test_think_native_param_never_stripped(self):
-        """Test that native thought parameter is never stripped from schema."""
-
-        def func_with_thought(thought: str, x: int) -> str:
-            """Uses thought natively."""
-            return f"{thought}: {x}"
-
-        tool = Tool.from_function(
-            func_with_thought, metadata=ToolMetadata(think_augment=False)
-        )
-        schema = tool.get_schema("openai-chat", _think_augment=False)
-        # Native thought should survive even with think_augment=False
-        assert "thought" in schema["function"]["parameters"]["properties"]
-
-    def test_think_strip_all_formats(self, sample_function):
-        """Test that thought is stripped across all API formats."""
+    def test_toolcall_reason_strip_all_formats(self, sample_function):
+        """Test that toolcall_reason is stripped across all API formats."""
         tool = Tool.from_function(sample_function)
         for fmt, path in [
             ("openai-chat", lambda s: s["function"]["parameters"]["properties"]),
@@ -475,7 +465,9 @@ class TestThinkAugmented:
             ("gemini", lambda s: s["parameters"]["properties"]),
         ]:
             schema = tool.get_schema(fmt, _think_augment=False)
-            assert "thought" not in path(schema), f"thought not stripped for {fmt}"
+            assert "toolcall_reason" not in path(schema), (
+                f"toolcall_reason not stripped for {fmt}"
+            )
 
 
 class TestToolMetadataFields:

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -643,10 +643,10 @@ class TestToolRegistryResultTruncation:
 
 
 class TestThinkAugmentedExecution:
-    """Test think-augmented calling in execute_tool_calls path."""
+    """Test think-augmented calling (toolcall_reason) in execute_tool_calls path."""
 
-    def test_execute_tool_calls_strips_thought(self):
-        """Test that thought is stripped in execute_tool_calls."""
+    def test_execute_tool_calls_strips_toolcall_reason(self):
+        """Test that toolcall_reason is stripped in execute_tool_calls."""
         from openai.types.chat.chat_completion_message_tool_call import (
             ChatCompletionMessageToolCall as ChatCompletionMessageFunctionToolCall,
             Function,
@@ -665,15 +665,15 @@ class TestThinkAugmentedExecution:
                 type="function",
                 function=Function(
                     name="greet",
-                    arguments='{"name": "World", "thought": "I should greet the world"}',
+                    arguments='{"name": "World", "toolcall_reason": "I should greet the world"}',
                 ),
             )
         ]
         results = registry.execute_tool_calls(tool_calls)
         assert results["call_think"] == "Hello, World!"
 
-    def test_get_schemas_default_no_thought(self):
-        """Test that get_schemas() excludes thought by default (think_augment=False)."""
+    def test_get_schemas_default_no_toolcall_reason(self):
+        """Test that get_schemas() excludes toolcall_reason by default (think_augment=False)."""
 
         def add(a: int, b: int) -> int:
             """Add two numbers."""
@@ -683,10 +683,10 @@ class TestThinkAugmentedExecution:
         registry.register(add)
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
-        assert "thought" not in props
+        assert "toolcall_reason" not in props
 
     def test_get_schemas_with_think_augment_enabled(self):
-        """Test that get_schemas() includes thought when think_augment=True."""
+        """Test that get_schemas() includes toolcall_reason when think_augment=True."""
 
         def add(a: int, b: int) -> int:
             """Add two numbers."""
@@ -696,7 +696,7 @@ class TestThinkAugmentedExecution:
         registry.register(add)
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
-        assert "thought" in props
+        assert "toolcall_reason" in props
 
     def test_enable_disable_think_augment(self):
         """Test enable/disable_think_augment toggle methods."""
@@ -710,17 +710,21 @@ class TestThinkAugmentedExecution:
 
         # Default: off
         schemas = registry.get_schemas()
-        assert "thought" not in schemas[0]["function"]["parameters"]["properties"]
+        assert (
+            "toolcall_reason" not in schemas[0]["function"]["parameters"]["properties"]
+        )
 
         # Enable
         registry.enable_think_augment()
         schemas = registry.get_schemas()
-        assert "thought" in schemas[0]["function"]["parameters"]["properties"]
+        assert "toolcall_reason" in schemas[0]["function"]["parameters"]["properties"]
 
         # Disable again
         registry.disable_think_augment()
         schemas = registry.get_schemas()
-        assert "thought" not in schemas[0]["function"]["parameters"]["properties"]
+        assert (
+            "toolcall_reason" not in schemas[0]["function"]["parameters"]["properties"]
+        )
 
     def test_per_tool_override_true(self):
         """Test per-tool think_augment=True overrides registry default (off)."""
@@ -735,7 +739,7 @@ class TestThinkAugmentedExecution:
         registry.register(tool)
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
-        assert "thought" in props
+        assert "toolcall_reason" in props
 
     def test_per_tool_override_false(self):
         """Test per-tool think_augment=False overrides registry setting (on)."""
@@ -750,7 +754,7 @@ class TestThinkAugmentedExecution:
         registry.register(tool)
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
-        assert "thought" not in props
+        assert "toolcall_reason" not in props
 
     def test_per_tool_none_follows_registry(self):
         """Test per-tool think_augment=None follows registry setting."""
@@ -765,12 +769,12 @@ class TestThinkAugmentedExecution:
         registry.register(tool)
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
-        assert "thought" in props
+        assert "toolcall_reason" in props
 
         registry.disable_think_augment()
         schemas = registry.get_schemas()
         props = schemas[0]["function"]["parameters"]["properties"]
-        assert "thought" not in props
+        assert "toolcall_reason" not in props
 
 
 class TestStructuredErrorHandling:


### PR DESCRIPTION
## Summary

- Rename the think-augmented injected field from `thought` to `toolcall_reason` to eliminate naming collisions with tools that natively declare a `thought` parameter (e.g. ThinkTool). This deletes `_has_native_thought_param()` and all conditional call sites, simplifying the execution path.
- Add a version info button (ⓘ) in the admin panel header, backed by a new `GET /api/info` endpoint that returns `toolregistry` and `toolregistry_server` versions.
- Validate environment variable requirements before enabling tools/namespaces — parses the `"Missing env: ..."` disable reason and returns 400 if vars are still unset. Also resets the UI toggle on enable failure.

## Test plan

- [x] Core tests: 914 passed
- [x] Hub tests: 667 passed
- [x] `ruff check` + `ruff format` clean
- [ ] Manual: start hub with admin panel, click ⓘ button to see version info
- [ ] Manual: try enabling a tool with missing env vars, confirm 400 error and toggle reset
- [ ] Manual: verify think tool's think checkbox is interactive (not grayed out)