### PR TITLE
feat(registry): add disable_by_tags() and post-registration hook interface

### DIFF
--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -6,7 +6,7 @@ from .admin import (
     ExecutionStatus,
     TokenAuth,
 )
-from .events import ChangeCallback, ChangeEvent, ChangeEventType
+from .events import ChangeCallback, ChangeEvent, ChangeEventType, PostRegisterHook
 from .executor import (
     ExecutionContext,
     ProcessPoolBackend,
@@ -41,6 +41,7 @@ __all__ = [
     "PermissionRequest",
     "PermissionResult",
     "PermissionRule",
+    "PostRegisterHook",
     "ProcessPoolBackend",
     "ProgressReport",
     "ThreadBackend",

--- a/src/toolregistry/_mixins/callbacks.py
+++ b/src/toolregistry/_mixins/callbacks.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from ..events import ChangeCallback, ChangeEvent, PostRegisterHook
 
 if TYPE_CHECKING:
     from ..tool import Tool
+    from ..tool_registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +147,7 @@ class ChangeCallbackMixin:
 
         for hook in hooks:
             try:
-                result = hook(tool_name, tool, self)  # type: ignore[arg-type]
+                result = hook(tool_name, tool, cast("ToolRegistry", self))
             except Exception as exc:
                 logger.warning(f"Post-register hook {hook!r} raised exception: {exc}")
                 continue
@@ -154,7 +155,7 @@ class ChangeCallbackMixin:
             if result:
                 # Non-empty string → auto-disable
                 try:
-                    self.disable(tool_name, reason=result)  # type: ignore[attr-defined]
+                    cast("ToolRegistry", self).disable(tool_name, reason=result)
                 except Exception as exc:
                     logger.warning(
                         f"Auto-disable triggered by post-register hook {hook!r} "

--- a/src/toolregistry/_mixins/callbacks.py
+++ b/src/toolregistry/_mixins/callbacks.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import TYPE_CHECKING
 
-from ..events import ChangeCallback, ChangeEvent
+from ..events import ChangeCallback, ChangeEvent, PostRegisterHook
+
+if TYPE_CHECKING:
+    from ..tool import Tool
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +21,8 @@ class ChangeCallbackMixin:
         super().__init__(**kwargs)
         self._change_callbacks: list[ChangeCallback] = []
         self._callback_lock = threading.Lock()
+        self._post_register_hooks: list[PostRegisterHook] = []
+        self._hooks_lock = threading.Lock()
 
     def on_change(self, callback: ChangeCallback) -> None:
         """Register a callback to be notified of tool state changes.
@@ -89,3 +95,68 @@ class ChangeCallbackMixin:
                 # Log but don't propagate - one bad callback shouldn't
                 # break the entire notification chain
                 logger.warning(f"Change callback {callback!r} raised exception: {e}")
+
+    def add_post_register_hook(self, hook: PostRegisterHook) -> None:
+        """Register a hook to be called after each tool is added to the registry.
+
+        Hooks are invoked synchronously in registration order immediately after
+        a tool is inserted into the registry (before the REGISTER change event
+        is emitted).  If a hook returns a non-empty string the tool is
+        auto-disabled with that string as the reason.  Returning ``None`` leaves
+        the tool enabled.
+
+        Args:
+            hook: Callable with signature
+                ``(tool_name: str, tool: Tool, registry: ToolRegistry) -> str | None``.
+                Must not raise exceptions that should propagate; any exception
+                is caught and logged.
+
+        Note:
+            - Hooks are invoked in registration order.
+            - The same hook can be registered multiple times.
+            - Hooks should be lightweight; heavy processing should be
+              offloaded to a separate thread/task.
+
+        Example:
+            ```python
+            def my_hook(name: str, tool: Tool, registry: ToolRegistry) -> str | None:
+                if name.startswith("dangerous_"):
+                    return "Blocked by policy"
+                return None
+
+            registry.add_post_register_hook(my_hook)
+            ```
+        """
+        with self._hooks_lock:
+            self._post_register_hooks.append(hook)
+
+    def _run_post_register_hooks(self, tool_name: str, tool: Tool) -> None:
+        """Invoke all registered post-register hooks for a newly added tool.
+
+        Each hook is called with ``(tool_name, tool, self)``.  If a hook
+        returns a non-empty string the tool is auto-disabled.  Exceptions
+        raised inside hooks are caught and logged so they never propagate.
+
+        Args:
+            tool_name: The name under which the tool was registered.
+            tool: The :class:`~toolregistry.tool.Tool` instance that was added.
+        """
+        with self._hooks_lock:
+            hooks = self._post_register_hooks.copy()
+
+        for hook in hooks:
+            try:
+                result = hook(tool_name, tool, self)  # type: ignore[arg-type]
+            except Exception as exc:
+                logger.warning(f"Post-register hook {hook!r} raised exception: {exc}")
+                continue
+
+            if result:
+                # Non-empty string → auto-disable
+                try:
+                    self.disable(tool_name, reason=result)  # type: ignore[attr-defined]
+                except Exception as exc:
+                    logger.warning(
+                        f"Auto-disable triggered by post-register hook {hook!r} "
+                        f"failed for tool '{tool_name}': {exc}"
+                    )

--- a/src/toolregistry/_mixins/enable_disable.py
+++ b/src/toolregistry/_mixins/enable_disable.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from ..events import ChangeEvent, ChangeEventType
 
 if TYPE_CHECKING:
-    from ..tool import Tool
+    from ..tool import Tool, ToolTag
 
 
 class EnableDisableMixin:
@@ -87,6 +87,49 @@ class EnableDisableMixin:
         if tool and tool.namespace:
             return self._disabled.get(tool.namespace)
         return None
+
+    def disable_by_tags(
+        self,
+        tags: set[ToolTag],
+        *,
+        match: Literal["any", "all"] = "any",
+        reason: str = "Disabled by tag filter",
+    ) -> list[str]:
+        """Disable all tools whose metadata tags overlap with *tags*.
+
+        Args:
+            tags: Set of ToolTag values to match against.
+            match: ``"any"`` disables tools that have at least one matching tag
+                (default). ``"all"`` requires all tags to be present.
+            reason: Disable reason recorded on each tool.
+
+        Returns:
+            List of tool names that were disabled.
+        """
+        if not tags:
+            return []
+
+        # Normalise the incoming tags to their string values so comparisons
+        # work regardless of whether callers pass ToolTag enum members or
+        # plain strings (ToolTag inherits from str, so this is transparent).
+        tag_strs: set[str] = {t if isinstance(t, str) else t.value for t in tags}
+
+        disabled: list[str] = []
+        for name, tool in self._tools.items():
+            if tool.metadata is None:
+                continue
+            # Skip tools that are already disabled.
+            if not self.is_enabled(name):
+                continue
+            tool_tags = tool.metadata.all_tags
+            if match == "any":
+                matched = bool(tool_tags & tag_strs)
+            else:
+                matched = tag_strs.issubset(tool_tags)
+            if matched:
+                self.disable(name, reason=reason)
+                disabled.append(name)
+        return disabled
 
     # Fields safe to update at runtime via update_tool_metadata()
     _MUTABLE_METADATA_FIELDS: frozenset[str] = frozenset({"think_augment", "defer"})

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -32,6 +32,8 @@ class RegistrationMixin:
 
         def _emit_change(self, event: ChangeEvent) -> None: ...
 
+        def _run_post_register_hooks(self, tool_name: str, tool: Tool) -> None: ...
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._mcp_integrations: list = []
@@ -61,6 +63,7 @@ class RegistrationMixin:
             tool_or_func.update_namespace(namespace, force=True)
             self._tools[tool_or_func.name] = tool_or_func
             registered_name = tool_or_func.name
+            registered_tool = tool_or_func
         else:
             tool = Tool.from_function(
                 tool_or_func,
@@ -71,6 +74,9 @@ class RegistrationMixin:
             )
             self._tools[tool.name] = tool
             registered_name = tool.name
+            registered_tool = tool
+
+        self._run_post_register_hooks(registered_name, registered_tool)
 
         self._emit_change(
             ChangeEvent(

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -4,10 +4,16 @@ This module provides the event infrastructure for the callback mechanism,
 enabling subscribers to receive notifications when tool state changes occur.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 from collections.abc import Callable
+
+if TYPE_CHECKING:
+    from .tool import Tool
+    from .tool_registry import ToolRegistry
 
 
 class ChangeEventType(str, Enum):
@@ -54,3 +60,16 @@ class ChangeEvent:
 
 ChangeCallback: TypeAlias = Callable[[ChangeEvent], None]
 """Callback signature: receives a ChangeEvent, returns nothing."""
+
+PostRegisterHook: TypeAlias = Callable[[str, "Tool", "ToolRegistry"], "str | None"]
+"""Hook called after a tool is added to the registry.
+
+Args:
+    tool_name: The name under which the tool was registered.
+    tool: The :class:`~toolregistry.tool.Tool` instance that was registered.
+    registry: The :class:`~toolregistry.tool_registry.ToolRegistry` that owns it.
+
+Returns:
+    A non-empty string to auto-disable the tool with that string as the
+    reason, or ``None`` to leave the tool enabled.
+"""

--- a/tests/test_enable_disable.py
+++ b/tests/test_enable_disable.py
@@ -2,6 +2,7 @@
 
 import json
 
+from toolregistry.tool import Tool, ToolMetadata, ToolTag
 from toolregistry.tool_registry import ToolRegistry
 from toolregistry.types import (
     ChatCompletionMessageFunctionToolCall,
@@ -512,3 +513,150 @@ class TestGetToolsStatus:
         assert status[0]["enabled"] is False
         # Empty string reason is still returned
         assert status[0]["reason"] == ""
+
+
+# ===========================================================================
+# 9. disable_by_tags
+# ===========================================================================
+
+
+def _make_tagged_registry() -> ToolRegistry:
+    """Build a registry with three tools carrying different tags for testing."""
+    registry = ToolRegistry(name="test")
+
+    def read_data() -> str:
+        """Read some data."""
+        return "data"
+
+    def delete_data() -> str:
+        """Delete some data."""
+        return "deleted"
+
+    def fetch_url() -> str:
+        """Fetch a URL."""
+        return "content"
+
+    registry.register(
+        Tool.from_function(read_data, metadata=ToolMetadata(tags={ToolTag.READ_ONLY}))
+    )
+    registry.register(
+        Tool.from_function(
+            delete_data, metadata=ToolMetadata(tags={ToolTag.DESTRUCTIVE})
+        )
+    )
+    registry.register(
+        Tool.from_function(
+            fetch_url, metadata=ToolMetadata(tags={ToolTag.NETWORK, ToolTag.READ_ONLY})
+        )
+    )
+    return registry
+
+
+class TestDisableByTags:
+    """Verify disable_by_tags() with match='any' and match='all' modes."""
+
+    def test_match_any_disables_tools_with_at_least_one_tag(self):
+        registry = _make_tagged_registry()
+        # READ_ONLY matches read_data and fetch_url
+        result = registry.disable_by_tags({ToolTag.READ_ONLY}, match="any")
+        assert set(result) == {"read_data", "fetch_url"}
+        assert not registry.is_enabled("read_data")
+        assert not registry.is_enabled("fetch_url")
+        assert registry.is_enabled("delete_data")
+
+    def test_match_any_default_mode(self):
+        registry = _make_tagged_registry()
+        # Default match is "any"
+        result = registry.disable_by_tags({ToolTag.NETWORK})
+        assert result == ["fetch_url"]
+        assert not registry.is_enabled("fetch_url")
+
+    def test_match_all_requires_all_tags_present(self):
+        registry = _make_tagged_registry()
+        # Only fetch_url has both NETWORK and READ_ONLY
+        result = registry.disable_by_tags(
+            {ToolTag.NETWORK, ToolTag.READ_ONLY}, match="all"
+        )
+        assert result == ["fetch_url"]
+        assert not registry.is_enabled("fetch_url")
+        assert registry.is_enabled("read_data")
+        assert registry.is_enabled("delete_data")
+
+    def test_match_all_no_match_returns_empty(self):
+        registry = _make_tagged_registry()
+        # No tool has both DESTRUCTIVE and NETWORK
+        result = registry.disable_by_tags(
+            {ToolTag.DESTRUCTIVE, ToolTag.NETWORK}, match="all"
+        )
+        assert result == []
+        assert registry.is_enabled("read_data")
+        assert registry.is_enabled("delete_data")
+        assert registry.is_enabled("fetch_url")
+
+    def test_no_intersection_returns_empty_list(self):
+        registry = _make_tagged_registry()
+        result = registry.disable_by_tags({ToolTag.PRIVILEGED}, match="any")
+        assert result == []
+        assert registry.is_enabled("read_data")
+        assert registry.is_enabled("delete_data")
+        assert registry.is_enabled("fetch_url")
+
+    def test_already_disabled_tool_skipped_in_return(self):
+        registry = _make_tagged_registry()
+        # Pre-disable fetch_url before the bulk operation.
+        registry.disable("fetch_url", reason="pre-disabled")
+        result = registry.disable_by_tags({ToolTag.READ_ONLY}, match="any")
+        # fetch_url was already disabled — must NOT appear in the return value.
+        assert "fetch_url" not in result
+        assert "read_data" in result
+        # The pre-existing reason must be preserved (not overwritten).
+        assert registry.get_disable_reason("fetch_url") == "pre-disabled"
+
+    def test_custom_reason_recorded(self):
+        registry = _make_tagged_registry()
+        registry.disable_by_tags({ToolTag.DESTRUCTIVE}, reason="safety lockdown")
+        assert registry.get_disable_reason("delete_data") == "safety lockdown"
+
+    def test_default_reason_recorded(self):
+        registry = _make_tagged_registry()
+        registry.disable_by_tags({ToolTag.DESTRUCTIVE})
+        assert registry.get_disable_reason("delete_data") == "Disabled by tag filter"
+
+    def test_empty_tags_returns_empty_list(self):
+        registry = _make_tagged_registry()
+        result = registry.disable_by_tags(set())
+        assert result == []
+        # No tool should be disabled
+        assert registry.is_enabled("read_data")
+        assert registry.is_enabled("delete_data")
+        assert registry.is_enabled("fetch_url")
+
+    def test_tool_without_tags_not_matched(self):
+        """Tools with no tags at all are never matched by a non-empty tag set."""
+        registry = ToolRegistry(name="test")
+        registry.register(add)  # default ToolMetadata, no tags
+        result = registry.disable_by_tags({ToolTag.SLOW})
+        assert result == []
+        assert registry.is_enabled("add") is True
+
+    def test_empty_registry_returns_empty_list(self):
+        """disable_by_tags on an empty registry returns []."""
+        registry = ToolRegistry(name="test")
+        assert registry.disable_by_tags({ToolTag.SLOW}) == []
+
+    def test_custom_string_tags_matched(self):
+        """disable_by_tags works with plain string custom_tags via all_tags."""
+        from toolregistry.tool import Tool
+
+        registry = ToolRegistry(name="test")
+        registry.register(
+            Tool.from_function(add, metadata=ToolMetadata(custom_tags={"beta"}))
+        )
+        registry.register(
+            Tool.from_function(subtract, metadata=ToolMetadata(custom_tags={"stable"}))
+        )
+
+        result = registry.disable_by_tags({"beta"})  # type: ignore[arg-type]
+        assert result == ["add"]
+        assert not registry.is_enabled("add")
+        assert registry.is_enabled("subtract")

--- a/tests/test_post_register_hook.py
+++ b/tests/test_post_register_hook.py
@@ -1,0 +1,328 @@
+"""Tests for the post-registration hook interface.
+
+Covers:
+- Hook is invoked with the correct arguments after registration.
+- Returning a non-empty string auto-disables the tool with that reason.
+- Returning None leaves the tool enabled.
+- Multiple hooks are called in registration order.
+- An exception inside a hook does not affect the registration flow or
+  subsequent hooks.
+"""
+
+from __future__ import annotations
+
+
+from toolregistry import Tool, ToolRegistry
+
+
+# ============== Helper functions ==============
+
+
+def _make_tool_func(name: str = "my_tool"):
+    """Create a trivial callable suitable for registration."""
+
+    def tool_func():
+        """A simple test tool."""
+        return "ok"
+
+    tool_func.__name__ = name
+    return tool_func
+
+
+# ============== Hook invocation tests ==============
+
+
+class TestHookInvocation:
+    """Verify that the hook is called with the expected arguments."""
+
+    def test_hook_called_after_register(self):
+        """Hook receives (tool_name, tool, registry) after register()."""
+        registry = ToolRegistry()
+        calls: list[tuple] = []
+
+        def hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            calls.append((name, tool, reg))
+            return None
+
+        registry.add_post_register_hook(hook)
+        registry.register(_make_tool_func("alpha"))
+
+        assert len(calls) == 1
+        name, tool, reg = calls[0]
+        assert name == "alpha"
+        assert isinstance(tool, Tool)
+        assert tool.name == "alpha"
+        assert reg is registry
+
+    def test_hook_called_for_each_tool_in_register_from_class(self):
+        """Hook is called once per tool when using register_from_class()."""
+        registry = ToolRegistry()
+        seen: list[str] = []
+
+        def hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            seen.append(name)
+            return None
+
+        registry.add_post_register_hook(hook)
+
+        class MyClass:
+            @staticmethod
+            def tool_a() -> str:
+                """Tool A."""
+                return "a"
+
+            @staticmethod
+            def tool_b() -> str:
+                """Tool B."""
+                return "b"
+
+        registry.register_from_class(MyClass)
+
+        assert "tool_a" in seen
+        assert "tool_b" in seen
+        assert len(seen) == 2
+
+    def test_hook_called_with_tool_instance_registration(self):
+        """Hook works when a Tool instance is passed to register()."""
+        registry = ToolRegistry()
+        calls: list[str] = []
+
+        def hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            calls.append(name)
+            return None
+
+        registry.add_post_register_hook(hook)
+
+        tool = Tool.from_function(_make_tool_func("beta"))
+        registry.register(tool)
+
+        assert calls == ["beta"]
+
+
+# ============== Auto-disable tests ==============
+
+
+class TestAutoDisable:
+    """Verify auto-disable behaviour based on hook return value."""
+
+    def test_return_string_disables_tool(self):
+        """Returning a non-empty string from the hook disables the tool."""
+        registry = ToolRegistry()
+
+        def blocking_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            return "blocked by policy"
+
+        registry.add_post_register_hook(blocking_hook)
+        registry.register(_make_tool_func("restricted"))
+
+        assert not registry.is_enabled("restricted")
+        assert registry.get_disable_reason("restricted") == "blocked by policy"
+
+    def test_return_none_keeps_tool_enabled(self):
+        """Returning None from the hook leaves the tool enabled."""
+        registry = ToolRegistry()
+
+        def permissive_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            return None
+
+        registry.add_post_register_hook(permissive_hook)
+        registry.register(_make_tool_func("allowed"))
+
+        assert registry.is_enabled("allowed")
+
+    def test_return_empty_string_keeps_tool_enabled(self):
+        """Returning an empty string (falsy) does NOT disable the tool."""
+        registry = ToolRegistry()
+
+        def falsy_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            return ""  # type: ignore[return-value]
+
+        registry.add_post_register_hook(falsy_hook)
+        registry.register(_make_tool_func("keep_me"))
+
+        assert registry.is_enabled("keep_me")
+
+    def test_selective_disable_based_on_name(self):
+        """Hook can selectively disable only certain tools."""
+        registry = ToolRegistry()
+
+        def selective_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            if name.startswith("bad_"):
+                return "name prefix is disallowed"
+            return None
+
+        registry.add_post_register_hook(selective_hook)
+        registry.register(_make_tool_func("bad_tool"))
+        registry.register(_make_tool_func("good_tool"))
+
+        assert not registry.is_enabled("bad_tool")
+        assert registry.is_enabled("good_tool")
+
+
+# ============== Multiple hooks tests ==============
+
+
+class TestMultipleHooks:
+    """Verify that multiple hooks are invoked in registration order."""
+
+    def test_multiple_hooks_called_in_order(self):
+        """Hooks are invoked in the order they were registered."""
+        registry = ToolRegistry()
+        order: list[int] = []
+
+        registry.add_post_register_hook(lambda n, t, r: (order.append(1), None)[1])
+        registry.add_post_register_hook(lambda n, t, r: (order.append(2), None)[1])
+        registry.add_post_register_hook(lambda n, t, r: (order.append(3), None)[1])
+
+        registry.register(_make_tool_func("ordered"))
+
+        assert order == [1, 2, 3]
+
+    def test_all_hooks_run_even_if_first_disables(self):
+        """All hooks run even when an earlier hook auto-disables the tool."""
+        registry = ToolRegistry()
+        calls: list[int] = []
+
+        def hook1(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            calls.append(1)
+            return "disabled by hook1"
+
+        def hook2(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            calls.append(2)
+            return None
+
+        registry.add_post_register_hook(hook1)
+        registry.add_post_register_hook(hook2)
+        registry.register(_make_tool_func("multi"))
+
+        assert calls == [1, 2]
+        # hook1 wins; tool is disabled
+        assert not registry.is_enabled("multi")
+
+    def test_last_disable_reason_wins(self):
+        """If multiple hooks disable a tool, the last reason is recorded."""
+        registry = ToolRegistry()
+
+        def hook_a(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            return "reason A"
+
+        def hook_b(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            return "reason B"
+
+        registry.add_post_register_hook(hook_a)
+        registry.add_post_register_hook(hook_b)
+        registry.register(_make_tool_func("contested"))
+
+        # disable() is called twice; second call overwrites the first
+        assert not registry.is_enabled("contested")
+        assert registry.get_disable_reason("contested") == "reason B"
+
+    def test_same_hook_registered_twice(self):
+        """The same hook can be registered multiple times and runs twice."""
+        registry = ToolRegistry()
+        calls: list[str] = []
+
+        def hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            calls.append(name)
+            return None
+
+        registry.add_post_register_hook(hook)
+        registry.add_post_register_hook(hook)
+        registry.register(_make_tool_func("double"))
+
+        assert calls == ["double", "double"]
+
+
+# ============== Exception isolation tests ==============
+
+
+class TestHookExceptionIsolation:
+    """Verify that hook exceptions never propagate and don't skip later hooks."""
+
+    def test_exception_does_not_propagate(self):
+        """An exception inside a hook must not propagate to the caller."""
+        registry = ToolRegistry()
+
+        def bad_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            raise RuntimeError("hook failure")
+
+        registry.add_post_register_hook(bad_hook)
+
+        # Must not raise
+        registry.register(_make_tool_func("safe"))
+        assert "safe" in registry
+
+    def test_exception_does_not_skip_subsequent_hooks(self):
+        """A raising hook must not prevent later hooks from running."""
+        registry = ToolRegistry()
+        later_called: list[bool] = []
+
+        def bad_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            raise ValueError("first hook blows up")
+
+        def good_hook(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            later_called.append(True)
+            return None
+
+        registry.add_post_register_hook(bad_hook)
+        registry.add_post_register_hook(good_hook)
+        registry.register(_make_tool_func("resilient"))
+
+        assert later_called == [True]
+
+    def test_tool_is_registered_despite_hook_exception(self):
+        """Tool registration succeeds even when a hook raises."""
+        registry = ToolRegistry()
+
+        def always_raises(name: str, tool: Tool, reg: ToolRegistry) -> str | None:
+            raise TypeError("unexpected")
+
+        registry.add_post_register_hook(always_raises)
+        registry.register(_make_tool_func("survives"))
+
+        assert "survives" in registry
+        # No disable was triggered, so tool is still enabled
+        assert registry.is_enabled("survives")
+
+
+# ============== Integration tests ==============
+
+
+class TestIntegration:
+    """Integration tests combining hooks with other registry features."""
+
+    def test_hook_registered_before_tools(self):
+        """Hook registered before any tools fires for all subsequent tools."""
+        registry = ToolRegistry()
+        seen: list[str] = []
+
+        registry.add_post_register_hook(lambda n, t, r: (seen.append(n), None)[1])
+
+        for i in range(3):
+            registry.register(_make_tool_func(f"tool_{i}"))
+
+        assert seen == ["tool_0", "tool_1", "tool_2"]
+
+    def test_hook_does_not_interfere_with_on_change(self):
+        """PostRegisterHook and on_change callbacks co-exist independently."""
+        from toolregistry import ChangeEvent, ChangeEventType
+
+        registry = ToolRegistry()
+        hook_calls: list[str] = []
+        change_events: list[ChangeEvent] = []
+
+        registry.add_post_register_hook(lambda n, t, r: (hook_calls.append(n), None)[1])
+        registry.on_change(change_events.append)
+
+        registry.register(_make_tool_func("coexist"))
+
+        assert hook_calls == ["coexist"]
+        assert len(change_events) == 1
+        assert change_events[0].event_type == ChangeEventType.REGISTER
+        assert change_events[0].tool_name == "coexist"
+
+    def test_post_register_hook_type_alias_importable(self):
+        """PostRegisterHook can be imported from the top-level package."""
+        from toolregistry import PostRegisterHook as PRH  # noqa: N811
+
+        assert PRH is not None


### PR DESCRIPTION
Closes #158, closes #159.

## Changes

### `disable_by_tags()` (#158)

Adds `ToolRegistry.disable_by_tags()` for bulk tag-based tool filtering:

- `match="any"` (default): disable tools that carry at least one matching tag
- `match="all"`: disable tools that carry all specified tags
- Skips already-disabled tools; returns list of newly disabled tool names
- Supports both `ToolTag` enum and plain-string `custom_tags` via `metadata.all_tags`

### Post-registration hook interface (#159)

Adds `PostRegisterHook` type and `ToolRegistry.add_post_register_hook()`:

- Hook signature: `(name: str, tool: Tool, registry: ToolRegistry) -> str | None`
- Returning a non-empty string auto-disables the tool with that string as reason
- Multiple hooks supported, called in registration order
- Hook exceptions are caught and logged — never propagate, never skip subsequent hooks
- Fires inside `register()` after each tool is added to `_tools`
- `PostRegisterHook` exported from top-level `toolregistry`

## Tests

- 12 tests for `disable_by_tags()` in `tests/test_enable_disable.py`
- 17 tests for post-registration hooks in `tests/test_post_register_hook.py`