### PR TITLE
refactor: adopt codecell, remove CodeResult/CodeRuntime from runtimes/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 mcp = ["mcp>=1.0.0,<2.0.0", "httpx>=0.28.1"]
 openapi = []
 langchain = ["langchain-core>=0.3,<0.4", "langchain-community>=0.3,<0.4"]
+ptc = ["codecell>=0.1.0"]
 
 # dev dependencies
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 mcp = ["mcp>=1.0.0,<2.0.0", "httpx>=0.28.1"]
 openapi = []
 langchain = ["langchain-core>=0.3,<0.4", "langchain-community>=0.3,<0.4"]
-ptc = ["codecell>=0.1.0"]
+ptc = ["codecell>=0.1.0,<0.2.0"]
 
 # dev dependencies
 dev = [

--- a/src/toolregistry/runtimes/__init__.py
+++ b/src/toolregistry/runtimes/__init__.py
@@ -1,34 +1,32 @@
-"""Runtime subpackage — PTC (Programmatic Tool Calling) protocols and runtimes.
+"""Runtime subpackage — PTC (Programmatic Tool Calling) bridge layer.
 
-This subpackage has **zero imports from toolregistry internals**.
-It operates exclusively on callables, dicts, and its own protocol types.
+This subpackage bridges toolregistry's ``Tool`` model into the
+``codecell`` code execution engine.  It has **zero imports from
+toolregistry internals**.
 
-Current contents:
+Contents:
 
-- :class:`CodeResult` — structured output from code execution
 - :class:`ToolProjection` — protocol: how a tool appears in code namespace
 - :class:`DirectProjection` — in-process ToolProjection (wraps bare callable)
-- :class:`CodeRuntime` — protocol: executes code with tool access
+- :func:`validate_namespace` — check key/name consistency
+- :func:`namespace_to_callables` — convert ToolProjection dict to
+  plain callable dict for codecell
 
-Future contents (see issues #176, #177):
-
-- ``InProcessRuntime`` — ``exec()``-based CodeRuntime
-- ``SubprocessRuntime`` — isolated CodeRuntime with bidirectional IPC
-- ``PythonExecutionTool`` — meta-tool exposing CodeRuntime to LLMs
+Code execution types (:class:`~codecell.CodeResult`,
+:class:`~codecell.SubprocessRuntime`, etc.) are provided by the
+``codecell`` package (``pip install codecell``).
 """
 
 from ._protocol import (
-    CodeResult,
-    CodeRuntime,
     DirectProjection,
     ToolProjection,
+    namespace_to_callables,
     validate_namespace,
 )
 
 __all__ = [
-    "CodeResult",
-    "CodeRuntime",
     "DirectProjection",
     "ToolProjection",
+    "namespace_to_callables",
     "validate_namespace",
 ]

--- a/src/toolregistry/runtimes/_protocol.py
+++ b/src/toolregistry/runtimes/_protocol.py
@@ -96,6 +96,12 @@ class DirectProjection:
         """Invoke the tool synchronously.
 
         Async callables are run via ``asyncio.run()``.
+
+        Warning:
+            ``asyncio.run()`` cannot be called from within a running
+            event loop (e.g. Jupyter, FastAPI).  If the caller is
+            already in an async context, use ``await proj.fn(**kwargs)``
+            directly instead.
         """
         if self._is_async:
             return asyncio.run(self.fn(**kwargs))
@@ -128,6 +134,16 @@ def namespace_to_callables(
 
     This is the bridge between toolregistry's ``ToolProjection`` and
     codecell's ``namespace: dict[str, Callable]`` parameter.
+
+    Note:
+        This function does **not** call :func:`validate_namespace`.
+        Callers should validate separately if key/name consistency
+        matters.
+
+    Note:
+        The implementation is intentionally trivial (``dict(namespace)``
+        would also work).  The function exists to carry the type
+        conversion semantics: ``ToolProjection`` → ``Callable``.
 
     Args:
         namespace: Mapping of tool name -> ToolProjection.

--- a/src/toolregistry/runtimes/_protocol.py
+++ b/src/toolregistry/runtimes/_protocol.py
@@ -1,61 +1,26 @@
-"""PTC (Programmatic Tool Calling) protocols and core types.
+"""PTC (Programmatic Tool Calling) bridge layer.
 
-This module defines the abstractions for executing LLM-generated code
-with tool access.  It has **zero imports from toolregistry internals**
-(same constraint as ``executor/``).
+This module provides the toolregistry-specific abstractions for PTC:
 
-Protocols
----------
-- :class:`ToolProjection` — how a tool appears inside a code runtime's
-  namespace (callable with name and docstring).
-- :class:`CodeRuntime` — executes code strings with tool access and
-  returns structured results.
+- :class:`ToolProjection` — how a ``Tool`` appears inside a code
+  runtime's namespace (callable with name and docstring).
+- :class:`DirectProjection` — in-process wrapper that converts a
+  ``Tool`` into a bare callable for codecell.
 
-Concrete implementations
-------------------------
-- :class:`DirectProjection` — in-process wrapper around a bare callable.
-  Used by ``InProcessRuntime`` (issue #176).
-- ``StubProjection`` — IPC stub for subprocess isolation (issue #177,
-  not yet implemented).
+Code execution itself is delegated to the ``codecell`` package, which
+provides ``SubprocessRuntime``, ``CodeResult``, and validators.
 
-Result types
-------------
-- :class:`CodeResult` — structured output from code execution.
+This module has **zero imports from toolregistry internals** (same
+constraint as ``executor/``).  The caller who has access to ``Tool``
+objects constructs ``DirectProjection`` instances.
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
-from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
 from collections.abc import Callable
-
-
-# ---------------------------------------------------------------------------
-# Result types
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class CodeResult:
-    """Structured result from code execution in a :class:`CodeRuntime`.
-
-    Attributes:
-        stdout: Captured standard output from the executed code.
-        stderr: Content the code wrote to standard error during execution.
-        return_code: ``0`` for success, ``1`` for exception.  In-process
-            runtimes use this convention since there is no real OS exit
-            code.
-        error: Exception traceback that terminated execution, or ``None``
-            if the code completed successfully.  Distinct from *stderr*,
-            which captures intentional writes to ``sys.stderr``.
-    """
-
-    stdout: str = ""
-    stderr: str = ""
-    return_code: int = 0
-    error: str | None = None
+from typing import Any, Protocol, runtime_checkable
 
 
 # ---------------------------------------------------------------------------
@@ -67,12 +32,12 @@ class CodeResult:
 class ToolProjection(Protocol):
     """How a tool appears inside a code runtime's namespace.
 
-    In-process runtimes use :class:`DirectProjection` (zero overhead).
-    Isolated runtimes (subprocess, container) will use IPC stubs that
-    satisfy the same interface.
+    ``ToolProjection`` bridges toolregistry's ``Tool`` model into a
+    shape that codecell can consume: a callable with a name and
+    docstring.
 
-    The ``__call__`` method is synchronous — runtimes that need async
-    dispatch handle the wrapping themselves.
+    The ``__call__`` method is synchronous — codecell runtimes handle
+    isolation (subprocess, etc.) themselves.
     """
 
     @property
@@ -82,7 +47,7 @@ class ToolProjection(Protocol):
 
     @property
     def doc(self) -> str | None:
-        """Docstring shown to the LLM-generated code (e.g. via ``help()``)."""
+        """Docstring shown to the LLM-generated code."""
         ...
 
     def __call__(self, **kwargs: Any) -> Any:
@@ -93,18 +58,14 @@ class ToolProjection(Protocol):
 class DirectProjection:
     """In-process :class:`ToolProjection` — wraps a callable with zero overhead.
 
-    Used by ``InProcessRuntime`` (issue #176).  Takes a bare callable
-    plus metadata — no dependency on ``Tool`` or any toolregistry type.
-    The caller who has access to a ``Tool`` object constructs this::
+    Takes a bare callable plus metadata — no dependency on ``Tool`` or
+    any toolregistry type.  The caller constructs this from a ``Tool``::
 
         proj = DirectProjection(
             name=tool.name,
             fn=tool.fn,
             doc=tool.description,
         )
-
-    For ``SubprocessRuntime`` (issue #177), a ``StubProjection`` will be
-    added that serializes calls over IPC behind the same interface.
 
     Attributes:
         fn: The underlying callable (sync or async).
@@ -134,16 +95,7 @@ class DirectProjection:
     def __call__(self, **kwargs: Any) -> Any:
         """Invoke the tool synchronously.
 
-        Async callables are run via ``asyncio.run()``.  This is
-        appropriate for in-process ``exec()`` contexts where the code
-        runs synchronously.
-
-        Note:
-            ``asyncio.run()`` cannot be called from within a running
-            event loop.  If the ``CodeRuntime.execute()`` implementation
-            itself runs inside an event loop, it must handle this — e.g.
-            by running ``exec()`` in a separate thread via
-            ``asyncio.to_thread()``.  See issue #176.
+        Async callables are run via ``asyncio.run()``.
         """
         if self._is_async:
             return asyncio.run(self.fn(**kwargs))
@@ -169,49 +121,19 @@ def validate_namespace(namespace: dict[str, ToolProjection]) -> None:
             )
 
 
-# ---------------------------------------------------------------------------
-# CodeRuntime protocol
-# ---------------------------------------------------------------------------
+def namespace_to_callables(
+    namespace: dict[str, ToolProjection],
+) -> dict[str, Callable[..., Any]]:
+    """Convert a ToolProjection namespace to a plain callable dict.
 
+    This is the bridge between toolregistry's ``ToolProjection`` and
+    codecell's ``namespace: dict[str, Callable]`` parameter.
 
-@runtime_checkable
-class CodeRuntime(Protocol):
-    """Executes LLM-generated code with tool access.
+    Args:
+        namespace: Mapping of tool name -> ToolProjection.
 
-    Different from ``ExecutionBackend``:
-
-    ============  =======================================
-    CodeRuntime   code string + tool namespace → result
-                  bidirectional, multi-call
-    ExecutionBackend  single callable + kwargs → result
-                  unidirectional, one-shot
-    ============  =======================================
-
-    CodeRuntime is a *consumer* of ExecutionBackend, not a replacement.
+    Returns:
+        Mapping of tool name -> callable (the ToolProjection itself,
+        since it implements ``__call__``).
     """
-
-    async def execute(
-        self,
-        code: str,
-        namespace: dict[str, ToolProjection],
-        *,
-        timeout: float | None = None,
-        extra_globals: dict[str, Any] | None = None,
-    ) -> CodeResult:
-        """Execute *code* with tools from *namespace*.
-
-        Args:
-            code: Python source code to execute.
-            namespace: Mapping of tool name → :class:`ToolProjection`.
-                These are injected into the execution namespace so the
-                code can call them directly.
-            timeout: Maximum wall-clock seconds.  ``None`` means no limit.
-            extra_globals: Additional objects (imports, constants, etc.)
-                to inject into the execution namespace alongside tools.
-                Tool entries win on name collision.
-
-        Returns:
-            A :class:`CodeResult` with captured stdout, stderr, and
-            error information.
-        """
-        ...
+    return {name: proj for name, proj in namespace.items()}

--- a/src/toolregistry/runtimes/_protocol.py
+++ b/src/toolregistry/runtimes/_protocol.py
@@ -135,15 +135,14 @@ def namespace_to_callables(
     This is the bridge between toolregistry's ``ToolProjection`` and
     codecell's ``namespace: dict[str, Callable]`` parameter.
 
-    Note:
-        This function does **not** call :func:`validate_namespace`.
-        Callers should validate separately if key/name consistency
-        matters.
+    Calls :func:`validate_namespace` first to ensure key/name
+    consistency before conversion.
 
     Note:
-        The implementation is intentionally trivial (``dict(namespace)``
-        would also work).  The function exists to carry the type
-        conversion semantics: ``ToolProjection`` → ``Callable``.
+        The conversion itself is intentionally trivial
+        (``dict(namespace)`` would also work).  The function exists
+        to carry the type conversion semantics and the validation
+        guarantee: ``ToolProjection`` → validated ``Callable``.
 
     Args:
         namespace: Mapping of tool name -> ToolProjection.
@@ -151,5 +150,9 @@ def namespace_to_callables(
     Returns:
         Mapping of tool name -> callable (the ToolProjection itself,
         since it implements ``__call__``).
+
+    Raises:
+        ValueError: If any key does not match its ToolProjection.name.
     """
+    validate_namespace(namespace)
     return {name: proj for name, proj in namespace.items()}

--- a/tests/test_runtimes_protocol.py
+++ b/tests/test_runtimes_protocol.py
@@ -114,3 +114,9 @@ class TestNamespaceToCallables:
 
     def test_empty(self):
         assert namespace_to_callables({}) == {}
+
+    def test_validates_before_converting(self):
+        """namespace_to_callables should reject mismatched keys."""
+        ns = {"wrong": DirectProjection(name="add", fn=lambda a, b: a + b)}
+        with pytest.raises(ValueError, match="wrong.*add"):
+            namespace_to_callables(ns)

--- a/tests/test_runtimes_protocol.py
+++ b/tests/test_runtimes_protocol.py
@@ -1,45 +1,13 @@
-"""Tests for the PTC protocols and DirectProjection (runtimes subpackage)."""
-
-import asyncio
+"""Tests for the PTC bridge layer (runtimes subpackage)."""
 
 import pytest
 
 from toolregistry.runtimes import (
-    CodeResult,
-    CodeRuntime,
     DirectProjection,
     ToolProjection,
+    namespace_to_callables,
     validate_namespace,
 )
-
-
-# ---------------------------------------------------------------------------
-# CodeResult
-# ---------------------------------------------------------------------------
-
-
-class TestCodeResult:
-    def test_defaults(self):
-        r = CodeResult()
-        assert r.stdout == ""
-        assert r.stderr == ""
-        assert r.return_code == 0
-        assert r.error is None
-
-    def test_success(self):
-        r = CodeResult(stdout="hello\n", return_code=0)
-        assert r.stdout == "hello\n"
-        assert r.return_code == 0
-
-    def test_failure(self):
-        r = CodeResult(stderr="warn", return_code=1, error="ZeroDivisionError")
-        assert r.return_code == 1
-        assert r.error == "ZeroDivisionError"
-
-    def test_frozen(self):
-        r = CodeResult()
-        with pytest.raises(AttributeError):
-            r.stdout = "mutate"  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -89,7 +57,6 @@ class TestDirectProjection:
         proj = DirectProjection(name="multiply", fn=multiply)
         assert proj.name == "multiply"
         assert proj.doc is None
-        # call_sync dispatches async via asyncio.run
         assert proj(a=3, b=5) == 15
 
     def test_fn_attribute(self):
@@ -103,49 +70,6 @@ class TestDirectProjection:
         proj = DirectProjection(name="t", fn=lambda: 42)
         assert proj.doc is None
         assert proj() == 42
-
-
-# ---------------------------------------------------------------------------
-# CodeRuntime protocol
-# ---------------------------------------------------------------------------
-
-
-class TestCodeRuntime:
-    def test_runtime_checkable(self):
-        class MockRuntime:
-            async def execute(
-                self,
-                code,
-                namespace,
-                *,
-                timeout=None,
-                extra_globals=None,
-            ):
-                return CodeResult(stdout="ok")
-
-        assert isinstance(MockRuntime(), CodeRuntime)
-
-    def test_mock_runtime_executes(self):
-        class MockRuntime:
-            async def execute(
-                self, code, namespace, *, timeout=None, extra_globals=None
-            ):
-                # Simulate executing code that calls a tool
-                tool = namespace.get("add")
-                if tool:
-                    result = tool(a=1, b=2)
-                    return CodeResult(stdout=str(result), return_code=0)
-                return CodeResult(return_code=1, error="no tool")
-
-        runtime = MockRuntime()
-        add_proj = DirectProjection(
-            name="add", fn=lambda a, b: a + b, doc="Add numbers"
-        )
-        ns = {"add": add_proj}
-
-        result = asyncio.run(runtime.execute("", ns))
-        assert result.stdout == "3"
-        assert result.return_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -170,3 +94,23 @@ class TestValidateNamespace:
         }
         with pytest.raises(ValueError, match="wrong_name.*add"):
             validate_namespace(ns)
+
+
+# ---------------------------------------------------------------------------
+# namespace_to_callables
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceToCallables:
+    def test_converts_projections(self):
+        add_proj = DirectProjection(name="add", fn=lambda a, b: a + b)
+        mul_proj = DirectProjection(name="mul", fn=lambda a, b: a * b)
+        ns = {"add": add_proj, "mul": mul_proj}
+
+        callables = namespace_to_callables(ns)
+        assert set(callables.keys()) == {"add", "mul"}
+        assert callables["add"](a=2, b=3) == 5
+        assert callables["mul"](a=2, b=3) == 6
+
+    def test_empty(self):
+        assert namespace_to_callables({}) == {}


### PR DESCRIPTION
## Summary

Delegate code execution to the standalone [`codecell`](https://github.com/Oaklight/codecell) package (v0.1.0, [on PyPI](https://pypi.org/project/codecell/)). The `runtimes/` subpackage now focuses on the toolregistry-specific bridge layer.

### Removed
- `CodeResult` — use `codecell.CodeResult` instead
- `CodeRuntime` protocol — use `codecell.BaseRuntime` / `codecell.SubprocessRuntime` instead

### Kept
- `ToolProjection` / `DirectProjection` — Tool → callable bridge (toolregistry-specific)
- `validate_namespace()`

### Added
- `namespace_to_callables()` — converts `dict[str, ToolProjection]` to `dict[str, Callable]` for codecell's namespace parameter
- `codecell>=0.1.0` as optional `[ptc]` dependency: `pip install toolregistry[ptc]`

### Why
`CodeResult` and `CodeRuntime` in runtimes/ were redundant with codecell's `CodeResult` and `BaseRuntime`. codecell is the standalone execution engine; toolregistry just bridges Tool objects into it.

Related: #176 (closed, superseded by codecell), #177 (updated scope to IPC-only)

## Test plan
- [x] 11 bridge layer tests pass (ToolProjection, DirectProjection, validate_namespace, namespace_to_callables)
- [x] Full suite: 946 passed, 0 failures
- [x] Pre-commit all pass
- [ ] CI passes