### PR TITLE
feat(admin): tool source display and config persistence

### DIFF
--- a/src/toolregistry/_mixins/admin.py
+++ b/src/toolregistry/_mixins/admin.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..admin import AdminInfo, AdminServer
+    from ..config import ToolConfig
     from ..tool_registry import ToolRegistry
 
 
@@ -23,6 +24,7 @@ class AdminMixin:
         serve_ui: bool = True,
         remote: bool = False,
         auth_token: str | None = None,
+        config: ToolConfig | None = None,
     ) -> AdminInfo:
         """Enable the admin panel.
 
@@ -37,6 +39,10 @@ class AdminMixin:
                 and auto-generates an auth token if none provided. Defaults to False.
             auth_token: Optional authentication token. If None and remote is True,
                 a random token is generated.
+            config: Optional ToolConfig for config-aware admin endpoints.
+                When provided, enables ``GET /api/config`` and
+                ``PUT /api/config`` endpoints for viewing and persisting
+                configuration changes to the source file.
 
         Returns:
             AdminInfo containing server details including URL and token.
@@ -67,6 +73,7 @@ class AdminMixin:
             serve_ui=serve_ui,
             remote=remote,
             auth_token=auth_token,
+            config=config,
         )
         return self._admin_server.start()
 

--- a/src/toolregistry/admin/admin.html
+++ b/src/toolregistry/admin/admin.html
@@ -1325,6 +1325,59 @@
         .badge-allow { background: rgba(61,139,95,0.10);  color: #3D8B5F; }
         .badge-deny  { background: rgba(196,65,65,0.10);  color: #C44141; }
         .badge-ask   { background: rgba(194,146,46,0.10); color: #C2922E; }
+        .badge-source {
+            display: inline-flex;
+            align-items: center;
+            padding: 1px 6px;
+            font-size: 0.5625rem;
+            font-weight: 600;
+            border-radius: 4px;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+            margin-left: 6px;
+            vertical-align: middle;
+        }
+        .badge-source-native   { background: rgba(128,128,128,0.12); color: #888; }
+        .badge-source-mcp      { background: rgba(59,130,246,0.12);  color: #3B82F6; }
+        .badge-source-openapi  { background: rgba(34,197,94,0.12);   color: #22C55E; }
+        .badge-source-langchain { background: rgba(168,85,247,0.12);  color: #A855F7; }
+        .source-card {
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 16px;
+            margin-bottom: 12px;
+        }
+        .source-card-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+        .source-detail {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            word-break: break-all;
+        }
+        .source-tools-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-top: 8px;
+        }
+        .source-tool-chip {
+            display: inline-block;
+            padding: 2px 8px;
+            font-size: 0.6875rem;
+            background: var(--bg-primary);
+            border-radius: 4px;
+            border: 1px solid var(--border);
+        }
+        .config-section {
+            margin-top: 8px;
+        }
+        .config-section .meta-item {
+            margin-bottom: 6px;
+        }
     </style>
 </head>
 <body>
@@ -1366,6 +1419,7 @@
             <div class="tabs">
                 <button class="tab active" data-tab="tools" onclick="switchTab('tools')" data-i18n="tab.tools">Tools</button>
                 <button class="tab" data-tab="namespaces" onclick="switchTab('namespaces')" data-i18n="tab.namespaces">Namespaces</button>
+                <button class="tab" data-tab="sources" onclick="switchTab('sources')" data-i18n="tab.sources">Sources</button>
                 <button class="tab" data-tab="logs" onclick="switchTab('logs')" data-i18n="tab.logs">Logs</button>
                 <button class="tab" data-tab="state" onclick="switchTab('state')" data-i18n="tab.state">State</button>
                 <button class="tab" data-tab="permissions" onclick="switchTab('permissions')" data-i18n="tab.permissions">Permissions</button>
@@ -1425,6 +1479,13 @@
                                     <option value="remote" data-i18n="filter.remote">Remote</option>
                                     <option value="any" data-i18n="filter.any">Any</option>
                                 </select>
+                                <select class="input select" id="source-filter" onchange="filterTools()">
+                                    <option value="" data-i18n="filter.allSources">All Sources</option>
+                                    <option value="native">Native</option>
+                                    <option value="mcp">MCP</option>
+                                    <option value="openapi">OpenAPI</option>
+                                    <option value="langchain">LangChain</option>
+                                </select>
                             </div>
                             <div class="table-container">
                                 <table class="tools-table">
@@ -1462,6 +1523,7 @@
                                 <thead>
                                     <tr>
                                         <th data-i18n="col.namespace">Namespace</th>
+                                        <th data-i18n="col.source">Source</th>
                                         <th data-i18n="col.totalTools">Total Tools</th>
                                         <th data-i18n="col.enabled">Enabled</th>
                                         <th data-i18n="col.disabled">Disabled</th>
@@ -1470,10 +1532,23 @@
                                     </tr>
                                 </thead>
                                 <tbody id="namespaces-body">
-                                    <tr><td colspan="6" class="loading"><div class="spinner"></div><span data-i18n="misc.loading">Loading...</span></td></tr>
+                                    <tr><td colspan="7" class="loading"><div class="spinner"></div><span data-i18n="misc.loading">Loading...</span></td></tr>
                                 </tbody>
                             </table>
                         </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Sources Tab -->
+            <div id="tab-sources" class="tab-content" style="display: none;">
+                <div class="card">
+                    <div class="card-header">
+                        <h2 class="card-title" data-i18n="tab.sources">Sources</h2>
+                        <button class="btn btn-secondary btn-sm" onclick="refreshSources()" data-i18n="btn.refresh">Refresh</button>
+                    </div>
+                    <div class="card-body" id="sources-body">
+                        <div class="loading"><div class="spinner"></div><span data-i18n="misc.loading">Loading...</span></div>
                     </div>
                 </div>
             </div>
@@ -1568,6 +1643,15 @@
                             </button>
                         </div>
                     </div>
+
+                    <div class="card" id="config-card" style="display: none;">
+                        <div class="card-header">
+                            <h2 class="card-title" data-i18n="section.configFile">Config File</h2>
+                        </div>
+                        <div class="card-body" id="config-body">
+                            <div class="loading"><div class="spinner"></div><span data-i18n="misc.loading">Loading...</span></div>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -1632,14 +1716,15 @@
           en: {
             'app.title':'ToolRegistry Admin Panel',
             'status.connected':'Connected', 'status.disconnected':'Disconnected',
-            'tab.tools':'Tools', 'tab.namespaces':'Namespaces', 'tab.logs':'Logs',
+            'tab.tools':'Tools', 'tab.namespaces':'Namespaces', 'tab.sources':'Sources', 'tab.logs':'Logs',
             'tab.state':'State', 'tab.permissions':'Permissions',
             'section.overview':'Overview', 'section.tools':'Tools',
             'section.execStats':'Execution Statistics', 'section.execLogs':'Execution Logs',
             'section.exportState':'Export State', 'section.importState':'Import State',
+            'section.configFile':'Config File',
             'section.permPolicy':'Permission Policy',
             'col.name':'Name', 'col.permission':'Permission', 'col.enabled':'Enabled',
-            'col.reason':'Reason', 'col.think':'Think', 'col.defer':'Defer', 'col.namespace':'Namespace', 'col.totalTools':'Total Tools',
+            'col.reason':'Reason', 'col.think':'Think', 'col.defer':'Defer', 'col.namespace':'Namespace', 'col.source':'Source', 'col.totalTools':'Total Tools',
             'col.disabled':'Disabled', 'col.tags':'Tags', 'col.actions':'Actions',
             'col.timestamp':'Timestamp', 'col.tool':'Tool', 'col.status':'Status',
             'col.duration':'Duration', 'col.ruleName':'Rule Name', 'col.result':'Result',
@@ -1648,7 +1733,7 @@
             'btn.cancel':'Cancel', 'btn.confirm':'Confirm',
             'btn.enableAll':'Enable All', 'btn.disableAll':'Disable All',
             'filter.allNamespaces':'All Namespaces', 'filter.allStatus':'All Status',
-            'filter.allTags':'All Tags', 'filter.allLocality':'All Locality',
+            'filter.allTags':'All Tags', 'filter.allLocality':'All Locality', 'filter.allSources':'All Sources',
             'filter.enabled':'Enabled', 'filter.disabled':'Disabled',
             'filter.local':'Local', 'filter.remote':'Remote', 'filter.any':'Any',
             'label.searchTools':'Search tools...', 'label.filterByTool':'Filter by tool...',
@@ -1685,6 +1770,7 @@
             'detail.status':'Status', 'detail.permission':'Permission',
             'detail.disableReason':'Disable Reason', 'detail.permReason':'Permission Reason',
             'detail.description':'Description',
+            'detail.source':'Source', 'detail.sourceDetail':'Source Detail',
             'detail.locality':'Locality', 'detail.async':'Async',
             'detail.concurrencySafe':'Concurrency Safe', 'detail.thinkAugment':'Think Augment',
             'detail.timeout':'Timeout', 'detail.maxResultSize':'Max Result Size',
@@ -1710,19 +1796,27 @@
             'misc.clickToDisableAll':'Click to disable all', 'misc.clickToEnableAll':'Click to enable all',
             'misc.thinkAugmentedAll':'Think-augmented (all)', 'misc.deferredAll':'Deferred (all)',
             'misc.nativeThought':'This tool natively declares a thought parameter',
+            'misc.none':'None',
+            'empty.sources':'No tool sources', 'empty.sourcesHint':'Sources will appear here once tools are registered.',
+            'config.mode':'Mode', 'config.filePath':'Config File', 'config.disabled':'Disabled Namespaces', 'config.enabled':'Enabled Namespaces',
+            'config.saveHint':'Write current disabled namespaces to config file',
+            'btn.saveToConfig':'Save to Config',
+            'toast.configSaved':'Config saved to file', 'toast.configSavedMemory':'Config updated (in memory only)',
+            'toast.configSaveFailed':'Failed to save config: {error}',
             'toast.detailFailed':'Failed to load tool details: {error}',
           },
           zh: {
             'app.title':'ToolRegistry \u7ba1\u7406\u9762\u677f',
             'status.connected':'\u5df2\u8fde\u63a5', 'status.disconnected':'\u5df2\u65ad\u5f00',
-            'tab.tools':'\u5de5\u5177', 'tab.namespaces':'\u547d\u540d\u7a7a\u95f4', 'tab.logs':'\u65e5\u5fd7',
+            'tab.tools':'\u5de5\u5177', 'tab.namespaces':'\u547d\u540d\u7a7a\u95f4', 'tab.sources':'\u6765\u6e90', 'tab.logs':'\u65e5\u5fd7',
             'tab.state':'\u72b6\u6001', 'tab.permissions':'\u6743\u9650',
             'section.overview':'\u6982\u89c8', 'section.tools':'\u5de5\u5177',
             'section.execStats':'\u6267\u884c\u7edf\u8ba1', 'section.execLogs':'\u6267\u884c\u65e5\u5fd7',
             'section.exportState':'\u5bfc\u51fa\u72b6\u6001', 'section.importState':'\u5bfc\u5165\u72b6\u6001',
+            'section.configFile':'\u914d\u7f6e\u6587\u4ef6',
             'section.permPolicy':'\u6743\u9650\u7b56\u7565',
             'col.name':'\u540d\u79f0', 'col.permission':'\u6743\u9650', 'col.enabled':'\u542f\u7528',
-            'col.reason':'\u539f\u56e0', 'col.think':'\u601d\u8003', 'col.defer':'\u5ef6\u8fdf', 'col.namespace':'\u547d\u540d\u7a7a\u95f4', 'col.totalTools':'\u5de5\u5177\u603b\u6570',
+            'col.reason':'\u539f\u56e0', 'col.think':'\u601d\u8003', 'col.defer':'\u5ef6\u8fdf', 'col.namespace':'\u547d\u540d\u7a7a\u95f4', 'col.source':'\u6765\u6e90', 'col.totalTools':'\u5de5\u5177\u603b\u6570',
             'col.disabled':'\u5df2\u7981\u7528', 'col.tags':'\u6807\u7b7e', 'col.actions':'\u64cd\u4f5c',
             'col.timestamp':'\u65f6\u95f4\u6233', 'col.tool':'\u5de5\u5177', 'col.status':'\u72b6\u6001',
             'col.duration':'\u8017\u65f6', 'col.ruleName':'\u89c4\u5219\u540d\u79f0', 'col.result':'\u7ed3\u679c',
@@ -1731,7 +1825,7 @@
             'btn.cancel':'\u53d6\u6d88', 'btn.confirm':'\u786e\u8ba4',
             'btn.enableAll':'\u5168\u90e8\u542f\u7528', 'btn.disableAll':'\u5168\u90e8\u7981\u7528',
             'filter.allNamespaces':'\u5168\u90e8\u547d\u540d\u7a7a\u95f4', 'filter.allStatus':'\u5168\u90e8\u72b6\u6001',
-            'filter.allTags':'\u5168\u90e8\u6807\u7b7e', 'filter.allLocality':'\u5168\u90e8\u4f4d\u7f6e',
+            'filter.allTags':'\u5168\u90e8\u6807\u7b7e', 'filter.allLocality':'\u5168\u90e8\u4f4d\u7f6e', 'filter.allSources':'\u5168\u90e8\u6765\u6e90',
             'filter.enabled':'\u5df2\u542f\u7528', 'filter.disabled':'\u5df2\u7981\u7528',
             'filter.local':'\u672c\u5730', 'filter.remote':'\u8fdc\u7a0b', 'filter.any':'\u4efb\u610f',
             'label.searchTools':'\u641c\u7d22\u5de5\u5177...', 'label.filterByTool':'\u6309\u5de5\u5177\u7b5b\u9009...',
@@ -1768,6 +1862,7 @@
             'detail.status':'\u72b6\u6001', 'detail.permission':'\u6743\u9650',
             'detail.disableReason':'\u7981\u7528\u539f\u56e0', 'detail.permReason':'\u6743\u9650\u539f\u56e0',
             'detail.description':'\u63cf\u8ff0',
+            'detail.source':'\u6765\u6e90', 'detail.sourceDetail':'\u6765\u6e90\u8be6\u60c5',
             'detail.locality':'\u4f4d\u7f6e', 'detail.async':'\u5f02\u6b65',
             'detail.concurrencySafe':'\u5e76\u53d1\u5b89\u5168', 'detail.thinkAugment':'\u601d\u8003\u589e\u5f3a',
             'detail.timeout':'\u8d85\u65f6', 'detail.maxResultSize':'\u6700\u5927\u7ed3\u679c\u5927\u5c0f',
@@ -1793,6 +1888,13 @@
             'misc.clickToDisableAll':'\u70b9\u51fb\u7981\u7528\u5168\u90e8', 'misc.clickToEnableAll':'\u70b9\u51fb\u542f\u7528\u5168\u90e8',
             'misc.thinkAugmentedAll':'\u601d\u8003\u589e\u5f3a\uff08\u5168\u90e8\uff09', 'misc.deferredAll':'\u5ef6\u8fdf\u6267\u884c\uff08\u5168\u90e8\uff09',
             'misc.nativeThought':'\u8be5\u5de5\u5177\u539f\u751f\u58f0\u660e\u4e86 thought \u53c2\u6570',
+            'misc.none':'\u65e0',
+            'empty.sources':'\u6682\u65e0\u5de5\u5177\u6765\u6e90', 'empty.sourcesHint':'\u5de5\u5177\u6ce8\u518c\u540e\u6765\u6e90\u5c06\u663e\u793a\u5728\u6b64\u5904\u3002',
+            'config.mode':'\u6a21\u5f0f', 'config.filePath':'\u914d\u7f6e\u6587\u4ef6', 'config.disabled':'\u7981\u7528\u7684\u547d\u540d\u7a7a\u95f4', 'config.enabled':'\u542f\u7528\u7684\u547d\u540d\u7a7a\u95f4',
+            'config.saveHint':'\u5c06\u5f53\u524d\u7981\u7528\u7684\u547d\u540d\u7a7a\u95f4\u5199\u5165\u914d\u7f6e\u6587\u4ef6',
+            'btn.saveToConfig':'\u4fdd\u5b58\u5230\u914d\u7f6e',
+            'toast.configSaved':'\u914d\u7f6e\u5df2\u4fdd\u5b58\u5230\u6587\u4ef6', 'toast.configSavedMemory':'\u914d\u7f6e\u5df2\u66f4\u65b0\uff08\u4ec5\u5185\u5b58\uff09',
+            'toast.configSaveFailed':'\u4fdd\u5b58\u914d\u7f6e\u5931\u8d25\uff1a{error}',
             'toast.detailFailed':'\u52a0\u8f7d\u5de5\u5177\u8be6\u60c5\u5931\u8d25\uff1a{error}',
           },
         };
@@ -1957,6 +2059,21 @@
             async getPermissions() {
                 return this.request('/api/permissions');
             }
+
+            async getSources() {
+                return this.request('/api/sources');
+            }
+
+            async getConfig() {
+                return this.request('/api/config');
+            }
+
+            async updateConfig(data) {
+                return this.request('/api/config', {
+                    method: 'PUT',
+                    body: JSON.stringify(data)
+                });
+            }
         }
 
         const api = new AdminAPI(API_BASE, AUTH_TOKEN);
@@ -2039,8 +2156,12 @@
             } else if (tabName === 'logs') {
                 refreshLogs();
                 refreshLogStats();
+            } else if (tabName === 'sources') {
+                refreshSources();
             } else if (tabName === 'permissions') {
                 refreshPermissions();
+            } else if (tabName === 'state') {
+                refreshConfig();
             }
         }
 
@@ -2072,6 +2193,12 @@
             // Strip "ToolTag." prefix and lowercase for matching
             const key = tag.replace(/^ToolTag\./i, '').toLowerCase();
             return key;
+        }
+
+        function renderSourceBadge(source) {
+            if (!source) return '';
+            const cls = 'badge-source badge-source-' + source;
+            return `<span class="${cls}">${escapeHtml(source)}</span>`;
         }
 
         function renderTagBadges(tags, systemOnly) {
@@ -2164,11 +2291,14 @@
                 const anyDefer = children.some(t => t.defer);
                 const nsId = 'ns-' + ns.replace(/[^a-zA-Z0-9_]/g, '_');
                 const isDefault = ns === 'default';
+                const nsSources = [...new Set(children.map(t => t.source))];
+                const nsSourceBadge = nsSources.length === 1 ? renderSourceBadge(nsSources[0]) : '';
                 html += `
                 <tr class="ns-row" onclick="toggleNsGroup('${nsId}')">
                     <td><span class="ns-chevron">${SVG_CHEVRON}</span></td>
                     <td>
                         <span style="font-weight: 500;">${escapeHtml(ns)}</span>
+                        ${nsSourceBadge}
                         <span class="text-muted" style="margin-left: 8px; font-size: 0.6875rem;">${children.length > 1 ? t('misc.toolCountPlural', {count: children.length}) : t('misc.toolCount', {count: children.length})}</span>
                     </td>
                     <td class="col-think" onclick="event.stopPropagation()">
@@ -2199,12 +2329,14 @@
                     const tagBadges = renderTagBadges(tool.tags, true);
                     const metaIcons = renderMetaIcons(tool);
                     const permBadge = renderPermissionBadge(tool.permission);
+                    const sourceBadge = nsSources.length > 1 ? renderSourceBadge(tool.source) : '';
                     html += `
                 <tr class="ns-child-row" data-ns-group="${nsId}">
                     <td></td>
                     <td>
                         <span class="ns-child-name-link" onclick="event.stopPropagation(); showToolDetailModal('${escapeHtml(tool.name)}')">${escapeHtml(shortName)}</span>
                         <span class="tool-badges">${tagBadges}</span>
+                        ${sourceBadge}
                         ${metaIcons}
                     </td>
                     <td class="col-think" onclick="event.stopPropagation()">${renderMetaToggle(tool.name, 'think_augment', tool.think_augment, tool.has_native_thought)}</td>
@@ -2280,6 +2412,7 @@
             const status = document.getElementById('status-filter').value;
             const tag = document.getElementById('tag-filter').value;
             const locality = document.getElementById('locality-filter').value;
+            const source = document.getElementById('source-filter').value;
 
             const filtered = allTools.filter(tool => {
                 const matchSearch = tool.name.toLowerCase().includes(search);
@@ -2289,7 +2422,8 @@
                     (status === 'disabled' && !tool.enabled);
                 const matchTag = !tag || (tool.tags && tool.tags.includes(tag));
                 const matchLocality = !locality || tool.locality === locality;
-                return matchSearch && matchNamespace && matchStatus && matchTag && matchLocality;
+                const matchSource = !source || tool.source === source;
+                return matchSearch && matchNamespace && matchStatus && matchTag && matchLocality && matchSource;
             });
 
             renderTools(filtered);
@@ -2412,16 +2546,28 @@
 
             if (namespaces.length === 0) {
                 tbody.innerHTML = `
-                    <tr><td colspan="6" class="empty-state">
+                    <tr><td colspan="7" class="empty-state">
                         <div class="empty-state-icon">${t('empty.ns')}</div>
                         <div class="empty-state-text">${t('empty.nsHint')}</div>
                     </td></tr>`;
                 return;
             }
 
-            tbody.innerHTML = namespaces.map(ns => `
+            // Determine source type per namespace from tools data
+            const nsSourceMap = {};
+            allTools.forEach(tool => {
+                const ns = tool.namespace || 'default';
+                if (!nsSourceMap[ns]) nsSourceMap[ns] = new Set();
+                nsSourceMap[ns].add(tool.source || 'native');
+            });
+
+            tbody.innerHTML = namespaces.map(ns => {
+                const sources = nsSourceMap[ns.name] || new Set();
+                const sourceBadges = [...sources].map(s => renderSourceBadge(s)).join(' ');
+                return `
                 <tr>
                     <td><span style="font-weight: 500;">${escapeHtml(ns.name)}</span></td>
+                    <td>${sourceBadges || '<span class="text-muted" style="font-size: 0.75rem;">&mdash;</span>'}</td>
                     <td>${ns.tool_count}</td>
                     <td><span class="text-success">${ns.enabled_count}</span></td>
                     <td><span class="text-error">${ns.disabled_count}</span></td>
@@ -2432,8 +2578,8 @@
                             <button class="btn btn-danger btn-sm" style="min-width: 90px; text-align: center;" onclick="showDisableNamespaceModal('${escapeHtml(ns.name)}')">${t('btn.disableAll')}</button>
                         </div>`}
                     </td>
-                </tr>
-            `).join('');
+                </tr>`;
+            }).join('');
         }
 
         function showDisableNamespaceModal(name) {
@@ -2700,9 +2846,11 @@
                         <div class="meta-item"><span class="meta-label">${t('detail.name')}</span><span class="meta-value">${escapeHtml(tool.name)}</span></div>
                         <div class="meta-item"><span class="meta-label">${t('detail.namespace')}</span><span class="meta-value">${escapeHtml(tool.namespace || 'default')}</span></div>
                         <div class="meta-item"><span class="meta-label">${t('detail.methodName')}</span><span class="meta-value">${escapeHtml(tool.method_name || tool.name)}</span></div>
+                        <div class="meta-item"><span class="meta-label">${t('detail.source')}</span><span class="meta-value">${renderSourceBadge(meta.source || 'native')}</span></div>
                         <div class="meta-item"><span class="meta-label">${t('detail.status')}</span><span class="meta-value">${tool.enabled ? `<span class="text-success">${t('stat.enabled')}</span>` : `<span class="text-error">${t('stat.disabled')}</span>`}</span></div>
                         <div class="meta-item"><span class="meta-label">${t('detail.permission')}</span><span class="meta-value">${permHtml}</span></div>
                     </div>
+                    ${meta.source_detail ? `<div class="meta-item mt-2"><span class="meta-label">${t('detail.sourceDetail')}</span><span class="meta-value" style="word-break: break-all;">${escapeHtml(meta.source_detail)}</span></div>` : ''}
                     ${tool.reason ? `<div class="meta-item mt-2"><span class="meta-label">${t('detail.disableReason')}</span><span class="meta-value text-error">${escapeHtml(tool.reason)}</span></div>` : ''}
                     ${perm && perm.reason ? `<div class="meta-item mt-2"><span class="meta-label">${t('detail.permReason')}</span><span class="meta-value">${escapeHtml(perm.reason)}</span></div>` : ''}
                     <div class="mt-2"><span class="meta-label">${t('detail.description')}</span><p style="font-size: 0.8125rem; margin-top: 4px;">${escapeHtml(tool.description || '')}</p></div>
@@ -2825,6 +2973,102 @@
             const div = document.createElement('div');
             div.textContent = str;
             return div.innerHTML;
+        }
+
+        // ============== Sources ==============
+        async function refreshSources() {
+            try {
+                const data = await api.getSources();
+                renderSources(data.sources || []);
+            } catch (e) {
+                document.getElementById('sources-body').innerHTML =
+                    `<div class="empty-state"><div class="text-error">${e.message}</div></div>`;
+            }
+        }
+
+        function renderSources(sources) {
+            const body = document.getElementById('sources-body');
+
+            if (sources.length === 0) {
+                body.innerHTML = `
+                    <div class="empty-state">
+                        <div class="empty-state-icon">${t('empty.sources')}</div>
+                        <div class="empty-state-text">${t('empty.sourcesHint')}</div>
+                    </div>`;
+                return;
+            }
+
+            body.innerHTML = sources.map(src => {
+                const toolChips = src.tools.map(tn =>
+                    `<span class="source-tool-chip">${escapeHtml(tn)}</span>`
+                ).join('');
+                return `
+                <div class="source-card">
+                    <div class="source-card-header">
+                        ${renderSourceBadge(src.type)}
+                        <span style="font-weight: 500;">${escapeHtml(src.namespace)}</span>
+                        <span class="text-muted" style="font-size: 0.75rem; margin-left: auto;">${src.enabled_count}/${src.tool_count} ${t('stat.enabled').toLowerCase()}</span>
+                    </div>
+                    ${src.detail ? `<div class="source-detail">${escapeHtml(src.detail)}</div>` : ''}
+                    <div class="source-tools-list">${toolChips}</div>
+                </div>`;
+            }).join('');
+        }
+
+        // ============== Config ==============
+        async function refreshConfig() {
+            try {
+                const config = await api.getConfig();
+                document.getElementById('config-card').style.display = '';
+                renderConfig(config);
+            } catch (e) {
+                // 404 means no config loaded — hide the card
+                document.getElementById('config-card').style.display = 'none';
+            }
+        }
+
+        function renderConfig(config) {
+            const body = document.getElementById('config-body');
+            const disabledList = (config.disabled || []).map(d =>
+                `<span class="source-tool-chip">${escapeHtml(d)}</span>`
+            ).join('') || `<span class="text-muted" style="font-size: 0.75rem;">${t('misc.none')}</span>`;
+            const enabledList = (config.enabled || []).map(e =>
+                `<span class="source-tool-chip">${escapeHtml(e)}</span>`
+            ).join('') || `<span class="text-muted" style="font-size: 0.75rem;">${t('misc.none')}</span>`;
+
+            body.innerHTML = `
+                <div class="config-section">
+                    <div class="metadata-grid">
+                        <div class="meta-item"><span class="meta-label">${t('config.mode')}</span><span class="meta-value"><strong>${escapeHtml(config.mode)}</strong></span></div>
+                        <div class="meta-item"><span class="meta-label">${t('config.filePath')}</span><span class="meta-value" style="word-break: break-all;">${config.source ? escapeHtml(config.source) : `<span class="text-muted">${t('misc.none')}</span>`}</span></div>
+                    </div>
+                    <div class="meta-item mt-2">
+                        <span class="meta-label">${config.mode === 'denylist' ? t('config.disabled') : t('config.enabled')}</span>
+                        <div style="margin-top: 4px; display: flex; flex-wrap: wrap; gap: 4px;">
+                            ${config.mode === 'denylist' ? disabledList : enabledList}
+                        </div>
+                    </div>
+                    ${config.source ? `<div class="mt-2">
+                        <button class="btn btn-primary btn-sm" onclick="saveCurrentStateToConfig()">${t('btn.saveToConfig')}</button>
+                        <span class="text-muted" style="font-size: 0.75rem; margin-left: 8px;">${t('config.saveHint')}</span>
+                    </div>` : ''}
+                </div>`;
+        }
+
+        async function saveCurrentStateToConfig() {
+            try {
+                const state = await api.exportState();
+                const disabled = Object.keys(state.disabled || {});
+                const result = await api.updateConfig({ disabled });
+                if (result.saved) {
+                    showToast(t('toast.configSaved'), 'success');
+                    refreshConfig();
+                } else {
+                    showToast(t('toast.configSavedMemory'), 'success');
+                }
+            } catch (e) {
+                showToast(t('toast.configSaveFailed', {error: e.message}), 'error');
+            }
         }
 
         function refreshAll() {

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -735,6 +735,7 @@ def _update_config(request: Request) -> Response:
     updates, err = _parse_config_updates(data)
     if err is not None:
         return err
+    assert updates is not None  # guaranteed when err is None
 
     new_config = replace(config, **updates)
 

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -222,12 +222,15 @@ def _handle_root(request: Request) -> Response:
                 "POST /api/namespaces/{ns}/enable",
                 "POST /api/namespaces/{ns}/disable",
                 "PATCH /api/namespaces/{ns}/metadata",
+                "GET /api/sources",
                 "GET /api/logs",
                 "GET /api/logs/stats",
                 "DELETE /api/logs",
                 "GET /api/state",
                 "POST /api/state",
                 "GET /api/permissions",
+                "GET /api/config",
+                "PUT /api/config",
             ],
         }
     )
@@ -272,6 +275,8 @@ def _get_tool(request: Request, name: str) -> Response:
             "max_result_size": tool.metadata.max_result_size,
             "tags": sorted(str(t) for t in tool.metadata.tags),
             "custom_tags": sorted(tool.metadata.custom_tags),
+            "source": tool.metadata.source,
+            "source_detail": tool.metadata.source_detail,
             "defer": tool.metadata.defer,
             "search_hint": tool.metadata.search_hint,
             "think_augment": tool.metadata.think_augment,
@@ -540,12 +545,52 @@ def _clear_logs(request: Request) -> Response:
     )
 
 
-def _export_state(request: Request) -> Response:
-    """Export current state."""
+def _get_sources(request: Request) -> Response:
+    """Get aggregated tool sources."""
     registry = _app(request).registry
+    groups: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    for tool_name in registry.list_tools(include_disabled=True):
+        tool = registry.get_tool(tool_name)
+        if tool is None:
+            continue
+        meta = tool.metadata
+        ns = tool.namespace or "default"
+        key = (meta.source, meta.source_detail, ns)
+
+        if key not in groups:
+            groups[key] = {
+                "type": meta.source,
+                "detail": meta.source_detail,
+                "namespace": ns,
+                "tool_count": 0,
+                "enabled_count": 0,
+                "tools": [],
+            }
+        groups[key]["tool_count"] += 1
+        if registry.is_enabled(tool_name):
+            groups[key]["enabled_count"] += 1
+        groups[key]["tools"].append(tool_name)
+
+    sources = sorted(groups.values(), key=lambda s: (s["type"], s["namespace"]))
+    return _json_response({"sources": sources})
+
+
+def _export_state(request: Request) -> Response:
+    """Export current state including source metadata."""
+    registry = _app(request).registry
+    sources: dict[str, dict[str, str]] = {}
+    for tool_name in registry.list_tools(include_disabled=True):
+        tool = registry.get_tool(tool_name)
+        if tool:
+            sources[tool_name] = {
+                "source": tool.metadata.source,
+                "source_detail": tool.metadata.source_detail,
+            }
     state = {
         "disabled": dict(registry._disabled),
         "tools": registry.list_tools(include_disabled=True),
+        "sources": sources,
     }
     return _json_response(state)
 
@@ -604,6 +649,89 @@ def _get_permissions(request: Request) -> Response:
     )
 
 
+def _get_config(request: Request) -> Response:
+    """Get the current tool configuration."""
+    config = _app(request).config
+    if config is None:
+        return _error_response(404, "Not Found", "No tool configuration is loaded")
+    data = config.to_dict()
+    data["source"] = config.source
+    return _json_response(data)
+
+
+def _update_config(request: Request) -> Response:
+    """Update tool configuration and persist to disk."""
+    from dataclasses import replace
+
+    from ..config import save_config
+
+    app = _app(request)
+    config = app.config
+    if config is None:
+        return _error_response(404, "Not Found", "No tool configuration is loaded")
+
+    if not request.body:
+        return _error_response(400, "Bad Request", "Request body is required")
+
+    try:
+        data = request.json()
+    except (json.JSONDecodeError, ValueError) as e:
+        return _error_response(400, "Bad Request", f"Invalid JSON: {e}")
+
+    if not isinstance(data, dict):
+        return _error_response(400, "Bad Request", "Body must be a JSON object")
+
+    # Build kwargs for replace()
+    updates: dict[str, Any] = {}
+    if "mode" in data:
+        mode = data["mode"]
+        if mode not in ("denylist", "allowlist"):
+            return _error_response(
+                400,
+                "Bad Request",
+                f"Invalid mode '{mode}'. Must be 'denylist' or 'allowlist'.",
+            )
+        updates["mode"] = mode
+    if "disabled" in data:
+        if not isinstance(data["disabled"], list):
+            return _error_response(400, "Bad Request", "'disabled' must be a list")
+        updates["disabled"] = tuple(data["disabled"])
+    if "enabled" in data:
+        if not isinstance(data["enabled"], list):
+            return _error_response(400, "Bad Request", "'enabled' must be a list")
+        updates["enabled"] = tuple(data["enabled"])
+
+    if not updates:
+        return _error_response(
+            400,
+            "Bad Request",
+            "No valid fields to update. Supported: mode, disabled, enabled.",
+        )
+
+    new_config = replace(config, **updates)
+
+    # Persist to disk if source path is known
+    saved_path = ""
+    if config.source:
+        try:
+            save_config(new_config, config.source)
+            new_config = replace(new_config, source=config.source)
+            saved_path = config.source
+        except Exception as e:
+            return _error_response(
+                500, "Internal Server Error", f"Failed to write config file: {e}"
+            )
+
+    app.config = new_config
+
+    result = new_config.to_dict()
+    result["source"] = new_config.source
+    result["saved"] = bool(saved_path)
+    if saved_path:
+        result["saved_path"] = saved_path
+    return _json_response(result)
+
+
 # ============== Route Setup ==============
 
 
@@ -632,9 +760,12 @@ def setup_routes(app: "AdminApp") -> None:
     app.post("/api/namespaces/<name>/enable")(_enable_namespace)
     app.post("/api/namespaces/<name>/disable")(_disable_namespace)
     app.patch("/api/namespaces/<name>/metadata")(_update_namespace_metadata)
+    app.get("/api/sources")(_get_sources)
     app.get("/api/logs")(_get_logs)
     app.get("/api/logs/stats")(_get_log_stats)
     app.delete("/api/logs")(_clear_logs)
     app.get("/api/state")(_export_state)
     app.post("/api/state")(_import_state)
     app.get("/api/permissions")(_get_permissions)
+    app.get("/api/config")(_get_config)
+    app.put("/api/config")(_update_config)

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -17,6 +17,7 @@ from .static import ADMIN_HTML
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
+    from toolregistry.tool import Tool
 
     from .server import AdminApp
 
@@ -356,6 +357,37 @@ def _update_tool_metadata(request: Request, name: str) -> Response:
     )
 
 
+def _new_namespace_entry(name: str) -> dict[str, Any]:
+    """Create a fresh namespace stats dict."""
+    return {
+        "name": name,
+        "tool_count": 0,
+        "enabled_count": 0,
+        "disabled_count": 0,
+        "async_count": 0,
+        "remote_count": 0,
+        "tags": set(),
+    }
+
+
+def _accumulate_tool_stats(
+    ns_data: dict[str, Any],
+    tool: "Tool",
+    is_enabled: bool,
+) -> None:
+    """Update namespace stats with a single tool's info."""
+    ns_data["tool_count"] += 1
+    if is_enabled:
+        ns_data["enabled_count"] += 1
+    else:
+        ns_data["disabled_count"] += 1
+    if tool.metadata.is_async:
+        ns_data["async_count"] += 1
+    if tool.metadata.locality == "remote":
+        ns_data["remote_count"] += 1
+    ns_data["tags"].update(tool.metadata.all_tags)
+
+
 def _get_namespaces(request: Request) -> Response:
     """Get all namespaces."""
     registry = _app(request).registry
@@ -365,25 +397,8 @@ def _get_namespaces(request: Request) -> Response:
         if tool:
             ns = tool.namespace or "default"
             if ns not in namespaces:
-                namespaces[ns] = {
-                    "name": ns,
-                    "tool_count": 0,
-                    "enabled_count": 0,
-                    "disabled_count": 0,
-                    "async_count": 0,
-                    "remote_count": 0,
-                    "tags": set(),
-                }
-            namespaces[ns]["tool_count"] += 1
-            if registry.is_enabled(tool_name):
-                namespaces[ns]["enabled_count"] += 1
-            else:
-                namespaces[ns]["disabled_count"] += 1
-            if tool.metadata.is_async:
-                namespaces[ns]["async_count"] += 1
-            if tool.metadata.locality == "remote":
-                namespaces[ns]["remote_count"] += 1
-            namespaces[ns]["tags"].update(tool.metadata.all_tags)
+                namespaces[ns] = _new_namespace_entry(ns)
+            _accumulate_tool_stats(namespaces[ns], tool, registry.is_enabled(tool_name))
 
     for ns_data in namespaces.values():
         ns_data["tags"] = sorted(ns_data["tags"])

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -659,6 +659,42 @@ def _get_config(request: Request) -> Response:
     return _json_response(data)
 
 
+def _parse_config_updates(data: dict) -> tuple[dict[str, Any] | None, Response | None]:
+    """Parse and validate config update fields from request data.
+
+    Returns:
+        A tuple of (updates_dict, None) on success, or (None, error_response) on failure.
+    """
+    updates: dict[str, Any] = {}
+    if "mode" in data:
+        mode = data["mode"]
+        if mode not in ("denylist", "allowlist"):
+            return None, _error_response(
+                400,
+                "Bad Request",
+                f"Invalid mode '{mode}'. Must be 'denylist' or 'allowlist'.",
+            )
+        updates["mode"] = mode
+    if "disabled" in data:
+        if not isinstance(data["disabled"], list):
+            return None, _error_response(
+                400, "Bad Request", "'disabled' must be a list"
+            )
+        updates["disabled"] = tuple(data["disabled"])
+    if "enabled" in data:
+        if not isinstance(data["enabled"], list):
+            return None, _error_response(400, "Bad Request", "'enabled' must be a list")
+        updates["enabled"] = tuple(data["enabled"])
+
+    if not updates:
+        return None, _error_response(
+            400,
+            "Bad Request",
+            "No valid fields to update. Supported: mode, disabled, enabled.",
+        )
+    return updates, None
+
+
 def _update_config(request: Request) -> Response:
     """Update tool configuration and persist to disk."""
     from dataclasses import replace
@@ -681,32 +717,9 @@ def _update_config(request: Request) -> Response:
     if not isinstance(data, dict):
         return _error_response(400, "Bad Request", "Body must be a JSON object")
 
-    # Build kwargs for replace()
-    updates: dict[str, Any] = {}
-    if "mode" in data:
-        mode = data["mode"]
-        if mode not in ("denylist", "allowlist"):
-            return _error_response(
-                400,
-                "Bad Request",
-                f"Invalid mode '{mode}'. Must be 'denylist' or 'allowlist'.",
-            )
-        updates["mode"] = mode
-    if "disabled" in data:
-        if not isinstance(data["disabled"], list):
-            return _error_response(400, "Bad Request", "'disabled' must be a list")
-        updates["disabled"] = tuple(data["disabled"])
-    if "enabled" in data:
-        if not isinstance(data["enabled"], list):
-            return _error_response(400, "Bad Request", "'enabled' must be a list")
-        updates["enabled"] = tuple(data["enabled"])
-
-    if not updates:
-        return _error_response(
-            400,
-            "Bad Request",
-            "No valid fields to update. Supported: mode, disabled, enabled.",
-        )
+    updates, err = _parse_config_updates(data)
+    if err is not None:
+        return err
 
     new_config = replace(config, **updates)
 

--- a/src/toolregistry/admin/server.py
+++ b/src/toolregistry/admin/server.py
@@ -16,6 +16,7 @@ from .auth import TokenAuth
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
+    from toolregistry.config import ToolConfig
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +45,13 @@ class AdminApp(App):
         registry: The ToolRegistry instance to manage.
         auth: Optional TokenAuth instance for authentication.
         serve_ui: Whether to serve the admin UI at root path.
+        config: Optional ToolConfig for config-aware endpoints.
     """
 
     registry: "ToolRegistry"
     auth: TokenAuth | None
     serve_ui: bool
+    config: "ToolConfig | None"
 
 
 class AdminServer:
@@ -84,6 +87,7 @@ class AdminServer:
         serve_ui: bool = True,
         remote: bool = False,
         auth_token: str | None = None,
+        config: "ToolConfig | None" = None,
     ) -> None:
         """Initialize admin server.
 
@@ -97,12 +101,17 @@ class AdminServer:
             auth_token: Optional authentication token. If None and remote is True,
                 a random token is generated. If None and remote is False, no
                 authentication is required.
+            config: Optional ToolConfig for config-aware admin endpoints.
+                When provided, enables ``GET /api/config`` and
+                ``PUT /api/config`` endpoints for viewing and persisting
+                configuration changes.
         """
         self._registry = registry
         self._host = "0.0.0.0" if remote else host
         self._port = port
         self._serve_ui = serve_ui
         self._remote = remote
+        self._config = config
 
         # Set up authentication
         if auth_token is not None:
@@ -166,6 +175,7 @@ class AdminServer:
         self._app.registry = self._registry
         self._app.auth = self._auth
         self._app.serve_ui = self._serve_ui
+        self._app.config = self._config
 
         # Register routes and middleware
         from .handlers import setup_routes

--- a/src/toolregistry/config/__init__.py
+++ b/src/toolregistry/config/__init__.py
@@ -13,7 +13,7 @@ Example::
         print(source)
 """
 
-from ._loader import load_config
+from ._loader import load_config, save_config
 from ._types import (
     AuthConfig,
     ConfigError,
@@ -26,6 +26,7 @@ from ._types import (
 
 __all__ = [
     "load_config",
+    "save_config",
     "AuthConfig",
     "ConfigError",
     "MCPSource",

--- a/src/toolregistry/config/_loader.py
+++ b/src/toolregistry/config/_loader.py
@@ -16,7 +16,7 @@ from ._types import (
     ToolSource,
 )
 
-__all__ = ["load_config"]
+__all__ = ["load_config", "save_config"]
 
 _TRANSPORT_ALIASES: dict[str, str] = {
     "http": "streamable-http",
@@ -45,6 +45,37 @@ def load_config(path: str | Path) -> ToolConfig:
     fmt = _detect_format(p)
     data = _parse_file(p, fmt)
     return _build_config(data, source=str(p))
+
+
+def save_config(config: ToolConfig, path: str | Path) -> None:
+    """Serialize a ``ToolConfig`` and write it to a file.
+
+    The output format is auto-detected from the file extension:
+    ``.json`` / ``.jsonc`` produce JSON, ``.yaml`` / ``.yml`` produce
+    YAML.  Uses the vendored serializers so no external dependencies
+    are required.
+
+    Args:
+        config: The configuration to serialize.
+        path: Destination file path.
+
+    Raises:
+        ConfigError: If the file extension is unsupported.
+    """
+    import json
+
+    p = Path(path)
+    fmt = _detect_format(p)
+    data = config.to_dict()
+
+    if fmt == "jsonc":
+        text = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    else:
+        from .._vendor.yaml import dump as yaml_dump
+
+        text = yaml_dump(data)
+
+    p.write_text(text, encoding="utf-8")
 
 
 # --- format detection -------------------------------------------------------

--- a/src/toolregistry/config/_types.py
+++ b/src/toolregistry/config/_types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 __all__ = [
     "ConfigError",
@@ -44,6 +44,22 @@ class AuthConfig:
     token_env: str | None = None
     header_name: str = "Authorization"
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a config-file-compatible dict.
+
+        Omits fields with default values for cleaner output.
+        The ``token`` field is excluded to avoid leaking secrets;
+        only ``token_env`` is preserved.
+        """
+        d: dict[str, Any] = {}
+        if self.type != "bearer":
+            d["type"] = self.type
+        if self.token_env:
+            d["token_env"] = self.token_env
+        if self.type == "header" and self.header_name != "Authorization":
+            d["header_name"] = self.header_name
+        return d
+
 
 @dataclass(frozen=True)
 class PythonSource:
@@ -80,6 +96,23 @@ class PythonSource:
                 "PythonSource accepts only one of 'class_path' or 'module_path', not both."
             )
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a config-file-compatible dict.
+
+        Maps ``class_path`` back to the ``"class"`` key and
+        ``module_path`` to ``"module"`` for config-file compatibility.
+        """
+        d: dict[str, Any] = {"type": "python"}
+        if self.class_path:
+            d["class"] = self.class_path
+        if self.module_path:
+            d["module"] = self.module_path
+        if self.namespace:
+            d["namespace"] = self.namespace
+        if not self.enabled:
+            d["enabled"] = False
+        return d
+
 
 @dataclass(frozen=True)
 class MCPSource:
@@ -113,6 +146,28 @@ class MCPSource:
     headers: dict[str, str] | None = None
     persistent: bool = True
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a config-file-compatible dict.
+
+        Omits fields with default values for cleaner output.
+        """
+        d: dict[str, Any] = {"type": "mcp", "transport": self.transport}
+        if self.namespace:
+            d["namespace"] = self.namespace
+        if not self.enabled:
+            d["enabled"] = False
+        if self.command:
+            d["command"] = list(self.command)
+        if self.env:
+            d["env"] = dict(self.env)
+        if self.url:
+            d["url"] = self.url
+        if self.headers:
+            d["headers"] = dict(self.headers)
+        if not self.persistent:
+            d["persistent"] = False
+        return d
+
 
 @dataclass(frozen=True)
 class OpenAPISource:
@@ -132,6 +187,22 @@ class OpenAPISource:
     enabled: bool = True
     auth: AuthConfig | None = None
     base_url: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a config-file-compatible dict.
+
+        Omits fields with default values for cleaner output.
+        """
+        d: dict[str, Any] = {"type": "openapi", "url": self.url}
+        if self.namespace:
+            d["namespace"] = self.namespace
+        if not self.enabled:
+            d["enabled"] = False
+        if self.auth:
+            d["auth"] = self.auth.to_dict()
+        if self.base_url:
+            d["base_url"] = self.base_url
+        return d
 
 
 ToolSource = PythonSource | MCPSource | OpenAPISource
@@ -157,3 +228,19 @@ class ToolConfig:
     enabled: tuple[str, ...] = ()
     tools: tuple[ToolSource, ...] = ()
     source: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a config-file-compatible dict.
+
+        Omits fields with default values for cleaner output.
+        The ``source`` (file path) field is excluded as it is
+        diagnostic metadata, not part of the config schema.
+        """
+        d: dict[str, Any] = {"mode": self.mode}
+        if self.disabled:
+            d["disabled"] = list(self.disabled)
+        if self.enabled:
+            d["enabled"] = list(self.enabled)
+        if self.tools:
+            d["tools"] = [t.to_dict() for t in self.tools]
+        return d

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -871,6 +871,10 @@ class ToolRegistry(
                 - tags (list[str]): Sorted union of predefined and custom tags
                 - locality (str): ``"local"``, ``"remote"``, or ``"any"``
                 - is_async (bool): Whether the tool requires async execution
+                - source (str): Origin of the tool (e.g. ``"native"``,
+                  ``"mcp"``, ``"openapi"``, ``"langchain"``)
+                - source_detail (str): Extra detail about the tool's origin
+                  (e.g. transport URI, spec URL, class name)
                 - think_augment (bool | None): Think-augmented calling setting
                 - defer (bool): Whether the tool is deferred from initial prompt
                 - has_native_thought (bool): Whether the function natively
@@ -910,6 +914,8 @@ class ToolRegistry(
                     "tags": sorted(meta.all_tags),
                     "locality": meta.locality,
                     "is_async": meta.is_async,
+                    "source": meta.source,
+                    "source_detail": meta.source_detail,
                     "think_augment": meta.think_augment,
                     "defer": meta.defer,
                     "has_native_thought": tool._has_native_thought_param(),

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -935,3 +935,169 @@ class TestAdminServerMetadataUpdate:
             data={"defer": True},
         )
         assert status == 404
+
+
+class TestAdminSourcesAndConfig:
+    """Tests for source info, /api/sources, and /api/config endpoints."""
+
+    @pytest.fixture
+    def server_with_tools(self):
+        """Create a server with registered tools."""
+        registry = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        def subtract(a: int, b: int) -> int:
+            """Subtract two numbers."""
+            return a - b
+
+        registry.register(add, namespace="math")
+        registry.register(subtract, namespace="math")
+
+        server = AdminServer(registry, port=18094)
+        info = server.start()
+        time.sleep(0.1)
+
+        yield server, info, registry
+
+        server.stop()
+
+    def _request(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict | None = None,
+    ) -> tuple[int, dict]:
+        """Make HTTP request and return status code and JSON response."""
+        headers = {"Content-Type": "application/json"}
+        body = json.dumps(data).encode() if data else None
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as response:
+                return response.status, json.loads(response.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode())
+
+    def test_get_tools_includes_source(self, server_with_tools) -> None:
+        """Test GET /api/tools includes source and source_detail fields."""
+        server, info, registry = server_with_tools
+        status, data = self._request(f"{info.url}/api/tools")
+        assert status == 200
+        for tool in data["tools"]:
+            assert "source" in tool
+            assert "source_detail" in tool
+            assert tool["source"] == "native"
+
+    def test_get_tool_detail_includes_source(self, server_with_tools) -> None:
+        """Test GET /api/tools/{name} includes source in metadata."""
+        server, info, registry = server_with_tools
+        status, data = self._request(f"{info.url}/api/tools/math-add")
+        assert status == 200
+        assert "source" in data["metadata"]
+        assert "source_detail" in data["metadata"]
+        assert data["metadata"]["source"] == "native"
+
+    def test_get_sources(self, server_with_tools) -> None:
+        """Test GET /api/sources returns aggregated source info."""
+        server, info, registry = server_with_tools
+        status, data = self._request(f"{info.url}/api/sources")
+        assert status == 200
+        assert "sources" in data
+        assert len(data["sources"]) >= 1
+        src = data["sources"][0]
+        assert "type" in src
+        assert "detail" in src
+        assert "namespace" in src
+        assert "tool_count" in src
+        assert "enabled_count" in src
+        assert "tools" in src
+        assert src["type"] == "native"
+        assert src["tool_count"] == 2
+
+    def test_export_state_includes_sources(self, server_with_tools) -> None:
+        """Test GET /api/state includes sources in export."""
+        server, info, registry = server_with_tools
+        status, data = self._request(f"{info.url}/api/state")
+        assert status == 200
+        assert "sources" in data
+        assert "math-add" in data["sources"]
+        assert data["sources"]["math-add"]["source"] == "native"
+
+    def test_get_config_no_config(self, server_with_tools) -> None:
+        """Test GET /api/config returns 404 when no config loaded."""
+        server, info, registry = server_with_tools
+        status, data = self._request(f"{info.url}/api/config")
+        assert status == 404
+
+    def test_config_endpoints_with_config(self, tmp_path) -> None:
+        """Test GET/PUT /api/config with a loaded config."""
+        from toolregistry.config import ToolConfig, PythonSource, load_config
+
+        config = ToolConfig(
+            mode="denylist",
+            disabled=("ns1",),
+            tools=(PythonSource(class_path="a.B", namespace="calc"),),
+            source=str(tmp_path / "tools.json"),
+        )
+        # Write initial config file
+        config_path = tmp_path / "tools.json"
+        config_path.write_text('{"mode": "denylist", "disabled": ["ns1"]}')
+
+        registry = ToolRegistry()
+        registry.register(lambda x: x, name="echo")
+        server = AdminServer(registry, port=18095, config=config)
+        info = server.start()
+        time.sleep(0.1)
+
+        try:
+            # GET /api/config
+            status, data = self._request(f"{info.url}/api/config")
+            assert status == 200
+            assert data["mode"] == "denylist"
+            assert "ns1" in data["disabled"]
+            assert data["source"] == str(config_path)
+
+            # PUT /api/config — update disabled list
+            status, data = self._request(
+                f"{info.url}/api/config",
+                method="PUT",
+                data={"disabled": ["ns1", "ns2"]},
+            )
+            assert status == 200
+            assert data["saved"] is True
+            assert "ns2" in data["disabled"]
+
+            # Verify file was written
+            reloaded = load_config(config_path)
+            assert "ns2" in reloaded.disabled
+
+            # GET /api/config should reflect update
+            status, data = self._request(f"{info.url}/api/config")
+            assert status == 200
+            assert "ns2" in data["disabled"]
+        finally:
+            server.stop()
+
+    def test_update_config_invalid_mode(self, tmp_path) -> None:
+        """Test PUT /api/config rejects invalid mode."""
+        from toolregistry.config import ToolConfig
+
+        config = ToolConfig(source=str(tmp_path / "tools.json"))
+        (tmp_path / "tools.json").write_text('{"mode": "denylist"}')
+
+        registry = ToolRegistry()
+        server = AdminServer(registry, port=18096, config=config)
+        info = server.start()
+        time.sleep(0.1)
+
+        try:
+            status, data = self._request(
+                f"{info.url}/api/config",
+                method="PUT",
+                data={"mode": "invalid"},
+            )
+            assert status == 400
+        finally:
+            server.stop()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,12 +7,14 @@ from pathlib import Path
 import pytest
 
 from toolregistry.config import (
+    AuthConfig,
     ConfigError,
     MCPSource,
     OpenAPISource,
     PythonSource,
     ToolConfig,
     load_config,
+    save_config,
 )
 
 
@@ -798,3 +800,234 @@ tools:
         assert isinstance(s4, MCPSource)
         assert s4.transport == "streamable-http"
         assert s4.url == "http://localhost:8080/mcp"
+
+
+# ---------------------------------------------------------------------------
+# Serialization — to_dict() and save_config()
+# ---------------------------------------------------------------------------
+
+
+class TestToDict:
+    """Tests for to_dict() methods on config dataclasses."""
+
+    def test_python_source_class_path(self) -> None:
+        """PythonSource with class_path maps to 'class' key."""
+        src = PythonSource(class_path="pkg.module.Cls", namespace="calc")
+        d = src.to_dict()
+        assert d["type"] == "python"
+        assert d["class"] == "pkg.module.Cls"
+        assert d["namespace"] == "calc"
+        assert "module" not in d
+        assert "enabled" not in d  # default True omitted
+
+    def test_python_source_module_path(self) -> None:
+        """PythonSource with module_path maps to 'module' key."""
+        src = PythonSource(module_path="pkg.tools", enabled=False)
+        d = src.to_dict()
+        assert d["type"] == "python"
+        assert d["module"] == "pkg.tools"
+        assert d["enabled"] is False
+        assert "class" not in d
+
+    def test_mcp_source_stdio(self) -> None:
+        """MCPSource with stdio transport serializes command."""
+        src = MCPSource(
+            transport="stdio",
+            command=("python", "-m", "srv"),
+            namespace="mcp1",
+            env={"DEBUG": "1"},
+        )
+        d = src.to_dict()
+        assert d["type"] == "mcp"
+        assert d["transport"] == "stdio"
+        assert d["command"] == ["python", "-m", "srv"]
+        assert d["env"] == {"DEBUG": "1"}
+        assert d["namespace"] == "mcp1"
+        assert "url" not in d
+        assert "persistent" not in d  # default True omitted
+
+    def test_mcp_source_sse(self) -> None:
+        """MCPSource with sse transport serializes url."""
+        src = MCPSource(
+            transport="sse",
+            url="http://localhost:8080/sse",
+            persistent=False,
+        )
+        d = src.to_dict()
+        assert d["type"] == "mcp"
+        assert d["transport"] == "sse"
+        assert d["url"] == "http://localhost:8080/sse"
+        assert d["persistent"] is False
+        assert "command" not in d
+
+    def test_openapi_source_basic(self) -> None:
+        """OpenAPISource serializes url and optional fields."""
+        src = OpenAPISource(
+            url="http://api.example.com/spec.json",
+            namespace="api1",
+            base_url="http://api.example.com",
+        )
+        d = src.to_dict()
+        assert d["type"] == "openapi"
+        assert d["url"] == "http://api.example.com/spec.json"
+        assert d["namespace"] == "api1"
+        assert d["base_url"] == "http://api.example.com"
+        assert "auth" not in d
+
+    def test_openapi_source_with_auth(self) -> None:
+        """OpenAPISource with auth config serializes auth."""
+        auth = AuthConfig(type="bearer", token_env="API_KEY")
+        src = OpenAPISource(url="http://api.example.com/spec.json", auth=auth)
+        d = src.to_dict()
+        assert "auth" in d
+        assert d["auth"]["token_env"] == "API_KEY"
+        # Token should not be in dict (security)
+        assert "token" not in d["auth"]
+
+    def test_auth_config_defaults_omitted(self) -> None:
+        """AuthConfig with all defaults produces empty dict."""
+        auth = AuthConfig()
+        d = auth.to_dict()
+        assert d == {}
+
+    def test_auth_config_custom_header(self) -> None:
+        """AuthConfig with custom header type serializes correctly."""
+        auth = AuthConfig(type="header", token_env="X_KEY", header_name="X-Api-Key")
+        d = auth.to_dict()
+        assert d["type"] == "header"
+        assert d["token_env"] == "X_KEY"
+        assert d["header_name"] == "X-Api-Key"
+
+    def test_tool_config_full(self) -> None:
+        """ToolConfig.to_dict() produces clean config dict."""
+        config = ToolConfig(
+            mode="denylist",
+            disabled=("ns1", "ns2"),
+            tools=(
+                PythonSource(class_path="a.B", namespace="calc"),
+                MCPSource(transport="stdio", command=("python", "-m", "srv")),
+            ),
+            source="/path/to/config.yaml",
+        )
+        d = config.to_dict()
+        assert d["mode"] == "denylist"
+        assert d["disabled"] == ["ns1", "ns2"]
+        assert len(d["tools"]) == 2
+        assert d["tools"][0]["type"] == "python"
+        assert d["tools"][1]["type"] == "mcp"
+        # source path should NOT be in the dict
+        assert "source" not in d
+
+    def test_tool_config_empty(self) -> None:
+        """ToolConfig with defaults produces minimal dict."""
+        config = ToolConfig()
+        d = config.to_dict()
+        assert d == {"mode": "denylist"}
+
+    def test_tool_config_allowlist(self) -> None:
+        """ToolConfig in allowlist mode includes enabled list."""
+        config = ToolConfig(mode="allowlist", enabled=("ns1",))
+        d = config.to_dict()
+        assert d["mode"] == "allowlist"
+        assert d["enabled"] == ["ns1"]
+        assert "disabled" not in d
+
+
+class TestSaveConfig:
+    """Tests for save_config() function."""
+
+    def test_save_json(self, tmp_path: Path) -> None:
+        """save_config writes valid JSON that can be reloaded."""
+        config = ToolConfig(
+            mode="denylist",
+            disabled=("ns1",),
+            tools=(PythonSource(class_path="a.B", namespace="calc"),),
+        )
+        path = tmp_path / "tools.json"
+        save_config(config, path)
+
+        loaded = load_config(path)
+        assert loaded.mode == "denylist"
+        assert loaded.disabled == ("ns1",)
+        assert len(loaded.tools) == 1
+        assert isinstance(loaded.tools[0], PythonSource)
+
+    def test_save_yaml(self, tmp_path: Path) -> None:
+        """save_config writes valid YAML that can be reloaded."""
+        config = ToolConfig(
+            mode="allowlist",
+            enabled=("calc",),
+            tools=(MCPSource(transport="sse", url="http://localhost:8080/sse"),),
+        )
+        path = tmp_path / "tools.yaml"
+        save_config(config, path)
+
+        loaded = load_config(path)
+        assert loaded.mode == "allowlist"
+        assert loaded.enabled == ("calc",)
+        assert len(loaded.tools) == 1
+        assert isinstance(loaded.tools[0], MCPSource)
+        assert loaded.tools[0].url == "http://localhost:8080/sse"
+
+    def test_save_roundtrip_complex(self, tmp_path: Path) -> None:
+        """Round-trip a complex config through save and load."""
+        original = ToolConfig(
+            mode="denylist",
+            disabled=("ns1", "ns2"),
+            tools=(
+                PythonSource(class_path="pkg.Cls", namespace="py1"),
+                PythonSource(module_path="pkg.tools", namespace="py2", enabled=False),
+                MCPSource(
+                    transport="stdio",
+                    command=("python", "-m", "srv"),
+                    namespace="mcp1",
+                    env={"KEY": "val"},
+                ),
+                MCPSource(
+                    transport="sse",
+                    url="http://localhost:8080/sse",
+                    namespace="mcp2",
+                    persistent=False,
+                ),
+                OpenAPISource(
+                    url="http://api.example.com/spec.json",
+                    namespace="api1",
+                    base_url="http://api.example.com",
+                ),
+            ),
+        )
+
+        for ext in (".json", ".yaml"):
+            path = tmp_path / f"config{ext}"
+            save_config(original, path)
+            loaded = load_config(path)
+
+            assert loaded.mode == original.mode
+            assert loaded.disabled == original.disabled
+            assert len(loaded.tools) == len(original.tools)
+
+            # Verify each tool type round-trips
+            assert isinstance(loaded.tools[0], PythonSource)
+            assert loaded.tools[0].class_path == "pkg.Cls"
+
+            assert isinstance(loaded.tools[1], PythonSource)
+            assert loaded.tools[1].module_path == "pkg.tools"
+            assert loaded.tools[1].enabled is False
+
+            assert isinstance(loaded.tools[2], MCPSource)
+            assert loaded.tools[2].transport == "stdio"
+            assert loaded.tools[2].command == ("python", "-m", "srv")
+            assert loaded.tools[2].env == {"KEY": "val"}
+
+            assert isinstance(loaded.tools[3], MCPSource)
+            assert loaded.tools[3].transport == "sse"
+            assert loaded.tools[3].persistent is False
+
+            assert isinstance(loaded.tools[4], OpenAPISource)
+            assert loaded.tools[4].base_url == "http://api.example.com"
+
+    def test_save_unsupported_extension(self, tmp_path: Path) -> None:
+        """save_config raises ConfigError for unsupported extension."""
+        config = ToolConfig()
+        with pytest.raises(ConfigError, match="Unsupported"):
+            save_config(config, tmp_path / "config.toml")


### PR DESCRIPTION
Closes #121

## Summary
- Add `to_dict()` methods to all config dataclasses for serialization
- Add `save_config()` to write ToolConfig back to JSON/YAML files
- Expose `source`/`source_detail` in admin API tool responses
- Add `GET /api/sources` endpoint aggregating tools by origin
- Add `GET/PUT /api/config` endpoints for config file persistence
- Add Sources tab, source badges, source filter in admin UI
- Add config section in State tab for save-to-file workflow
- Enhanced state export includes per-tool source metadata
- Add i18n translations (en/zh) for all new UI strings

## Test plan
- [x] 11 `to_dict()` serialization tests
- [x] 4 `save_config()` tests (JSON, YAML, roundtrip, error)
- [x] 7 admin API endpoint tests (sources, config GET/PUT, error cases)
- [x] Full suite: 915 passed, 0 regressions