### PR TITLE
Fix tool schema generation robustness

### DIFF
--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -230,13 +230,18 @@ class MCPTool(Tool):
         input_schema = getattr(tool_spec, "input_schema", None) or getattr(
             tool_spec, "inputSchema", {}
         )
+        if not isinstance(input_schema, dict) or input_schema.get("type") != "object":
+            input_schema = {"type": "object", "properties": {}}
+        else:
+            properties = input_schema.get("properties")
+            if not isinstance(properties, dict):
+                properties = {}
+            input_schema["properties"] = properties
 
         wrapper = MCPToolWrapper(
             connection=connection,
             name=name,
-            params=(
-                list(input_schema.get("properties", {}).keys()) if input_schema else []
-            ),
+            params=list(input_schema["properties"].keys()),
         )
 
         # Build a human-readable source_detail from the transport config.

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -105,6 +105,16 @@ class OpenAPIToolWrapper(BaseToolWrapper):
         return response.json()
 
 
+def _copy_json_schema(schema: dict[str, Any], description: str = "") -> dict[str, Any]:
+    """Copy a JSON Schema fragment and merge an OpenAPI description."""
+    copied = dict(schema) if isinstance(schema, dict) else {}
+    if "type" not in copied:
+        copied["type"] = "string"
+    if description and "description" not in copied:
+        copied["description"] = description
+    return copied
+
+
 class OpenAPITool(Tool):
     """Wrapper class for OpenAPI tools preserving function metadata."""
 
@@ -145,10 +155,10 @@ class OpenAPITool(Tool):
         for param in spec.get("parameters", []):
             param_schema = param.get("schema", {})
             param_name = param["name"]
-            parameters["properties"][param_name] = {
-                "type": param_schema.get("type", "string"),
-                "description": param.get("description", ""),
-            }
+            parameters["properties"][param_name] = _copy_json_schema(
+                param_schema,
+                param.get("description", ""),
+            )
             param_names.append(param_name)
             if param.get("required", False):
                 parameters["required"].append(param_name)
@@ -158,13 +168,13 @@ class OpenAPITool(Tool):
             if "application/json" in content:
                 schema = content["application/json"].get("schema", {})
                 for prop_name, prop_schema in schema.get("properties", {}).items():
-                    parameters["properties"][prop_name] = {
-                        "type": prop_schema.get("type", "string"),
-                        "description": prop_schema.get("description", ""),
-                    }
+                    parameters["properties"][prop_name] = _copy_json_schema(prop_schema)
                     param_names.append(prop_name)
                 if "required" in schema:
                     parameters["required"].extend(schema["required"])
+
+        if not parameters["required"]:
+            parameters.pop("required")
 
         wrapper = OpenAPIToolWrapper(
             client_config=client_config,

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -12,14 +12,14 @@ The search backend is a vendored copy of *zerodep*'s ``SparseIndex``
 from __future__ import annotations
 
 import re
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .._vendor.sparse_search import SparseIndex
+from .tool_calls import API_FORMATS
 
 if TYPE_CHECKING:
     from ..tool import Tool
     from ..tool_registry import ToolRegistry
-    from .tool_calls import API_FORMATS
 
 _DEFAULT_FIELD_WEIGHTS: dict[str, float] = {
     "name": 3.0,

--- a/src/toolregistry/parameter_models.py
+++ b/src/toolregistry/parameter_models.py
@@ -61,7 +61,7 @@ def _get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
         # Manually set the annotation on the dummy function.
         dummy.__annotations__ = {"a": annotation}
         try:
-            hints = get_type_hints(dummy, globalns)
+            hints = get_type_hints(dummy, globalns, include_extras=True)
             return hints["a"]
         except Exception as e:
             raise InvalidSignature(
@@ -100,6 +100,103 @@ def _create_field(
         return (annotation_type | None, field_info)
 
 
+def _warn_parameter_fallback(
+    func: Callable, param_name: str, reason: Exception
+) -> None:
+    """Warn that a parameter annotation fell back to ``Any``."""
+    warnings.warn(
+        f"Parameter '{param_name}' in '{getattr(func, '__name__', '<unknown>')}' "
+        f"has an annotation that cannot be represented in JSON Schema: {reason}. "
+        "Falling back to an unconstrained schema for this parameter.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+
+def _is_json_schema_compatible(
+    param_name: str, field_def: tuple[Any, FieldInfo]
+) -> bool:
+    """Return whether a single field can produce JSON Schema."""
+    try:
+        field_definitions: dict[str, Any] = {param_name: field_def}
+        test_model = create_model(
+            f"_{param_name}SchemaProbe",
+            **field_definitions,
+            __base__=ArgModelBase,
+        )
+        test_model.model_json_schema()
+        return True
+    except Exception:
+        return False
+
+
+def _warn_skipped_variadic_parameter(func: Callable, param: inspect.Parameter) -> None:
+    """Warn that a variadic parameter is excluded from the schema."""
+    label = (
+        f"*{param.name}"
+        if param.kind == inspect.Parameter.VAR_POSITIONAL
+        else f"**{param.name}"
+    )
+    kind = "*args" if param.kind == inspect.Parameter.VAR_POSITIONAL else "**kwargs"
+    warnings.warn(
+        f"Parameter '{label}' ({kind}) in "
+        f"'{getattr(func, '__name__', '<unknown>')}' is not "
+        "representable in JSON Schema and will be excluded "
+        "from the tool schema.",
+        UserWarning,
+        stacklevel=2,
+    )
+
+
+def _field_def_for_parameter(
+    func: Callable,
+    param: inspect.Parameter,
+    globalns: dict[str, Any],
+    resolved_hints: dict[str, Any],
+) -> tuple[Any, FieldInfo]:
+    """Create a schema-safe field definition for one parameter."""
+    if param.annotation is inspect.Parameter.empty:
+        field_def = _create_field(param, Any)
+    elif param.annotation is None:
+        field_def = _create_field(param, None)
+    else:
+        try:
+            annotation = resolved_hints.get(param.name)
+            if annotation is None:
+                annotation = _get_typed_annotation(param.annotation, globalns)
+            field_def = _create_field(param, annotation)
+        except Exception as e:
+            _warn_parameter_fallback(func, param.name, e)
+            field_def = _create_field(param, Any)
+
+    if _is_json_schema_compatible(param.name, field_def):
+        return field_def
+
+    _warn_parameter_fallback(
+        func,
+        param.name,
+        InvalidSignature(f"unsupported annotation {param.annotation!r}"),
+    )
+    return _create_field(param, Any)
+
+
+def _create_parameters_model(
+    func: Callable,
+    field_definitions: dict[str, Any],
+) -> type[ArgModelBase] | None:
+    """Create and validate the final Pydantic parameter model."""
+    try:
+        model = create_model(
+            f"{getattr(func, '__name__', 'unknown')}Parameters",
+            **field_definitions,
+            __base__=ArgModelBase,
+        )
+        model.model_json_schema()
+        return model
+    except Exception:
+        return None
+
+
 def _generate_parameters_model(func: Callable) -> type[ArgModelBase] | None:
     """Generate a Pydantic model from a function's parameters.
 
@@ -116,48 +213,30 @@ def _generate_parameters_model(func: Callable) -> type[ArgModelBase] | None:
     """
     try:
         signature = inspect.signature(func)
-        globalns = getattr(func, "__globals__", {})
-        dynamic_model_creation_dict: dict[str, Any] = {}
-
-        for param in signature.parameters.values():
-            if param.name == "self":
-                continue
-            # Skip *args and **kwargs — they are not individual named parameters
-            if param.kind == inspect.Parameter.VAR_POSITIONAL:
-                warnings.warn(
-                    f"Parameter '*{param.name}' (*args) in "
-                    f"'{getattr(func, '__name__', '<unknown>')}' is not "
-                    "representable in JSON Schema and will be excluded "
-                    "from the tool schema.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                continue
-            if param.kind == inspect.Parameter.VAR_KEYWORD:
-                warnings.warn(
-                    f"Parameter '**{param.name}' (**kwargs) in "
-                    f"'{getattr(func, '__name__', '<unknown>')}' is not "
-                    "representable in JSON Schema and will be excluded "
-                    "from the tool schema.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                continue
-
-            annotation = _get_typed_annotation(param.annotation, globalns)
-            if param.annotation is inspect.Parameter.empty:
-                dynamic_model_creation_dict[param.name] = _create_field(param, Any)
-            elif param.annotation is None:
-                dynamic_model_creation_dict[param.name] = _create_field(param, None)
-            else:
-                dynamic_model_creation_dict[param.name] = _create_field(
-                    param, annotation
-                )
-
-        return create_model(
-            f"{getattr(func, '__name__', 'unknown')}Parameters",
-            **dynamic_model_creation_dict,
-            __base__=ArgModelBase,
-        )
     except Exception:
         return None
+
+    globalns = getattr(func, "__globals__", {})
+    try:
+        resolved_hints = get_type_hints(func, globalns, include_extras=True)
+    except Exception:
+        resolved_hints = {}
+
+    field_definitions: dict[str, Any] = {}
+    for param in signature.parameters.values():
+        if param.name == "self":
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            _warn_skipped_variadic_parameter(func, param)
+            continue
+        field_definitions[param.name] = _field_def_for_parameter(
+            func,
+            param,
+            globalns,
+            resolved_hints,
+        )
+
+    return _create_parameters_model(func, field_definitions)

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -225,8 +225,14 @@ class Tool(BaseModel):
         The ``toolcall_reason`` field is only added when ``parameters``
         already contains a ``properties`` mapping.
         """
-        props = self.parameters.get("properties")
-        if props is not None and "toolcall_reason" not in props:
+        had_properties = isinstance(self.parameters.get("properties"), dict)
+        if self.parameters.get("type") != "object":
+            self.parameters = {"type": "object", "properties": {}}
+        elif not had_properties:
+            self.parameters["properties"] = {}
+
+        props = self.parameters["properties"]
+        if had_properties and "toolcall_reason" not in props:
             props["toolcall_reason"] = TOOLCALL_REASON_PROPERTY
 
     @property

--- a/tests/test_mcp_post_processing.py
+++ b/tests/test_mcp_post_processing.py
@@ -273,6 +273,17 @@ class TestMCPToolFromJson:
         tool = MCPTool.from_tool_json(spec, mock_conn)
         assert tool.callable.params == []
 
+    def test_non_object_input_schema_is_normalized(self):
+        """Non-object MCP input schemas are normalized to empty object schemas."""
+        spec = MCPToolSpec(
+            name="invalid_schema_tool",
+            inputSchema={"type": "string"},
+        )
+        mock_conn = MagicMock()
+        tool = MCPTool.from_tool_json(spec, mock_conn)
+        assert tool.callable.params == []
+        assert tool.parameters["type"] == "object"
+
 
 # ===========================================================================
 # TestMCPToolWrapperEdgeCases

--- a/tests/test_openapi_integration.py
+++ b/tests/test_openapi_integration.py
@@ -603,7 +603,69 @@ class TestOpenAPITool:
         """Operation with no parameters has no user-defined properties."""
         spec = {"operationId": "health_check", "parameters": []}
         tool = self._make_tool(spec=spec)
-        assert tool.parameters["required"] == []
+        user_props = set(tool.parameters["properties"]) - {"toolcall_reason"}
+        assert user_props == set()
+        assert "required" not in tool.parameters
+
+    def test_parameter_schema_preserves_constraints(self):
+        """OpenAPI parameter schemas preserve enum, format, defaults, and bounds."""
+        spec = {
+            "operationId": "searchPets",
+            "summary": "Search pets",
+            "parameters": [
+                {
+                    "name": "status",
+                    "in": "query",
+                    "schema": {
+                        "type": "string",
+                        "enum": ["available", "pending", "sold"],
+                        "default": "available",
+                    },
+                    "description": "Pet status",
+                },
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "schema": {"type": "integer", "minimum": 1, "maximum": 100},
+                },
+            ],
+        }
+        tool = self._make_tool(spec=spec)
+        props = tool.parameters["properties"]
+        assert props["status"]["enum"] == ["available", "pending", "sold"]
+        assert props["status"]["default"] == "available"
+        assert props["status"]["description"] == "Pet status"
+        assert props["limit"]["minimum"] == 1
+        assert props["limit"]["maximum"] == 100
+
+    def test_request_body_schema_preserves_nested_objects(self):
+        """OpenAPI request body properties preserve nested schema details."""
+        spec = {
+            "operationId": "createComplexPet",
+            "summary": "Create complex pet",
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {"type": "array", "items": {"type": "string"}},
+                                "owner": {
+                                    "type": "object",
+                                    "properties": {"name": {"type": "string"}},
+                                },
+                            },
+                            "required": ["tags"],
+                        }
+                    }
+                }
+            },
+        }
+        tool = self._make_tool(method="post", spec=spec)
+        props = tool.parameters["properties"]
+        assert props["tags"]["items"]["type"] == "string"
+        assert props["owner"]["properties"]["name"]["type"] == "string"
+        assert tool.parameters["required"] == ["tags"]
 
 
 # ===========================================================================

--- a/tests/test_param_warnings.py
+++ b/tests/test_param_warnings.py
@@ -146,7 +146,7 @@ class TestParameterModelGenerationFailureWarning:
         # Tool should still be created, but without parameter validation
         assert tool is not None
         assert tool.parameters_model is None
-        assert tool.parameters == {}
+        assert tool.parameters == {"type": "object", "properties": {}}
 
     def test_generation_failure_warning_includes_func_name(self):
         """Warning message should include the function name."""

--- a/tests/test_parameter_models.py
+++ b/tests/test_parameter_models.py
@@ -94,6 +94,23 @@ class TestArgModelBase:
         assert model.custom == custom_obj
         assert model.custom.value == "test"
 
+    def test_arbitrary_type_schema_generation_requires_fallback(self):
+        """Arbitrary runtime types should not block schema generation."""
+
+        class CustomType:
+            pass
+
+        def f(custom: CustomType, name: str) -> None:
+            pass
+
+        with pytest.warns(UserWarning, match="custom.*Falling back"):
+            model = _generate_parameters_model(f)
+
+        assert model is not None
+        schema = model.model_json_schema()
+        assert "custom" in schema["properties"]
+        assert schema["properties"]["name"]["type"] == "string"
+
 
 class TestGetTypedAnnotation:
     """Test cases for the _get_typed_annotation function."""
@@ -366,19 +383,44 @@ class TestGenerateParametersModel:
         assert model.name == "hello"
         assert model.count == 3
 
-    def test_generate_parameters_model_exception_handling(self):
-        """Test that exceptions during model generation are handled gracefully."""
+    def test_generate_parameters_model_unresolved_annotation_falls_back(self):
+        """Unresolved annotations should fall back per parameter instead of failing."""
 
         def problematic_func(x) -> str:
             return str(x)
 
-        # Manually set a problematic annotation that will cause issues
         problematic_func.__annotations__ = {"x": "NonExistentType", "return": str}
 
-        # Should return None instead of raising exception
-        model_class = _generate_parameters_model(problematic_func)
+        with pytest.warns(UserWarning, match="Falling back"):
+            model_class = _generate_parameters_model(problematic_func)
 
-        assert model_class is None
+        assert model_class is not None
+        schema = model_class.model_json_schema()
+        assert schema["type"] == "object"
+        assert "x" in schema["properties"]
+        assert "type" not in schema["properties"]["x"]
+
+    def test_generate_parameters_model_mixed_unresolved_annotation_keeps_valid_fields(
+        self,
+    ):
+        """A bad annotation should not discard other valid parameter schemas."""
+
+        def mixed_func(name: str, value) -> str:
+            return f"{name}:{value}"
+
+        mixed_func.__annotations__ = {
+            "name": str,
+            "value": "MissingRuntimeType",
+            "return": str,
+        }
+
+        with pytest.warns(UserWarning, match="value.*Falling back"):
+            model_class = _generate_parameters_model(mixed_func)
+
+        assert model_class is not None
+        schema = model_class.model_json_schema()
+        assert schema["properties"]["name"]["type"] == "string"
+        assert "value" in schema["properties"]
 
     def test_generate_parameters_model_with_invalid_signature(self):
         """Test generating parameters model with function that has invalid signature."""

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -64,6 +64,30 @@ class TestTool:
         assert tool.name == "double"
         assert tool.callable == lambda_func
 
+    def test_tool_creation_normalizes_empty_parameters_schema(self):
+        """Direct Tool construction should always produce object parameters."""
+        tool = Tool(
+            name="bare",
+            description="Bare tool",
+            parameters={},
+            callable=lambda: None,
+            metadata=ToolMetadata(think_augment=False),
+        )
+
+        assert tool.parameters == {"type": "object", "properties": {}}
+
+    def test_tool_creation_normalizes_non_object_parameters_schema(self):
+        """Non-object parameter schemas should be replaced with empty objects."""
+        tool = Tool(
+            name="bad_schema",
+            description="Bad schema tool",
+            parameters={"type": "string"},
+            callable=lambda: None,
+            metadata=ToolMetadata(think_augment=False),
+        )
+
+        assert tool.parameters == {"type": "object", "properties": {}}
+
     def test_get_json_schema_openai_format(self, sample_tool):
         """Test getting JSON schema in OpenAI format."""
         schema = sample_tool.get_schema("openai-chat")
@@ -406,14 +430,14 @@ class TestThinkAugmented:
         assert "toolcall_reason" in tool.parameters["properties"]
 
     def test_toolcall_reason_empty_schema_no_inject(self):
-        """Test that toolcall_reason is not injected when schema has no properties."""
+        """Test that toolcall_reason is not injected into normalized empty schemas."""
         tool = Tool(
             name="empty_tool",
             description="Tool with empty schema",
             parameters={},
             callable=lambda: "ok",
         )
-        assert "properties" not in tool.parameters
+        assert tool.parameters == {"type": "object", "properties": {}}
 
     def test_think_metadata_false_strips_from_schema(self, sample_function):
         """Test that think_augment=False strips toolcall_reason from get_schema output."""

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -298,6 +298,7 @@ class TestToolDiscoveryExact:
         registry.enable_tool_discovery()
 
         discoverer = registry._tool_discovery
+        assert discoverer is not None
         results = discoverer.discover("discover_tools")
         # Should not return discover_tools as an exact match
         names = [r["name"] for r in results]
@@ -341,6 +342,16 @@ class TestToolDiscoveryIntegration:
         schemas = registry.get_schemas()
         names = [s["function"]["name"] for s in schemas]
         assert "discover_tools" in names
+
+    def test_discover_tools_has_object_parameters_schema(self):
+        """discover_tools should have a valid object parameter schema."""
+        registry = ToolRegistry()
+        registry.enable_tool_discovery()
+
+        tool = registry.get_tool("discover_tools")
+        assert tool is not None
+        assert tool.parameters["type"] == "object"
+        assert set(tool.parameters["properties"]) >= {"query", "top_k", "api_format"}
 
     def test_disable_tool_discovery(self):
         """After disable_tool_discovery(), discover_tools is removed."""
@@ -410,6 +421,7 @@ class TestToolDiscoveryIntegration:
         registry.register(second)
 
         discoverer = registry._tool_discovery
+        assert discoverer is not None
         results = discoverer.discover("second tool")
         assert len(results) > 0
         assert results[0]["name"] == "second"
@@ -451,6 +463,7 @@ class TestToolDiscoveryIntegration:
         registry.enable_tool_discovery()
 
         discoverer = registry._tool_discovery
+        assert discoverer is not None
         results = discoverer.discover("discover tools")
         result_names = [r["name"] for r in results]
         assert "discover_tools" not in result_names


### PR DESCRIPTION
## Summary
- keep parameter schema generation working when individual annotations cannot be resolved or represented as JSON Schema
- normalize empty/non-object Tool parameter schemas to object schemas
- normalize imported MCP schemas and preserve richer OpenAPI schema fragments

## Test plan
- [x] pre-commit run --all-files
- [x] pytest tests/test_parameter_models.py tests/test_param_warnings.py -q