### PR TITLE
feat: add runtimes/ subpackage with BashTool via submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
@@ -29,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:
@@ -44,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: v${{ inputs.version }}
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/rosetta-compat.yml
+++ b/.github/workflows/rosetta-compat.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v6

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/toolregistry/runtimes/_bashtool"]
+	path = src/toolregistry/runtimes/_bashtool
+	url = https://github.com/Oaklight/bashtool.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,20 @@ version = { attr = "toolregistry.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+exclude = ["toolregistry.runtimes._bashtool.tests*"]
 
 [tool.setuptools.package-data]
 "toolregistry" = ["py.typed"]
 "toolregistry.admin" = ["*.html"]
+
+[tool.setuptools.exclude-package-data]
+"toolregistry.runtimes._bashtool" = [
+    "tests/*",
+    "Makefile",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+    ".pre-commit-config.yaml",
+    ".github/*",
+    ".gitignore",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ Issues = "https://github.com/Oaklight/ToolRegistry/issues"
 
 [tool.ruff]
 target-version = "py310"
-exclude = ["src/toolregistry/_vendor"]
+exclude = ["src/toolregistry/_vendor", "src/toolregistry/runtimes/_bashtool"]
 
 [tool.ruff.lint]
 select = ["E", "F", "UP"]
@@ -83,13 +83,13 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
-exclude = ["src/toolregistry/_vendor"]
+exclude = ["src/toolregistry/_vendor", "src/toolregistry/runtimes/_bashtool"]
 
 [tool.ty.rules]
 unresolved-import = "ignore"
 
 [tool.complexipy]
-exclude = ["src/toolregistry/_vendor", "examples"]
+exclude = ["src/toolregistry/_vendor", "src/toolregistry/runtimes/_bashtool", "examples"]
 max-complexity-allowed = 20
 
 [tool.setuptools.dynamic]

--- a/src/toolregistry/runtimes/__init__.py
+++ b/src/toolregistry/runtimes/__init__.py
@@ -16,6 +16,6 @@ Future contents (see issue #175+):
 - ``PythonExecutionTool``
 """
 
-from ._bashtool import BashTool, truncate, validate_command
+from ._bashtool import BashTool
 
-__all__ = ["BashTool", "truncate", "validate_command"]
+__all__ = ["BashTool"]

--- a/src/toolregistry/runtimes/__init__.py
+++ b/src/toolregistry/runtimes/__init__.py
@@ -1,0 +1,21 @@
+"""Runtime subpackage -- agent infrastructure tools and code execution runtimes.
+
+This subpackage hosts tools that are part of the agent infrastructure layer
+(not domain-specific), and will eventually contain the PTC (Programmatic
+Tool Calling) code execution runtimes.
+
+Current contents:
+
+- :class:`BashTool` -- shell command execution with safety validation
+  (via the ``bashtool`` submodule)
+
+Future contents (see issue #175+):
+
+- ``CodeRuntime`` / ``ToolProjection`` protocols
+- ``InProcessRuntime``, ``SubprocessRuntime``
+- ``PythonExecutionTool``
+"""
+
+from ._bashtool import BashTool, truncate, validate_command
+
+__all__ = ["BashTool", "truncate", "validate_command"]

--- a/tests/test_runtimes_bash.py
+++ b/tests/test_runtimes_bash.py
@@ -1,0 +1,66 @@
+"""Smoke tests for the runtimes.BashTool integration (bashtool submodule)."""
+
+import pytest
+
+from toolregistry.runtimes import BashTool, truncate, validate_command
+
+
+class TestBashToolImport:
+    """Verify that BashTool is importable from toolregistry.runtimes."""
+
+    def test_import_bashtool(self):
+        assert BashTool is not None
+        assert hasattr(BashTool, "execute")
+
+    def test_import_validate_command(self):
+        assert callable(validate_command)
+
+    def test_import_truncate(self):
+        assert callable(truncate)
+
+
+class TestBashToolExecute:
+    """Basic execution tests via the runtimes re-export."""
+
+    def test_echo(self):
+        result = BashTool.execute("echo hello")
+        assert result["stdout"].strip() == "hello"
+        assert result["exit_code"] == 0
+        assert result["timed_out"] is False
+
+    def test_return_dict_keys(self):
+        result = BashTool.execute("echo test")
+        assert set(result.keys()) == {"stdout", "stderr", "exit_code", "timed_out"}
+
+    def test_timeout(self):
+        result = BashTool.execute("sleep 10", timeout=1)
+        assert result["timed_out"] is True
+        assert result["exit_code"] == -1
+
+
+class TestValidateCommand:
+    """Verify safety validation via the runtimes re-export."""
+
+    def test_safe_command_passes(self):
+        validate_command("ls -la")
+
+    def test_dangerous_command_blocked(self):
+        with pytest.raises(ValueError, match="Recursive forced deletion"):
+            validate_command("rm -rf /")
+
+    def test_sudo_blocked(self):
+        with pytest.raises(ValueError, match="sudo"):
+            validate_command("sudo apt update")
+
+
+class TestTruncate:
+    """Verify truncation via the runtimes re-export."""
+
+    def test_short_text_unchanged(self):
+        assert truncate("hello") == "hello"
+
+    def test_long_text_truncated(self):
+        long_text = "x" * 200_000
+        result = truncate(long_text, max_bytes=100)
+        assert len(result.encode("utf-8")) < 200_000
+        assert "[output truncated]" in result

--- a/tests/test_runtimes_bash.py
+++ b/tests/test_runtimes_bash.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from toolregistry.runtimes import BashTool, truncate, validate_command
+from toolregistry.runtimes import BashTool
+from toolregistry.runtimes._bashtool import truncate, validate_command
 
 
 class TestBashToolImport:
@@ -12,10 +13,9 @@ class TestBashToolImport:
         assert BashTool is not None
         assert hasattr(BashTool, "execute")
 
-    def test_import_validate_command(self):
+    def test_submodule_internals_accessible(self):
+        """Internal utils are accessible from _bashtool but not from runtimes."""
         assert callable(validate_command)
-
-    def test_import_truncate(self):
         assert callable(truncate)
 
 


### PR DESCRIPTION
## Summary

- Create `runtimes/` subpackage as the home for agent infrastructure tools and future PTC code execution runtimes
- Integrate BashTool from standalone [Oaklight/bashtool](https://github.com/Oaklight/bashtool) repo as a git submodule at `src/toolregistry/runtimes/_bashtool/`
- Add smoke tests verifying import, execution, safety validation, and truncation
- Update all CI workflows (`ci.yml`, `release.yml`, `rosetta-compat.yml`) with `submodules: recursive`
- Exclude submodule from ruff/ty/complexipy linting (has its own CI)

Closes #174

## Test plan

- [x] `make lint` passes (submodule excluded from linting)
- [x] `make test` passes — 949 tests + 11 new smoke tests, 0 failures
- [x] `from toolregistry.runtimes import BashTool` works
- [ ] CI passes with submodule checkout