### PR TITLE
fix: support sync callables in Tool.arun/arun_raw

### DIFF
--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -471,6 +471,9 @@ class Tool(BaseModel):
         Unlike ``run()``, this method does **not** catch exceptions — they
         propagate to the caller, preserving full stack-trace information.
 
+        Sync callables are invoked directly.  Async callables are run via
+        ``asyncio.run()`` so callers never receive a bare coroutine.
+
         Args:
             parameters: Input parameters for the tool.
 
@@ -488,6 +491,10 @@ class Tool(BaseModel):
         """
         parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
         validated_params = self._validate_parameters(parameters)
+
+        if inspect.iscoroutinefunction(self.callable):
+            return asyncio.run(self.callable(**validated_params))
+
         return self.callable(**validated_params)
 
     def run(self, parameters: dict[str, Any]) -> Any:

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import warnings
 from enum import Enum
@@ -530,6 +531,10 @@ class Tool(BaseModel):
         Unlike ``arun()``, this method does **not** catch exceptions — they
         propagate to the caller, preserving full stack-trace information.
 
+        Async callables are awaited directly.  Sync callables are
+        dispatched via ``asyncio.to_thread()`` so they never block the
+        event loop.
+
         Args:
             parameters: Input parameters for the tool.
 
@@ -537,7 +542,6 @@ class Tool(BaseModel):
             The tool execution result.
 
         Raises:
-            NotImplementedError: If async execution is unsupported.
             Exception: Any exception raised during validation or execution.
 
         Note:
@@ -551,12 +555,10 @@ class Tool(BaseModel):
 
         if inspect.iscoroutinefunction(self.callable):
             return await self.callable(**validated_params)
-        elif hasattr(self.callable, "__call__"):
-            return await self.callable(**validated_params)
-        raise NotImplementedError(
-            "Async execution requires either an async function (coroutine) "
-            "or a callable whose __call__ method is async or returns an awaitable object."
-        )
+
+        # Sync callable — run in a thread to avoid blocking the event loop.
+        fn = self.callable
+        return await asyncio.to_thread(fn, **validated_params)
 
     async def arun(self, parameters: dict[str, Any]) -> Any:
         """Execute tool asynchronously.
@@ -568,7 +570,6 @@ class Tool(BaseModel):
             Any: Tool execution result.
 
         Raises:
-            NotImplementedError: If async execution unsupported.
             Exception: On execution failure.
 
         Note:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -230,6 +230,13 @@ class TestTool:
         assert result == 30
 
     @pytest.mark.asyncio
+    async def test_arun_raw_with_sync_function(self, sample_tool):
+        """Test arun_raw dispatches sync callable via asyncio.to_thread."""
+        parameters = {"a": 10, "b": 20}
+        result = await sample_tool.arun_raw(parameters)
+        assert result == 30
+
+    @pytest.mark.asyncio
     async def test_arun_raw_raises_on_invalid_parameters(self, async_sample_function):
         """Test arun_raw raises instead of returning error string."""
         tool = Tool.from_function(async_sample_function)
@@ -238,13 +245,11 @@ class TestTool:
             await tool.arun_raw(parameters)
 
     @pytest.mark.asyncio
-    async def test_arun_with_sync_function_returns_result_or_error(self, sample_tool):
-        """Test async execution of sync tool."""
+    async def test_arun_with_sync_function(self, sample_tool):
+        """Test async execution of sync tool runs via asyncio.to_thread."""
         parameters = {"a": 5, "b": 3}
         result = await sample_tool.arun(parameters)
-
-        # Sync functions called via arun may either succeed or return error
-        assert result == 8 or (isinstance(result, str) and "Error executing" in result)
+        assert result == 8
 
     @pytest.mark.asyncio
     async def test_arun_with_invalid_parameters_returns_error_string(

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,5 +1,6 @@
 """Unit tests for the Tool class."""
 
+import asyncio
 import inspect
 
 import pytest
@@ -196,6 +197,13 @@ class TestTool:
 
         assert result == 8
 
+    def test_run_raw_with_async_function(self, async_sample_function):
+        """Test run_raw runs async callable via asyncio.run."""
+        tool = Tool.from_function(async_sample_function)
+        parameters = {"a": 10, "b": 20}
+        result = tool.run_raw(parameters)
+        assert result == 30
+
     def test_run_raw_raises_on_invalid_parameters(self, sample_tool):
         """Test run_raw raises instead of returning error string."""
         parameters = {"invalid": "params"}
@@ -250,6 +258,20 @@ class TestTool:
         parameters = {"a": 5, "b": 3}
         result = await sample_tool.arun(parameters)
         assert result == 8
+
+    @pytest.mark.asyncio
+    async def test_arun_parallel_sync_and_async(
+        self, sample_tool, async_sample_function
+    ):
+        """Test parallel arun with mixed sync and async tools."""
+        async_tool = Tool.from_function(async_sample_function)
+        results = await asyncio.gather(
+            sample_tool.arun_raw({"a": 1, "b": 1}),
+            sample_tool.arun_raw({"a": 2, "b": 2}),
+            async_tool.arun_raw({"a": 3, "b": 3}),
+            async_tool.arun_raw({"a": 4, "b": 4}),
+        )
+        assert results == [2, 4, 6, 8]
 
     @pytest.mark.asyncio
     async def test_arun_with_invalid_parameters_returns_error_string(


### PR DESCRIPTION
## Summary

Fix sync/async transparency in `Tool.run_raw()` and `Tool.arun_raw()` — users should never need to care whether a tool's underlying callable is sync or async.

**Before (broken):**
| | `run_raw` (sync caller) | `arun_raw` (async caller) |
|---|---|---|
| sync tool | ✅ works | ❌ `"object int can't be used in 'await' expression"` |
| async tool | ❌ returns bare coroutine object | ✅ works |

**After (fixed):**
| | `run_raw` (sync caller) | `arun_raw` (async caller) |
|---|---|---|
| sync tool | ✅ direct call | ✅ `asyncio.to_thread()` |
| async tool | ✅ `asyncio.run()` | ✅ `await` |

Note: executor backends (`ThreadBackend`, `ProcessPoolBackend`) already handle this correctly via `make_sync_wrapper()` — this fix is for direct `Tool.run/arun` callers.

Prerequisite for PTC (#175) where all registered tools must be callable transparently from both sync and async contexts.

## Test plan

- [x] All 4 combinations verified (sync/async tool × run/arun)
- [x] Parallel `asyncio.gather` with mixed sync/async tools works
- [x] Full suite: 941 passed, 0 failures