### PR TITLE
fix: address #175 review feedback

### DIFF
--- a/src/toolregistry/runtimes/__init__.py
+++ b/src/toolregistry/runtimes/__init__.py
@@ -17,11 +17,18 @@ Future contents (see issues #176, #177):
 - ``PythonExecutionTool`` — meta-tool exposing CodeRuntime to LLMs
 """
 
-from ._protocol import CodeResult, CodeRuntime, DirectProjection, ToolProjection
+from ._protocol import (
+    CodeResult,
+    CodeRuntime,
+    DirectProjection,
+    ToolProjection,
+    validate_namespace,
+)
 
 __all__ = [
     "CodeResult",
     "CodeRuntime",
     "DirectProjection",
     "ToolProjection",
+    "validate_namespace",
 ]

--- a/src/toolregistry/runtimes/_protocol.py
+++ b/src/toolregistry/runtimes/_protocol.py
@@ -137,10 +137,36 @@ class DirectProjection:
         Async callables are run via ``asyncio.run()``.  This is
         appropriate for in-process ``exec()`` contexts where the code
         runs synchronously.
+
+        Note:
+            ``asyncio.run()`` cannot be called from within a running
+            event loop.  If the ``CodeRuntime.execute()`` implementation
+            itself runs inside an event loop, it must handle this — e.g.
+            by running ``exec()`` in a separate thread via
+            ``asyncio.to_thread()``.  See issue #176.
         """
         if self._is_async:
             return asyncio.run(self.fn(**kwargs))
         return self.fn(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Namespace helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_namespace(namespace: dict[str, ToolProjection]) -> None:
+    """Check that each key matches its ``ToolProjection.name``.
+
+    Raises:
+        ValueError: If any key/name pair is inconsistent.
+    """
+    for key, proj in namespace.items():
+        if key != proj.name:
+            raise ValueError(
+                f"Namespace key {key!r} does not match "
+                f"ToolProjection.name {proj.name!r}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtimes_protocol.py
+++ b/tests/test_runtimes_protocol.py
@@ -9,6 +9,7 @@ from toolregistry.runtimes import (
     CodeRuntime,
     DirectProjection,
     ToolProjection,
+    validate_namespace,
 )
 
 
@@ -145,3 +146,27 @@ class TestCodeRuntime:
         result = asyncio.run(runtime.execute("", ns))
         assert result.stdout == "3"
         assert result.return_code == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_namespace
+# ---------------------------------------------------------------------------
+
+
+class TestValidateNamespace:
+    def test_consistent_namespace(self):
+        ns = {
+            "add": DirectProjection(name="add", fn=lambda a, b: a + b),
+            "mul": DirectProjection(name="mul", fn=lambda a, b: a * b),
+        }
+        validate_namespace(ns)  # should not raise
+
+    def test_empty_namespace(self):
+        validate_namespace({})  # should not raise
+
+    def test_mismatched_key_raises(self):
+        ns = {
+            "wrong_name": DirectProjection(name="add", fn=lambda a, b: a + b),
+        }
+        with pytest.raises(ValueError, match="wrong_name.*add"):
+            validate_namespace(ns)


### PR DESCRIPTION
## Summary

Address Elena's review feedback on PR #184:

1. **DirectProjection docstring NOTE** — documents `asyncio.run()` nesting limitation and how `InProcessRuntime` (#176) should handle it (run `exec()` in a separate thread)
2. **`validate_namespace()` helper** — catches key/name mismatches early (`{"wrong": proj_with_name_add}` → `ValueError`). Runtimes can call this at the top of `execute()` as a sanity check
3. *(Point 2 from review — sync `__call__` in async `execute()` bridging — is a #176 design concern, not actionable here)*

## Test plan

- [x] 3 new tests for `validate_namespace` (consistent, empty, mismatched)
- [x] 15 protocol tests pass
- [x] Pre-commit all pass
- [x] CI passes