### PR TITLE
feat(config): add kwargs field to PythonSource for constructor arguments

### DIFF
--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -288,6 +288,7 @@ class RegistrationMixin:
         cls: type | object,
         namespace: bool | str = False,
         traverse_mro: bool = True,
+        constructor_kwargs: dict | None = None,
         **kwargs,
     ):
         """Register all static methods from a class or instance as tools.
@@ -305,6 +306,9 @@ class RegistrationMixin:
                 ``object``), with subclass methods taking priority over parent
                 class methods. When False, only methods defined directly on the
                 class are registered.
+            constructor_kwargs: Keyword arguments forwarded to the class
+                constructor when *cls* is a class that needs to be instantiated.
+                Ignored when a pre-built instance is passed.
 
         Example:
             ```python
@@ -323,13 +327,14 @@ class RegistrationMixin:
         hub = ClassToolIntegration(
             cast("ToolRegistry", self), traverse_mro=traverse_mro
         )
-        return hub.register_class_methods(cls, namespace)
+        return hub.register_class_methods(cls, namespace, constructor_kwargs)
 
     async def register_from_class_async(
         self,
         cls: type | object,
         namespace: bool | str = False,
         traverse_mro: bool = True,
+        constructor_kwargs: dict | None = None,
         **kwargs,
     ):
         """Async implementation to register all static methods from a class or instance as tools.
@@ -347,6 +352,9 @@ class RegistrationMixin:
                 ``object``), with subclass methods taking priority over parent
                 class methods. When False, only methods defined directly on the
                 class are registered.
+            constructor_kwargs: Keyword arguments forwarded to the class
+                constructor when *cls* is a class that needs to be instantiated.
+                Ignored when a pre-built instance is passed.
 
         Example:
             ```python
@@ -361,7 +369,9 @@ class RegistrationMixin:
         hub = ClassToolIntegration(
             cast("ToolRegistry", self), traverse_mro=traverse_mro
         )
-        return await hub.register_class_methods_async(cls, namespace)
+        return await hub.register_class_methods_async(
+            cls, namespace, constructor_kwargs
+        )
 
 
 def _resolve_namespace_compat(

--- a/src/toolregistry/config/_loader.py
+++ b/src/toolregistry/config/_loader.py
@@ -219,11 +219,19 @@ def _build_python_source(
             f"Tool entry at index {index} (type=python): requires 'class' or 'module'."
         )
 
+    raw_kwargs = entry.get("kwargs", {})
+    if not isinstance(raw_kwargs, dict):
+        raise ConfigError(
+            f"Tool entry at index {index} (type=python): "
+            f"'kwargs' must be a mapping, got {type(raw_kwargs).__name__}."
+        )
+
     return PythonSource(
         class_path=class_path,
         module_path=module_path,
         namespace=namespace,
         enabled=enabled,
+        kwargs=raw_kwargs,
     )
 
 

--- a/src/toolregistry/config/_types.py
+++ b/src/toolregistry/config/_types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 __all__ = [
@@ -79,12 +79,17 @@ class PythonSource:
             (e.g. ``"my_package.tools"``).
         namespace: Optional namespace passed to the registration call.
         enabled: Per-source enabled flag.
+        kwargs: Keyword arguments forwarded to the class constructor when
+            *class_path* is used.  Allows passing configuration (e.g. API
+            keys, base URLs) directly from the config file instead of
+            requiring a pre-constructed instance.
     """
 
     class_path: str | None = None
     module_path: str | None = None
     namespace: str | None = None
     enabled: bool = True
+    kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.class_path and not self.module_path:
@@ -101,6 +106,7 @@ class PythonSource:
 
         Maps ``class_path`` back to the ``"class"`` key and
         ``module_path`` to ``"module"`` for config-file compatibility.
+        Omits ``kwargs`` when empty.
         """
         d: dict[str, Any] = {"type": "python"}
         if self.class_path:
@@ -111,6 +117,8 @@ class PythonSource:
             d["namespace"] = self.namespace
         if not self.enabled:
             d["enabled"] = False
+        if self.kwargs:
+            d["kwargs"] = dict(self.kwargs)
         return d
 
 

--- a/src/toolregistry/integrations/native/integration.py
+++ b/src/toolregistry/integrations/native/integration.py
@@ -41,6 +41,7 @@ class ClassToolIntegration:
         self,
         cls_or_instance: type | object,
         namespace: bool | str = False,
+        constructor_kwargs: dict | None = None,
     ) -> None:
         """Register all methods from a class or instance as tools.
 
@@ -57,6 +58,10 @@ class ClassToolIntegration:
                 - If True, the namespace is derived from the class name.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            constructor_kwargs: Keyword arguments forwarded to the class
+                constructor when *cls_or_instance* is a class that needs
+                to be instantiated.  Ignored when a pre-built instance is
+                passed.  Defaults to ``None`` (no extra arguments).
         """
         resolved_ns = _determine_namespace(cls_or_instance, namespace)
 
@@ -64,7 +69,9 @@ class ClassToolIntegration:
             if _is_all_static_methods(cls_or_instance):
                 self._register_static_methods(cls_or_instance, resolved_ns)
             else:
-                instance = self._instantiate_class(cls_or_instance)
+                instance = self._instantiate_class(
+                    cls_or_instance, constructor_kwargs or {}
+                )
                 self._register_instance_methods(instance, resolved_ns)
         else:
             self._register_instance_methods(cls_or_instance, resolved_ns)
@@ -73,6 +80,7 @@ class ClassToolIntegration:
         self,
         cls_or_instance: type | object,
         namespace: bool | str = False,
+        constructor_kwargs: dict | None = None,
     ) -> None:
         """Async implementation to register tools from a class.
 
@@ -85,10 +93,18 @@ class ClassToolIntegration:
                 - If True, the namespace is derived from the class name.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
+            constructor_kwargs: Keyword arguments forwarded to the class
+                constructor when *cls_or_instance* is a class that needs
+                to be instantiated.  Ignored when a pre-built instance is
+                passed.  Defaults to ``None`` (no extra arguments).
         """
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
-            None, self.register_class_methods, cls_or_instance, namespace
+            None,
+            self.register_class_methods,
+            cls_or_instance,
+            namespace,
+            constructor_kwargs,
         )
 
     @staticmethod
@@ -145,39 +161,44 @@ class ClassToolIntegration:
             return f"{param.name}: {ann}"
         return param.name
 
-    def _instantiate_class(self, cls: type) -> object:
-        """Attempt to instantiate *cls* with no arguments.
+    def _instantiate_class(self, cls: type, constructor_kwargs: dict) -> object:
+        """Attempt to instantiate *cls* with the given keyword arguments.
 
-        Before calling ``cls()``, this method inspects ``__init__`` for
-        required parameters.  If any are found, a ``TypeError`` is raised
-        immediately with a message that lists the missing parameters and
-        suggests passing a pre-constructed instance instead.
+        When *constructor_kwargs* is non-empty the class is called directly
+        with those arguments.  When it is empty, ``__init__`` is first
+        inspected for required parameters and a ``TypeError`` is raised
+        immediately if any are found (preserving the original zero-argument
+        behaviour).
 
         Args:
             cls: The class to instantiate.
+            constructor_kwargs: Keyword arguments forwarded to ``cls()``.
 
         Returns:
             An instance of *cls*.
 
         Raises:
-            TypeError: If the class requires constructor arguments or if
-                zero-argument instantiation fails for another reason.
+            TypeError: If the class requires constructor arguments that are
+                not satisfied by *constructor_kwargs*, or if instantiation
+                fails for another reason.
         """
-        required_params = self._get_required_init_params(cls)
-        if required_params:
-            formatted = ", ".join(self._format_param(p) for p in required_params)
-            example_args = ", ".join(f"{p.name}=..." for p in required_params)
-            raise TypeError(
-                f"Class '{cls.__name__}' requires constructor arguments ({formatted}). "
-                f"Please instantiate it first: "
-                f"register_from_class({cls.__name__}({example_args}))"
-            )
+        if not constructor_kwargs:
+            required_params = self._get_required_init_params(cls)
+            if required_params:
+                formatted = ", ".join(self._format_param(p) for p in required_params)
+                example_args = ", ".join(f"{p.name}=..." for p in required_params)
+                raise TypeError(
+                    f"Class '{cls.__name__}' requires constructor arguments ({formatted}). "
+                    f"Please instantiate it first: "
+                    f"register_from_class({cls.__name__}({example_args}))"
+                )
 
         try:
-            return cls()
+            return cls(**constructor_kwargs)
         except TypeError as e:
             raise TypeError(
-                f"Failed to instantiate class '{cls.__name__}' with no arguments: {e}. "
+                f"Failed to instantiate class '{cls.__name__}' "
+                f"with arguments {constructor_kwargs!r}: {e}. "
                 f"Please pass a pre-constructed instance instead: "
                 f"register_from_class({cls.__name__}(...))"
             ) from e

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -241,6 +241,91 @@ tools:
         with pytest.raises(ConfigError, match="requires 'class' or 'module'"):
             load_config(p)
 
+    def test_kwargs_empty_by_default(self, tmp_path: Path) -> None:
+        """PythonSource.kwargs defaults to empty dict when not specified."""
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    class: mypackage.MyTool
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.kwargs == {}
+
+    def test_kwargs_parsed_from_yaml(self, tmp_path: Path) -> None:
+        """kwargs dict is correctly parsed from YAML config."""
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    class: mypackage.SearchTool
+    namespace: search
+    kwargs:
+      api_key: secret123
+      base_url: https://api.example.com
+      timeout: 30
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.kwargs == {
+            "api_key": "secret123",
+            "base_url": "https://api.example.com",
+            "timeout": 30,
+        }
+
+    def test_kwargs_parsed_from_jsonc(self, tmp_path: Path) -> None:
+        """kwargs dict is correctly parsed from JSONC config."""
+        p = _write(
+            tmp_path,
+            "cfg.jsonc",
+            """\
+{
+  "tools": [
+    {
+      "type": "python",
+      "class": "mypackage.SearchTool",
+      "namespace": "search",
+      "kwargs": {
+        "api_key": "secret123",
+        "base_url": "https://api.example.com"
+      }
+    }
+  ]
+}
+""",
+        )
+        cfg = load_config(p)
+        src = cfg.tools[0]
+        assert isinstance(src, PythonSource)
+        assert src.kwargs == {
+            "api_key": "secret123",
+            "base_url": "https://api.example.com",
+        }
+
+    def test_kwargs_invalid_type(self, tmp_path: Path) -> None:
+        """Non-mapping kwargs raises ConfigError."""
+        p = _write(
+            tmp_path,
+            "cfg.yaml",
+            """\
+tools:
+  - type: python
+    class: mypackage.MyTool
+    kwargs: not_a_mapping
+""",
+        )
+        with pytest.raises(ConfigError, match="'kwargs' must be a mapping"):
+            load_config(p)
+
 
 # ---------------------------------------------------------------------------
 # MCPSource
@@ -828,6 +913,21 @@ class TestToDict:
         assert d["module"] == "pkg.tools"
         assert d["enabled"] is False
         assert "class" not in d
+
+    def test_python_source_kwargs_omitted_when_empty(self) -> None:
+        """PythonSource with empty kwargs does not include 'kwargs' key in dict."""
+        src = PythonSource(class_path="pkg.Cls")
+        d = src.to_dict()
+        assert "kwargs" not in d
+
+    def test_python_source_kwargs_serialized(self) -> None:
+        """PythonSource with non-empty kwargs includes 'kwargs' key in dict."""
+        src = PythonSource(
+            class_path="pkg.Cls",
+            kwargs={"api_key": "secret", "timeout": 30},
+        )
+        d = src.to_dict()
+        assert d["kwargs"] == {"api_key": "secret", "timeout": 30}
 
     def test_mcp_source_stdio(self) -> None:
         """MCPSource with stdio transport serializes command."""

--- a/tests/test_constructor_error.py
+++ b/tests/test_constructor_error.py
@@ -154,3 +154,64 @@ class TestConstructorErrorMessage:
         # Unannotated params should appear without colon
         assert "host:" not in msg
         assert "port:" not in msg
+
+
+class TestConstructorKwargs:
+    """Verify that constructor_kwargs are forwarded correctly to the class."""
+
+    def test_kwargs_passed_to_constructor(self):
+        """constructor_kwargs are forwarded to the class __init__."""
+        registry = ToolRegistry()
+        registry.register_from_class(
+            ServiceWithRequiredArgs,
+            constructor_kwargs={"api_key": "mykey", "timeout": 10},
+        )
+        assert "call_api" in registry.list_tools()
+
+    def test_kwargs_values_available_on_instance(self):
+        """The registered instance retains the kwargs passed at construction."""
+        registry = ToolRegistry()
+        registry.register_from_class(
+            ServiceWithRequiredArgs,
+            constructor_kwargs={"api_key": "testkey", "timeout": 5},
+        )
+        result = registry["call_api"](endpoint="/test")
+        assert result == "testkey:/test"
+
+    def test_empty_kwargs_preserves_original_behaviour(self):
+        """Passing an empty constructor_kwargs dict behaves like no kwargs."""
+        registry = ToolRegistry()
+        registry.register_from_class(ServiceNoArgs, constructor_kwargs={})
+        assert "ping" in registry.list_tools()
+
+    def test_none_kwargs_preserves_original_behaviour(self):
+        """Passing None for constructor_kwargs behaves like no kwargs."""
+        registry = ToolRegistry()
+        registry.register_from_class(ServiceNoArgs, constructor_kwargs=None)
+        assert "ping" in registry.list_tools()
+
+    def test_kwargs_with_defaults_override(self):
+        """constructor_kwargs override default parameter values."""
+        registry = ToolRegistry()
+        registry.register_from_class(
+            ServiceWithDefaults,
+            constructor_kwargs={"retries": 7, "verbose": True},
+        )
+        assert "status" in registry.list_tools()
+
+    def test_required_args_without_kwargs_still_errors(self):
+        """Without constructor_kwargs, required-arg classes still raise TypeError."""
+        registry = ToolRegistry()
+        with pytest.raises(TypeError, match="ServiceWithRequiredArgs"):
+            registry.register_from_class(ServiceWithRequiredArgs)
+
+    def test_kwargs_wrong_values_raise_type_error(self):
+        """Passing constructor_kwargs with wrong types raises TypeError with context."""
+        registry = ToolRegistry()
+        # ServiceWithRequiredArgs expects api_key: str, timeout: int
+        # Passing an unexpected keyword should propagate as TypeError
+        with pytest.raises(TypeError):
+            registry.register_from_class(
+                ServiceWithRequiredArgs,
+                constructor_kwargs={"api_key": "key", "unknown_param": 42},
+            )


### PR DESCRIPTION
Closes #160.

## Changes

### `PythonSource.kwargs` field

Adds `kwargs: dict[str, Any]` to `PythonSource` dataclass, allowing constructor arguments to be specified in config files (JSONC/YAML):

```yaml
tools:
  - type: python
    class: mypackage.tools.SearchTool
    namespace: search
    kwargs:
      api_key: "my-key"
      base_url: "https://api.example.com"
```

- `kwargs` defaults to `{}` — fully backward compatible
- Config loader validates that `kwargs` is a mapping, raises `ConfigError` otherwise
- `_instantiate_class()` passes `**constructor_kwargs` when non-empty; retains original zero-arg guard when empty
- `register_from_class()` gains `constructor_kwargs: dict | None = None` parameter, forwarded through the integration layer
- `to_dict()` serializes `kwargs` only when non-empty

## Tests

- `TestPythonSource`: default empty, YAML/JSONC parse, invalid type raises error
- `TestToDict`: empty kwargs not serialized, non-empty correctly serialized
- `TestConstructorKwargs`: 7 tests covering kwargs passthrough, value preservation, empty/None backward compat, bad args raise `TypeError`