### PR TITLE
fix(admin): discover_enabled must check is_enabled, not just registration

### DIFF
--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -846,7 +846,8 @@ def _get_info(request: Request) -> Response:
     info: dict[str, Any] = {
         "toolregistry": toolregistry.__version__,
         "name_sep": getattr(registry, "_name_sep", "-"),
-        "discover_enabled": "discover_tools" in registry._tools,
+        "discover_enabled": "discover_tools" in registry._tools
+        and registry.is_enabled("discover_tools"),
     }
     try:
         import toolregistry_server
@@ -904,7 +905,7 @@ def _get_schema(request: Request) -> Response:
     # --- discover_tools description view ---
     if fmt_str == "discover":
         discovery_tool = registry._tools.get("discover_tools")
-        if discovery_tool is None:
+        if discovery_tool is None or not registry.is_enabled("discover_tools"):
             return _error_response(404, "Not Found", "Tool discovery is not enabled")
         deferred_count, disabled_count = _schema_counts(registry)
 


### PR DESCRIPTION
## Summary

- `discover_enabled` in `/api/info` only checked `"discover_tools" in registry._tools` (registration), not `registry.is_enabled()` (enabled state)
- Disabling discover_tools in admin still showed the Discover Tools sub-tab because the tool remained registered
- Also fix `/api/schema?format=discover` to return 404 when discover_tools is disabled

## Test plan

- [x] Disable discover_tools → `/api/info` returns `discover_enabled: false`
- [x] Enable discover_tools → `discover_enabled: true`
- [x] Discover Tools sub-tab hides/shows accordingly in admin UI
- [x] `/api/schema?format=discover` returns 404 when disabled