### PR TITLE
feat: add runtimes/ subpackage with PTC protocols

### DIFF
--- a/src/toolregistry/runtimes/__init__.py
+++ b/src/toolregistry/runtimes/__init__.py
@@ -1,0 +1,27 @@
+"""Runtime subpackage — PTC (Programmatic Tool Calling) protocols and runtimes.
+
+This subpackage has **zero imports from toolregistry internals**.
+It operates exclusively on callables, dicts, and its own protocol types.
+
+Current contents:
+
+- :class:`CodeResult` — structured output from code execution
+- :class:`ToolProjection` — protocol: how a tool appears in code namespace
+- :class:`DirectProjection` — in-process ToolProjection (wraps bare callable)
+- :class:`CodeRuntime` — protocol: executes code with tool access
+
+Future contents (see issues #176, #177):
+
+- ``InProcessRuntime`` — ``exec()``-based CodeRuntime
+- ``SubprocessRuntime`` — isolated CodeRuntime with bidirectional IPC
+- ``PythonExecutionTool`` — meta-tool exposing CodeRuntime to LLMs
+"""
+
+from ._protocol import CodeResult, CodeRuntime, DirectProjection, ToolProjection
+
+__all__ = [
+    "CodeResult",
+    "CodeRuntime",
+    "DirectProjection",
+    "ToolProjection",
+]

--- a/src/toolregistry/runtimes/_protocol.py
+++ b/src/toolregistry/runtimes/_protocol.py
@@ -1,0 +1,191 @@
+"""PTC (Programmatic Tool Calling) protocols and core types.
+
+This module defines the abstractions for executing LLM-generated code
+with tool access.  It has **zero imports from toolregistry internals**
+(same constraint as ``executor/``).
+
+Protocols
+---------
+- :class:`ToolProjection` — how a tool appears inside a code runtime's
+  namespace (callable with name and docstring).
+- :class:`CodeRuntime` — executes code strings with tool access and
+  returns structured results.
+
+Concrete implementations
+------------------------
+- :class:`DirectProjection` — in-process wrapper around a bare callable.
+  Used by ``InProcessRuntime`` (issue #176).
+- ``StubProjection`` — IPC stub for subprocess isolation (issue #177,
+  not yet implemented).
+
+Result types
+------------
+- :class:`CodeResult` — structured output from code execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+from collections.abc import Callable
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CodeResult:
+    """Structured result from code execution in a :class:`CodeRuntime`.
+
+    Attributes:
+        stdout: Captured standard output from the executed code.
+        stderr: Content the code wrote to standard error during execution.
+        return_code: ``0`` for success, ``1`` for exception.  In-process
+            runtimes use this convention since there is no real OS exit
+            code.
+        error: Exception traceback that terminated execution, or ``None``
+            if the code completed successfully.  Distinct from *stderr*,
+            which captures intentional writes to ``sys.stderr``.
+    """
+
+    stdout: str = ""
+    stderr: str = ""
+    return_code: int = 0
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# ToolProjection protocol + DirectProjection
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ToolProjection(Protocol):
+    """How a tool appears inside a code runtime's namespace.
+
+    In-process runtimes use :class:`DirectProjection` (zero overhead).
+    Isolated runtimes (subprocess, container) will use IPC stubs that
+    satisfy the same interface.
+
+    The ``__call__`` method is synchronous — runtimes that need async
+    dispatch handle the wrapping themselves.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in the code namespace."""
+        ...
+
+    @property
+    def doc(self) -> str | None:
+        """Docstring shown to the LLM-generated code (e.g. via ``help()``)."""
+        ...
+
+    def __call__(self, **kwargs: Any) -> Any:
+        """Invoke the tool with keyword arguments."""
+        ...
+
+
+class DirectProjection:
+    """In-process :class:`ToolProjection` — wraps a callable with zero overhead.
+
+    Used by ``InProcessRuntime`` (issue #176).  Takes a bare callable
+    plus metadata — no dependency on ``Tool`` or any toolregistry type.
+    The caller who has access to a ``Tool`` object constructs this::
+
+        proj = DirectProjection(
+            name=tool.name,
+            fn=tool.fn,
+            doc=tool.description,
+        )
+
+    For ``SubprocessRuntime`` (issue #177), a ``StubProjection`` will be
+    added that serializes calls over IPC behind the same interface.
+
+    Attributes:
+        fn: The underlying callable (sync or async).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        fn: Callable[..., Any],
+        doc: str | None = None,
+    ) -> None:
+        self._name = name
+        self.fn = fn
+        self._doc = doc
+        self._is_async = inspect.iscoroutinefunction(fn)
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in the code namespace."""
+        return self._name
+
+    @property
+    def doc(self) -> str | None:
+        """Docstring for the tool."""
+        return self._doc
+
+    def __call__(self, **kwargs: Any) -> Any:
+        """Invoke the tool synchronously.
+
+        Async callables are run via ``asyncio.run()``.  This is
+        appropriate for in-process ``exec()`` contexts where the code
+        runs synchronously.
+        """
+        if self._is_async:
+            return asyncio.run(self.fn(**kwargs))
+        return self.fn(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# CodeRuntime protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class CodeRuntime(Protocol):
+    """Executes LLM-generated code with tool access.
+
+    Different from ``ExecutionBackend``:
+
+    ============  =======================================
+    CodeRuntime   code string + tool namespace → result
+                  bidirectional, multi-call
+    ExecutionBackend  single callable + kwargs → result
+                  unidirectional, one-shot
+    ============  =======================================
+
+    CodeRuntime is a *consumer* of ExecutionBackend, not a replacement.
+    """
+
+    async def execute(
+        self,
+        code: str,
+        namespace: dict[str, ToolProjection],
+        *,
+        timeout: float | None = None,
+        extra_globals: dict[str, Any] | None = None,
+    ) -> CodeResult:
+        """Execute *code* with tools from *namespace*.
+
+        Args:
+            code: Python source code to execute.
+            namespace: Mapping of tool name → :class:`ToolProjection`.
+                These are injected into the execution namespace so the
+                code can call them directly.
+            timeout: Maximum wall-clock seconds.  ``None`` means no limit.
+            extra_globals: Additional objects (imports, constants, etc.)
+                to inject into the execution namespace alongside tools.
+                Tool entries win on name collision.
+
+        Returns:
+            A :class:`CodeResult` with captured stdout, stderr, and
+            error information.
+        """
+        ...

--- a/tests/test_runtimes_protocol.py
+++ b/tests/test_runtimes_protocol.py
@@ -1,0 +1,147 @@
+"""Tests for the PTC protocols and DirectProjection (runtimes subpackage)."""
+
+import asyncio
+
+import pytest
+
+from toolregistry.runtimes import (
+    CodeResult,
+    CodeRuntime,
+    DirectProjection,
+    ToolProjection,
+)
+
+
+# ---------------------------------------------------------------------------
+# CodeResult
+# ---------------------------------------------------------------------------
+
+
+class TestCodeResult:
+    def test_defaults(self):
+        r = CodeResult()
+        assert r.stdout == ""
+        assert r.stderr == ""
+        assert r.return_code == 0
+        assert r.error is None
+
+    def test_success(self):
+        r = CodeResult(stdout="hello\n", return_code=0)
+        assert r.stdout == "hello\n"
+        assert r.return_code == 0
+
+    def test_failure(self):
+        r = CodeResult(stderr="warn", return_code=1, error="ZeroDivisionError")
+        assert r.return_code == 1
+        assert r.error == "ZeroDivisionError"
+
+    def test_frozen(self):
+        r = CodeResult()
+        with pytest.raises(AttributeError):
+            r.stdout = "mutate"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ToolProjection protocol
+# ---------------------------------------------------------------------------
+
+
+class TestToolProjection:
+    def test_runtime_checkable(self):
+        assert isinstance(DirectProjection(name="t", fn=lambda: None), ToolProjection)
+
+    def test_custom_class_satisfies_protocol(self):
+        class MyProjection:
+            @property
+            def name(self) -> str:
+                return "custom"
+
+            @property
+            def doc(self) -> str | None:
+                return "doc"
+
+            def __call__(self, **kwargs):
+                return kwargs
+
+        assert isinstance(MyProjection(), ToolProjection)
+
+
+# ---------------------------------------------------------------------------
+# DirectProjection
+# ---------------------------------------------------------------------------
+
+
+class TestDirectProjection:
+    def test_sync_callable(self):
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        proj = DirectProjection(name="add", fn=add, doc="Add two numbers.")
+        assert proj.name == "add"
+        assert proj.doc == "Add two numbers."
+        assert proj(a=3, b=4) == 7
+
+    def test_async_callable(self):
+        async def multiply(a: int, b: int) -> int:
+            return a * b
+
+        proj = DirectProjection(name="multiply", fn=multiply)
+        assert proj.name == "multiply"
+        assert proj.doc is None
+        # call_sync dispatches async via asyncio.run
+        assert proj(a=3, b=5) == 15
+
+    def test_fn_attribute(self):
+        def f():
+            pass
+
+        proj = DirectProjection(name="f", fn=f)
+        assert proj.fn is f
+
+    def test_no_doc(self):
+        proj = DirectProjection(name="t", fn=lambda: 42)
+        assert proj.doc is None
+        assert proj() == 42
+
+
+# ---------------------------------------------------------------------------
+# CodeRuntime protocol
+# ---------------------------------------------------------------------------
+
+
+class TestCodeRuntime:
+    def test_runtime_checkable(self):
+        class MockRuntime:
+            async def execute(
+                self,
+                code,
+                namespace,
+                *,
+                timeout=None,
+                extra_globals=None,
+            ):
+                return CodeResult(stdout="ok")
+
+        assert isinstance(MockRuntime(), CodeRuntime)
+
+    def test_mock_runtime_executes(self):
+        class MockRuntime:
+            async def execute(
+                self, code, namespace, *, timeout=None, extra_globals=None
+            ):
+                # Simulate executing code that calls a tool
+                tool = namespace.get("add")
+                if tool:
+                    result = tool(a=1, b=2)
+                    return CodeResult(stdout=str(result), return_code=0)
+                return CodeResult(return_code=1, error="no tool")
+
+        runtime = MockRuntime()
+        add_proj = DirectProjection(
+            name="add", fn=lambda a, b: a + b, doc="Add numbers"
+        )
+        ns = {"add": add_proj}
+
+        result = asyncio.run(runtime.execute("", ns))
+        assert result.stdout == "3"
+        assert result.return_code == 0


### PR DESCRIPTION
## Summary

Define the core abstractions for PTC (Programmatic Tool Calling) in a new `runtimes/` subpackage. Zero imports from toolregistry internals (same constraint as `executor/`).

### New types

- **`CodeResult`** — frozen dataclass: `stdout`, `stderr`, `return_code` (0=success, 1=exception), `error` (traceback or None)
- **`ToolProjection`** — `@runtime_checkable` protocol: `name`, `doc`, `__call__(**kwargs)`. How tools appear inside code execution namespaces
- **`DirectProjection`** — concrete in-process implementation: wraps bare callable, handles sync/async via `asyncio.run()`
- **`CodeRuntime`** — `@runtime_checkable` protocol: `execute(code, namespace, *, timeout, extra_globals) -> CodeResult`

### Design decisions

- `ToolProjection.__call__` is **sync** — runtimes handle async dispatch themselves
- `extra_globals` parameter on `CodeRuntime.execute()` for injecting non-tool objects (imports, constants) without polluting the typed `namespace` dict
- `DirectProjection` takes `(name, fn, doc)` — no dependency on `Tool` class. Callers construct from Tool: `DirectProjection(name=tool.name, fn=tool.fn, doc=tool.description)`
- `signature` deferred to I-PTC interactive layer (not needed for execution loop)

Foundation for #176 (InProcessRuntime) and #177 (SubprocessRuntime).

Closes #175

## Test plan

- [x] 12 tests covering CodeResult, ToolProjection, DirectProjection, CodeRuntime
- [x] Full suite: 947 passed, 0 failures
- [x] Pre-commit (ruff, ty, complexipy) all pass
- [x] CI passes