### PR TITLE
Switch complexipy to local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,11 @@ repos:
         require_serial: true
         types: [python]
 
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
+  - repo: local
     hooks:
       - id: complexipy
+        name: complexipy (complexity check)
+        entry: complexipy src/toolregistry tests -e _vendor -mx 20
+        language: system
         pass_filenames: false
-        args: [., -e, src/toolregistry/_vendor, -e, examples, -mx, "20"]
+        always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "fastapi>=0.115.12",
     "ty>=0.0.21",
     "ruff>=0.1.0",
+    "complexipy>=4.2.0",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
     "deprecated>=1.2.18",


### PR DESCRIPTION
## Summary
- Replace complexipy pre-commit repo hook with local hook
- The repo hook's `-e` flag does not recursively exclude subdirectories, so vendored subpackages still get scanned
- Local hook with explicit scan paths (`src/toolregistry tests`) and `-e _vendor` works correctly

## Test plan
- [x] `pre-commit run complexipy --all-files` passes