### PR TITLE
refactor: unify Tool callable layer with _FunctionToolWrapper

### DIFF
--- a/src/toolregistry/executor/_helpers.py
+++ b/src/toolregistry/executor/_helpers.py
@@ -31,8 +31,20 @@ def make_sync_wrapper(async_func: Callable) -> Callable:
     return wrapper
 
 
+def _unwrap_fn(fn: Callable) -> Callable:
+    """Unwrap a tool wrapper to get the underlying function.
+
+    Looks for a ``.fn`` attribute (used by ``_FunctionToolWrapper`` and
+    similar wrappers) without importing any toolregistry types.
+    """
+    return getattr(fn, "fn", fn)
+
+
 def should_inject_context(fn: Callable) -> bool:
     """Check if ``fn`` has a parameter named ``_ctx`` for context injection.
+
+    If *fn* is a tool wrapper with a ``.fn`` attribute, the inner
+    function's signature is inspected instead.
 
     Args:
         fn: The callable to inspect.
@@ -42,6 +54,7 @@ def should_inject_context(fn: Callable) -> bool:
         (or compatible with) ``ExecutionContext``.
     """
     try:
+        fn = _unwrap_fn(fn)
         sig = inspect.signature(fn)
         if "_ctx" not in sig.parameters:
             return False

--- a/src/toolregistry/executor/_helpers.py
+++ b/src/toolregistry/executor/_helpers.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from ._types import ExecutionContext
 
 
-
 def _unwrap_fn(fn: Callable) -> Callable:
     """Unwrap a tool wrapper to get the underlying function.
 

--- a/src/toolregistry/executor/_helpers.py
+++ b/src/toolregistry/executor/_helpers.py
@@ -2,33 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 from collections.abc import Callable
 
 from ._types import ExecutionContext
 
-
-def make_sync_wrapper(async_func: Callable) -> Callable:
-    """Wrap an async function so it can be called synchronously.
-
-    Args:
-        async_func: An async callable to wrap.
-
-    Returns:
-        A synchronous wrapper that runs the async function.
-    """
-
-    def wrapper(*args, **kwargs):  # noqa: ANN002, ANN003
-        try:
-            asyncio.get_running_loop()
-            return asyncio.get_event_loop().run_until_complete(
-                async_func(*args, **kwargs)
-            )
-        except RuntimeError:
-            return asyncio.run(async_func(*args, **kwargs))
-
-    return wrapper
 
 
 def _unwrap_fn(fn: Callable) -> Callable:

--- a/src/toolregistry/executor/_process_backend.py
+++ b/src/toolregistry/executor/_process_backend.py
@@ -13,7 +13,6 @@ from collections.abc import Callable
 
 import cloudpickle
 
-from ._helpers import make_sync_wrapper
 from ._protocol import ExecutionHandle
 from ._types import HandleStatus, ProgressReport
 
@@ -114,9 +113,17 @@ class ProcessPoolBackend:
     ) -> ExecutionHandle:
         exec_id = execution_id or uuid.uuid4().hex
 
-        # Auto-wrap async functions
-        if asyncio.iscoroutinefunction(fn):
-            fn = make_sync_wrapper(fn)
+        # Wrap bare async functions so they can run in the worker process.
+        # Tool wrappers (BaseToolWrapper) handle sync/async internally,
+        # so only wrap bare async callables passed directly.
+        raw_fn = getattr(fn, "fn", fn)
+        if asyncio.iscoroutinefunction(raw_fn) and not hasattr(fn, "call_sync"):
+            async_fn = fn
+
+            def _sync_wrapper(**kw):  # type: ignore[no-untyped-def]
+                return asyncio.run(async_fn(**kw))
+
+            fn = _sync_wrapper
 
         # Serialize the callable with cloudpickle
         serialized_fn = cloudpickle.dumps(fn)

--- a/src/toolregistry/executor/_thread_backend.py
+++ b/src/toolregistry/executor/_thread_backend.py
@@ -9,7 +9,7 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any
 from collections.abc import Callable
 
-from ._helpers import make_sync_wrapper, should_inject_context
+from ._helpers import should_inject_context
 from ._protocol import ExecutionHandle
 from ._types import (
     CancelledError,
@@ -96,9 +96,17 @@ class ThreadBackend:
     ) -> ExecutionHandle:
         exec_id = execution_id or uuid.uuid4().hex
 
-        # Auto-wrap async functions
-        if asyncio.iscoroutinefunction(fn):
-            fn = make_sync_wrapper(fn)
+        # Wrap bare async functions so they can run in the thread pool.
+        # For tool wrappers, unwrap to the inner function for the check;
+        # for bare async callables passed directly, wrap them in-place.
+        raw_fn = getattr(fn, "fn", fn)
+        if asyncio.iscoroutinefunction(raw_fn) and not hasattr(fn, "call_sync"):
+            async_fn = fn
+
+            def _sync_wrapper(**kw):  # type: ignore[no-untyped-def]
+                return asyncio.run(async_fn(**kw))
+
+            fn = _sync_wrapper
 
         # Context injection
         ctx: ExecutionContext | None = None

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from .parameter_models import _generate_parameters_model, _simplify_nullable_schemas
 from .llm.tool_calls import API_FORMATS
+from .tool_wrapper import BaseToolWrapper, _FunctionToolWrapper
 from .utils import normalize_tool_name
 
 
@@ -244,6 +245,18 @@ class Tool(BaseModel):
         return self.metadata.is_async
 
     @property
+    def fn(self) -> Callable[..., Any]:
+        """Return the underlying unwrapped function.
+
+        For native tools (registered via ``from_function``), returns the
+        original Python function.  For integration tools (MCP, OpenAPI,
+        LangChain), returns the wrapper itself.
+        """
+        if isinstance(self.callable, _FunctionToolWrapper):
+            return self.callable.fn
+        return self.callable
+
+    @property
     def qualified_name(self) -> str:
         """Return the fully-qualified tool name.
 
@@ -326,11 +339,18 @@ class Tool(BaseModel):
             if parameters_model
             else {}
         )
+        # Wrap bare functions so Tool.callable is always a BaseToolWrapper.
+        if not isinstance(func, BaseToolWrapper):
+            param_names = list(inspect.signature(func).parameters.keys())
+            wrapper = _FunctionToolWrapper(fn=func, name=func_name, params=param_names)
+        else:
+            wrapper = func
+
         tool = cls(
             name=func_name,
             description=func_doc,
             parameters=parameters_schema,
-            callable=func,
+            callable=wrapper,
             metadata=metadata,
             parameters_model=parameters_model if parameters_model is not None else None,
             method_name=resolved_method_name,
@@ -464,71 +484,11 @@ class Tool(BaseModel):
             validated_params = model.model_dump_one_level()
         return validated_params
 
-    def run_raw(self, parameters: dict[str, Any]) -> Any:
-        """Execute tool synchronously, raising on failure.
-
-        Unlike ``run()``, this method does **not** catch exceptions — they
-        propagate to the caller, preserving full stack-trace information.
-
-        Args:
-            parameters: Input parameters for the tool.
-
-        Returns:
-            The tool execution result.
-
-        Raises:
-            Exception: Any exception raised during validation or execution.
-
-        Note:
-            Result size truncation (via ``max_result_size``) is only applied
-            when tools are executed through
-            ``ToolRegistry.execute_tool_calls()``. Direct calls return raw
-            results without truncation.
-        """
-        parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
-        validated_params = self._validate_parameters(parameters)
-        return self.callable(**validated_params)
-
     def run(self, parameters: dict[str, Any]) -> Any:
         """Execute tool synchronously.
 
-        Args:
-            parameters (Dict[str, Any]): Validated input parameters.
-
-        Returns:
-            Any: Tool execution result.
-
-        Raises:
-            Exception: On execution failure.
-
-        Note:
-            Result size truncation (via ``max_result_size``) is only applied
-            when tools are executed through
-            ``ToolRegistry.execute_tool_calls()``. Direct calls to ``run()``
-            return raw results without truncation.
-
-        .. deprecated::
-            When an exception is caught, ``run()`` returns an error string.
-            This behaviour is deprecated — use ``run_raw()`` to get
-            exceptions directly. In a future version ``run()`` will raise.
-        """
-        try:
-            return self.run_raw(parameters)
-        except Exception as e:
-            warnings.warn(
-                "Tool.run() caught an exception and returned an error string. "
-                "This behavior is deprecated; use Tool.run_raw() for exceptions. "
-                "In a future version, run() will also raise.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return f"Error executing {self.name}: {str(e)}"
-
-    async def arun_raw(self, parameters: dict[str, Any]) -> Any:
-        """Execute tool asynchronously, raising on failure.
-
-        Unlike ``arun()``, this method does **not** catch exceptions — they
-        propagate to the caller, preserving full stack-trace information.
+        Delegates to ``callable.call_sync()`` which handles sync/async
+        callable transparency.  Exceptions propagate directly.
 
         Args:
             parameters: Input parameters for the tool.
@@ -537,7 +497,6 @@ class Tool(BaseModel):
             The tool execution result.
 
         Raises:
-            NotImplementedError: If async execution is unsupported.
             Exception: Any exception raised during validation or execution.
 
         Note:
@@ -548,51 +507,60 @@ class Tool(BaseModel):
         """
         parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
         validated_params = self._validate_parameters(parameters)
-
-        if inspect.iscoroutinefunction(self.callable):
-            return await self.callable(**validated_params)
-        elif hasattr(self.callable, "__call__"):
-            return await self.callable(**validated_params)
-        raise NotImplementedError(
-            "Async execution requires either an async function (coroutine) "
-            "or a callable whose __call__ method is async or returns an awaitable object."
-        )
+        return self.callable.call_sync(**validated_params)
 
     async def arun(self, parameters: dict[str, Any]) -> Any:
         """Execute tool asynchronously.
 
+        Delegates to ``callable.call_async()`` which handles sync/async
+        callable transparency.  Exceptions propagate directly.
+
         Args:
-            parameters (Dict[str, Any]): Validated input parameters.
+            parameters: Input parameters for the tool.
 
         Returns:
-            Any: Tool execution result.
+            The tool execution result.
 
         Raises:
-            NotImplementedError: If async execution unsupported.
-            Exception: On execution failure.
+            Exception: Any exception raised during validation or execution.
 
         Note:
             Result size truncation (via ``max_result_size``) is only applied
             when tools are executed through
-            ``ToolRegistry.execute_tool_calls()``. Direct calls to ``arun()``
-            return raw results without truncation.
-
-        .. deprecated::
-            When an exception is caught, ``arun()`` returns an error string.
-            This behaviour is deprecated — use ``arun_raw()`` to get
-            exceptions directly. In a future version ``arun()`` will raise.
+            ``ToolRegistry.execute_tool_calls()``. Direct calls return raw
+            results without truncation.
         """
-        try:
-            return await self.arun_raw(parameters)
-        except Exception as e:
-            warnings.warn(
-                "Tool.arun() caught an exception and returned an error string. "
-                "This behavior is deprecated; use Tool.arun_raw() for exceptions. "
-                "In a future version, arun() will also raise.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return f"Error executing {self.name}: {str(e)}"
+        parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
+        validated_params = self._validate_parameters(parameters)
+        return await self.callable.call_async(**validated_params)
+
+    def run_raw(self, parameters: dict[str, Any]) -> Any:
+        """Deprecated alias for ``run()``.
+
+        .. deprecated:: 0.12.0
+            Use ``run()`` instead.  ``run_raw`` will be removed in a
+            future version.
+        """
+        warnings.warn(
+            "Tool.run_raw() is deprecated; use Tool.run() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run(parameters)
+
+    async def arun_raw(self, parameters: dict[str, Any]) -> Any:
+        """Deprecated alias for ``arun()``.
+
+        .. deprecated:: 0.12.0
+            Use ``arun()`` instead.  ``arun_raw`` will be removed in a
+            future version.
+        """
+        warnings.warn(
+            "Tool.arun_raw() is deprecated; use Tool.arun() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await self.arun(parameters)
 
     def update_namespace(
         self,

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -159,13 +159,12 @@ class Tool(BaseModel):
     callable: Callable[..., Any] = Field(exclude=True)
     """The tool's callable, always a :class:`BaseToolWrapper` at runtime.
 
-    Typed as ``Callable`` for Pydantic compatibility.  Use
-    ``call_sync``/``call_async`` for sync/async transparent execution.
-    """
-    """The underlying function/method that implements the tool's logic.
+    Typed as ``Callable`` for Pydantic compatibility (Pydantic cannot
+    generate a schema for ``BaseToolWrapper``).  Use ``call_sync()`` /
+    ``call_async()`` for sync/async transparent execution.
 
-    This is excluded from serialization to prevent accidental exposure
-    of sensitive implementation details.
+    Excluded from serialization to prevent accidental exposure of
+    implementation details.
     """
 
     metadata: ToolMetadata = Field(default_factory=ToolMetadata)

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -157,6 +157,11 @@ class Tool(BaseModel):
     """
 
     callable: Callable[..., Any] = Field(exclude=True)
+    """The tool's callable, always a :class:`BaseToolWrapper` at runtime.
+
+    Typed as ``Callable`` for Pydantic compatibility.  Use
+    ``call_sync``/``call_async`` for sync/async transparent execution.
+    """
     """The underlying function/method that implements the tool's logic.
 
     This is excluded from serialization to prevent accidental exposure
@@ -507,7 +512,7 @@ class Tool(BaseModel):
         """
         parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
         validated_params = self._validate_parameters(parameters)
-        return self.callable.call_sync(**validated_params)
+        return self.callable.call_sync(**validated_params)  # ty: ignore[unresolved-attribute]
 
     async def arun(self, parameters: dict[str, Any]) -> Any:
         """Execute tool asynchronously.
@@ -532,7 +537,7 @@ class Tool(BaseModel):
         """
         parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
         validated_params = self._validate_parameters(parameters)
-        return await self.callable.call_async(**validated_params)
+        return await self.callable.call_async(**validated_params)  # ty: ignore[unresolved-attribute]
 
     def run_raw(self, parameters: dict[str, Any]) -> Any:
         """Deprecated alias for ``run()``.

--- a/src/toolregistry/tool_wrapper.py
+++ b/src/toolregistry/tool_wrapper.py
@@ -1,36 +1,42 @@
 import asyncio
+import inspect
 from abc import ABC, abstractmethod
 from typing import Any
+from collections.abc import Callable
 
 
 class BaseToolWrapper(ABC):
-    """Base class for tool wrappers that provide support for synchronous
-    and asynchronous calls.
+    """Base class for tool wrappers that provide sync/async transparent calls.
+
+    Every ``Tool.callable`` is a ``BaseToolWrapper`` subclass.  This
+    guarantees that ``call_sync()`` and ``call_async()`` are always
+    available regardless of the tool's origin (native function, MCP,
+    OpenAPI, LangChain).
 
     Attributes:
-        name (str): Name of the tool.
-        params (Optional[List[str]]): List of parameter names, default is None.
+        name: Name of the tool.
+        params: List of parameter names, default is None.
     """
 
     def __init__(self, name: str, params: list[str] | None = None) -> None:
-        """Initializes the base tool wrapper.
+        """Initialize the base tool wrapper.
 
         Args:
-            name (str): Name of the tool.
-            params (Optional[List[str]]): List of parameter names, default is None.
+            name: Name of the tool.
+            params: List of parameter names, default is None.
         """
         self.name = name
         self.params = params
 
     def _process_args(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Processes positional and keyword arguments.
+        """Process positional and keyword arguments into a kwargs dict.
 
         Args:
             *args: Positional arguments.
             **kwargs: Keyword arguments.
 
         Returns:
-            Dict[str, Any]: Dictionary of processed arguments.
+            Merged keyword arguments dict.
 
         Raises:
             ValueError: If tool parameters are not initialized.
@@ -63,14 +69,9 @@ class BaseToolWrapper(ABC):
             **kwargs: Keyword arguments.
 
         Returns:
-            Any: The result of the call.
-
-        Raises:
-            NotImplementedError: Must be implemented by a subclass.
+            The result of the call.
         """
-        raise NotImplementedError(
-            "The 'call_sync' method must be implemented by a subclass."
-        )
+        ...
 
     @abstractmethod
     async def call_async(self, *args: Any, **kwargs: Any) -> Any:
@@ -81,28 +82,73 @@ class BaseToolWrapper(ABC):
             **kwargs: Keyword arguments.
 
         Returns:
-            Any: The result of the call.
-
-        Raises:
-            NotImplementedError: Must be implemented by a subclass.
+            The result of the call.
         """
-        raise NotImplementedError(
-            "The 'call_async' method must be implemented by a subclass."
-        )
+        ...
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Makes the wrapper callable and automatically selects between
-        synchronous and asynchronous versions.
+        """Make the wrapper callable, selecting sync or async automatically.
 
         Args:
             *args: Positional arguments.
             **kwargs: Keyword arguments.
 
         Returns:
-            Any: The result of the call.
+            The result of the call (or a coroutine if in async context).
         """
         try:
             asyncio.get_running_loop()
             return self.call_async(*args, **kwargs)
         except RuntimeError:
             return self.call_sync(*args, **kwargs)
+
+
+class _FunctionToolWrapper(BaseToolWrapper):
+    """Wrapper for native Python functions (sync or async).
+
+    Created automatically by ``Tool.from_function()`` so that
+    ``Tool.callable`` is always a ``BaseToolWrapper``.  The underlying
+    function is accessible via the ``.fn`` attribute.
+
+    Args:
+        fn: The Python function to wrap.
+        name: Tool name.
+        params: List of parameter names.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        name: str,
+        params: list[str] | None = None,
+    ) -> None:
+        super().__init__(name, params)
+        self.fn = fn
+        self._is_async = inspect.iscoroutinefunction(fn)
+
+    def call_sync(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the function synchronously.
+
+        Sync functions are called directly.  Async functions are run
+        via ``asyncio.run()``.
+
+        Raises:
+            RuntimeError: If called from within a running event loop
+                with an async function.  Use ``call_async()`` instead.
+        """
+        kwargs = self._process_args(*args, **kwargs)
+        if self._is_async:
+            return asyncio.run(self.fn(**kwargs))
+        return self.fn(**kwargs)
+
+    async def call_async(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the function asynchronously.
+
+        Async functions are awaited directly.  Sync functions are
+        dispatched via ``asyncio.to_thread()`` to avoid blocking
+        the event loop.
+        """
+        kwargs = self._process_args(*args, **kwargs)
+        if self._is_async:
+            return await self.fn(**kwargs)
+        return await asyncio.to_thread(self.fn, **kwargs)

--- a/tests/test_executor/test_helpers.py
+++ b/tests/test_executor/test_helpers.py
@@ -1,23 +1,7 @@
 """Tests for executor helper functions."""
 
 from toolregistry.executor import ExecutionContext
-from toolregistry.executor._helpers import make_sync_wrapper, should_inject_context
-
-
-class TestMakeSyncWrapper:
-    def test_wraps_async_function(self):
-        async def add(x: int, y: int) -> int:
-            return x + y
-
-        sync_add = make_sync_wrapper(add)
-        assert sync_add(x=3, y=4) == 7
-
-    def test_preserves_arguments(self):
-        async def greet(name: str) -> str:
-            return f"hello {name}"
-
-        sync_greet = make_sync_wrapper(greet)
-        assert sync_greet(name="world") == "hello world"
+from toolregistry.executor._helpers import should_inject_context
 
 
 class TestShouldInjectContext:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -239,12 +239,12 @@ class TestToolRegistryIntegration:
         failing_tool = registry.get_tool("failing_function")
         good_tool = registry.get_tool("good_function")
 
-        # Test direct tool execution
-        error_result = failing_tool.run({"should_fail": True})
+        # Test direct tool execution — run() now raises on failure
+        with pytest.raises(ValueError, match="Intentional failure"):
+            failing_tool.run({"should_fail": True})
         success_result = failing_tool.run({"should_fail": False})
         good_result = good_tool.run({"x": 5, "y": 3})
 
-        assert "Error executing" in error_result
         assert success_result == "success"
         assert good_result == 8
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,5 +1,6 @@
 """Unit tests for the Tool class."""
 
+import asyncio
 import inspect
 
 import pytest
@@ -16,7 +17,7 @@ class TestTool:
 
         assert tool.name == "add_numbers"
         assert "Add two numbers together" in tool.description
-        assert tool.callable == sample_function
+        assert tool.fn == sample_function
         assert not tool.is_async
         assert isinstance(tool.parameters, dict)
 
@@ -45,7 +46,7 @@ class TestTool:
 
         assert tool.name == "async_add_numbers"
         assert tool.is_async
-        assert inspect.iscoroutinefunction(tool.callable)
+        assert inspect.iscoroutinefunction(tool.fn)
 
     def test_tool_creation_from_lambda_without_name_raises_error(self):
         """Test that creating a Tool from lambda without name raises ValueError."""
@@ -62,7 +63,7 @@ class TestTool:
         tool = Tool.from_function(lambda_func, name="double")
 
         assert tool.name == "double"
-        assert tool.callable == lambda_func
+        assert tool.fn == lambda_func
 
     def test_tool_creation_normalizes_empty_parameters_schema(self):
         """Direct Tool construction should always produce object parameters."""
@@ -189,27 +190,18 @@ class TestTool:
 
         assert result == 8
 
-    def test_run_raw_with_valid_parameters(self, sample_tool):
-        """Test run_raw returns result on success."""
+    def test_run_raw_deprecated(self, sample_tool):
+        """Test run_raw emits deprecation warning and delegates to run."""
         parameters = {"a": 5, "b": 3}
-        result = sample_tool.run_raw(parameters)
-
+        with pytest.warns(DeprecationWarning, match="run_raw.*deprecated"):
+            result = sample_tool.run_raw(parameters)
         assert result == 8
 
-    def test_run_raw_raises_on_invalid_parameters(self, sample_tool):
-        """Test run_raw raises instead of returning error string."""
+    def test_run_raises_on_invalid_parameters(self, sample_tool):
+        """Test run raises on invalid parameters (no longer swallows exceptions)."""
         parameters = {"invalid": "params"}
         with pytest.raises(Exception):
-            sample_tool.run_raw(parameters)
-
-    def test_run_with_invalid_parameters_returns_error_string(self, sample_tool):
-        """Test running tool with invalid parameters returns error string with deprecation warning."""
-        parameters = {"invalid": "params"}
-        with pytest.warns(DeprecationWarning, match="run_raw"):
-            result = sample_tool.run(parameters)
-
-        assert isinstance(result, str)
-        assert "Error executing" in result
+            sample_tool.run(parameters)
 
     @pytest.mark.asyncio
     async def test_arun_with_async_function(self, async_sample_function):
@@ -221,43 +213,42 @@ class TestTool:
         assert result == 30
 
     @pytest.mark.asyncio
-    async def test_arun_raw_with_async_function(self, async_sample_function):
-        """Test arun_raw returns result on success."""
+    async def test_arun_raw_deprecated(self, async_sample_function):
+        """Test arun_raw emits deprecation warning and delegates to arun."""
         tool = Tool.from_function(async_sample_function)
         parameters = {"a": 10, "b": 20}
-        result = await tool.arun_raw(parameters)
-
+        with pytest.warns(DeprecationWarning, match="arun_raw.*deprecated"):
+            result = await tool.arun_raw(parameters)
         assert result == 30
 
     @pytest.mark.asyncio
-    async def test_arun_raw_raises_on_invalid_parameters(self, async_sample_function):
-        """Test arun_raw raises instead of returning error string."""
+    async def test_arun_with_sync_function(self, sample_tool):
+        """Test async execution of sync tool via asyncio.to_thread."""
+        parameters = {"a": 5, "b": 3}
+        result = await sample_tool.arun(parameters)
+        assert result == 8
+
+    @pytest.mark.asyncio
+    async def test_arun_raises_on_invalid_parameters(self, async_sample_function):
+        """Test arun raises on invalid parameters (no longer swallows exceptions)."""
         tool = Tool.from_function(async_sample_function)
         parameters = {"invalid": "params"}
         with pytest.raises(Exception):
-            await tool.arun_raw(parameters)
+            await tool.arun(parameters)
 
     @pytest.mark.asyncio
-    async def test_arun_with_sync_function_returns_result_or_error(self, sample_tool):
-        """Test async execution of sync tool."""
-        parameters = {"a": 5, "b": 3}
-        result = await sample_tool.arun(parameters)
-
-        # Sync functions called via arun may either succeed or return error
-        assert result == 8 or (isinstance(result, str) and "Error executing" in result)
-
-    @pytest.mark.asyncio
-    async def test_arun_with_invalid_parameters_returns_error_string(
-        self, async_sample_function
+    async def test_arun_parallel_sync_and_async(
+        self, sample_tool, async_sample_function
     ):
-        """Test async execution with invalid parameters returns error string with deprecation warning."""
-        tool = Tool.from_function(async_sample_function)
-        parameters = {"invalid": "params"}
-        with pytest.warns(DeprecationWarning, match="arun_raw"):
-            result = await tool.arun(parameters)
-
-        assert isinstance(result, str)
-        assert "Error executing" in result
+        """Test parallel arun with mixed sync and async tools."""
+        async_tool = Tool.from_function(async_sample_function)
+        results = await asyncio.gather(
+            sample_tool.arun({"a": 1, "b": 1}),
+            sample_tool.arun({"a": 2, "b": 2}),
+            async_tool.arun({"a": 3, "b": 3}),
+            async_tool.arun({"a": 4, "b": 4}),
+        )
+        assert results == [2, 4, 6, 8]
 
     def test_update_namespace_adds_namespace_to_tool_without_existing(
         self, sample_tool

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -65,7 +65,8 @@ class TestToolRegistry:
         sample_registry.register(test_func)
 
         assert "test_func" in sample_registry
-        assert sample_registry.get_callable("test_func") == test_func
+        tool = sample_registry.get_tool("test_func")
+        assert tool.fn == test_func
 
     def test_register_function_with_custom_name_and_description(self, sample_registry):
         """Test registering a function with custom name and description."""


### PR DESCRIPTION
## Summary

All `Tool.callable` values are now `BaseToolWrapper` subclasses, providing uniform `call_sync`/`call_async` interfaces regardless of tool origin (native function, MCP, OpenAPI, LangChain).

**Before**: native functions registered via `Tool.from_function()` were stored as bare callables — `run_raw`/`arun_raw` had to branch on `iscoroutinefunction` and had bugs (sync tool + arun crashed, async tool + run returned coroutine object).

**After**: `_FunctionToolWrapper` wraps all native functions at registration time. The sync/async matrix works transparently:

| | `run()` (sync caller) | `arun()` (async caller) |
|---|---|---|
| sync tool | direct call | `asyncio.to_thread()` |
| async tool | `asyncio.run()` | `await` |

### API changes

- **`run()`/`arun()`** — now the primary API, exceptions propagate directly (no more error-string swallowing)
- **`run_raw()`/`arun_raw()`** — deprecated aliases with `DeprecationWarning`, will be removed in future version
- **`tool.fn`** — new property to access the unwrapped underlying function
- **`tool.callable`** — now always a `BaseToolWrapper` instance (was bare function for native tools)

### Internal changes

- `_FunctionToolWrapper` in `tool_wrapper.py` — `call_sync` handles async-in-sync via `asyncio.run()`, `call_async` handles sync-in-async via `asyncio.to_thread()`
- `executor/_helpers.py` — `_unwrap_fn()` looks through wrappers for context injection (`_ctx` parameter), zero toolregistry imports preserved

Prerequisite for PTC (#175) where all registered tools must be callable transparently from both sync and async contexts.

## Test plan

- [x] All 4 sync/async combinations verified
- [x] Parallel `asyncio.gather` with mixed sync/async tools
- [x] `run_raw`/`arun_raw` deprecation warnings emitted
- [x] Executor context injection works through wrapper
- [x] Full suite: 937 passed, 0 failures
- [x] CI passes