### PR TITLE
fix: make MCP/OpenAPI wrappers cloudpickle-safe

### DIFF
--- a/src/toolregistry/integrations/mcp/connection.py
+++ b/src/toolregistry/integrations/mcp/connection.py
@@ -110,6 +110,30 @@ class MCPConnectionManager:
         async with MCPClient(self._transport, self._headers) as client:
             return await client.call_tool(name, arguments)
 
+    # -- Pickling support (for ProcessPoolBackend) ------------------
+
+    def __getstate__(self) -> dict:
+        """Drop live connection state before pickling.
+
+        The config (transport, headers, persistent flag) is preserved.
+        The live ``_client`` (holding OS sockets) and ``_lock``
+        (event-loop-bound) are dropped.  The worker process will
+        reconnect lazily on first ``call_tool()``.
+        """
+        return {
+            "_transport": self._transport,
+            "_headers": self._headers,
+            "_persistent": self._persistent,
+        }
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore config; connection will be re-established lazily."""
+        self._transport = state["_transport"]
+        self._headers = state["_headers"]
+        self._persistent = state["_persistent"]
+        self._client = None
+        self._lock = asyncio.Lock()
+
     async def close(self) -> None:
         """Close the persistent connection."""
         async with self._lock:

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -215,6 +215,35 @@ class HttpClientConfig:
             self._sync_client.close()
             self._sync_client = None
 
+    # -- Pickling support (for ProcessPoolBackend) ------------------
+
+    def __getstate__(self) -> dict:
+        """Drop live HTTP clients before pickling.
+
+        The config (base_url, headers, timeout, auth, extra_options)
+        is preserved.  Live ``_sync_client`` / ``_async_client``
+        (holding thread locks and connection pools) are dropped.
+        The worker process will recreate them lazily via
+        ``get_persistent_client()``.
+        """
+        return {
+            "base_url": self.base_url,
+            "headers": self.headers,
+            "timeout": self.timeout,
+            "auth": self.auth,
+            "extra_options": self.extra_options,
+        }
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore config; clients will be created lazily on first use."""
+        self.base_url = state["base_url"]
+        self.headers = state["headers"]
+        self.timeout = state["timeout"]
+        self.auth = state["auth"]
+        self.extra_options = state["extra_options"]
+        self._sync_client = None
+        self._async_client = None
+
 
 def HttpxClientConfig(*args: Any, **kwargs: Any) -> HttpClientConfig:
     """Deprecated alias for HttpClientConfig.

--- a/tests/test_pickle_wrappers.py
+++ b/tests/test_pickle_wrappers.py
@@ -1,0 +1,88 @@
+"""Tests for cloudpickle serialization of tool wrappers (#189)."""
+
+import pickle
+
+import cloudpickle
+import pytest
+
+from toolregistry.utils import HttpClientConfig
+
+
+class TestHttpClientConfigPickle:
+    def test_pickle_fresh(self):
+        """Config with no active clients pickles cleanly."""
+        cfg = HttpClientConfig(
+            "http://api.example.com",
+            headers={"Authorization": "Bearer token"},
+            timeout=30.0,
+        )
+        data = cloudpickle.dumps(cfg)
+        cfg2 = pickle.loads(data)  # noqa: S301
+        assert cfg2.base_url == "http://api.example.com"
+        assert cfg2.headers == {"Authorization": "Bearer token"}
+        assert cfg2.timeout == 30.0
+        assert cfg2._sync_client is None
+        assert cfg2._async_client is None
+
+    def test_pickle_after_persistent_client(self):
+        """Config with active persistent client pickles by dropping client."""
+        cfg = HttpClientConfig("http://api.example.com")
+        cfg.get_persistent_client(use_async=False)
+        assert cfg._sync_client is not None
+
+        data = cloudpickle.dumps(cfg)
+        cfg2 = pickle.loads(data)  # noqa: S301
+        assert cfg2.base_url == "http://api.example.com"
+        assert cfg2._sync_client is None  # dropped
+
+        # Clean up
+        cfg.close()
+
+    def test_pickle_preserves_extra_options(self):
+        cfg = HttpClientConfig(
+            "http://api.example.com", verify=False, proxy="http://proxy"
+        )
+        data = cloudpickle.dumps(cfg)
+        cfg2 = pickle.loads(data)  # noqa: S301
+        assert cfg2.extra_options == {"verify": False, "proxy": "http://proxy"}
+
+    def test_pickle_preserves_auth(self):
+        cfg = HttpClientConfig("http://api.example.com", auth=("user", "pass"))
+        data = cloudpickle.dumps(cfg)
+        cfg2 = pickle.loads(data)  # noqa: S301
+        assert cfg2.auth == ("user", "pass")
+
+
+# MCPConnectionManager tests require the mcp package — guarded import
+try:
+    from toolregistry.integrations.mcp.connection import MCPConnectionManager
+
+    _HAS_MCP = True
+except ImportError:
+    _HAS_MCP = False
+
+
+@pytest.mark.skipif(not _HAS_MCP, reason="mcp package not installed")
+class TestMCPConnectionManagerPickle:
+    def test_pickle_fresh(self):
+        """Fresh manager (no connection) pickles cleanly."""
+        mgr = MCPConnectionManager(
+            "http://localhost:8000/mcp",
+            headers={"X-Key": "val"},
+            persistent=True,
+        )
+        data = cloudpickle.dumps(mgr)
+        mgr2 = pickle.loads(data)  # noqa: S301
+        assert mgr2._transport == "http://localhost:8000/mcp"
+        assert mgr2._headers == {"X-Key": "val"}
+        assert mgr2._persistent is True
+        assert mgr2._client is None
+
+    def test_pickle_preserves_transport_dict(self):
+        """Dict transport config survives pickling."""
+        transport = {"command": "python", "args": ["-m", "my_server"]}
+        mgr = MCPConnectionManager(transport, persistent=False)
+        data = cloudpickle.dumps(mgr)
+        mgr2 = pickle.loads(data)  # noqa: S301
+        assert mgr2._transport == transport
+        assert mgr2._persistent is False


### PR DESCRIPTION
## Summary

Add `__getstate__`/`__setstate__` to `MCPConnectionManager` and `HttpClientConfig` so they survive cloudpickle serialization across `ProcessPoolBackend` workers.

Based on Elena's research in #189.

### Problem

Active MCP/OpenAPI tool wrappers hold OS sockets and thread locks that can't be pickled:
- `MCPConnectionManager._client` → socket FDs → `TypeError: cannot pickle 'socket'`
- `HttpClientConfig._sync_client` → `_thread.RLock` → `TypeError: cannot pickle '_thread.RLock'`

### Fix

`__getstate__` drops live connections, `__setstate__` restores config only. Worker process reconnects lazily on first use.

| Class | Dropped | Preserved |
|-------|---------|-----------|
| `MCPConnectionManager` | `_client`, `_lock` | `_transport`, `_headers`, `_persistent` |
| `HttpClientConfig` | `_sync_client`, `_async_client` | `base_url`, `headers`, `timeout`, `auth`, `extra_options` |

Ref #189 (issue kept open for long-term IPC approach)

## Test plan

- [x] 6 new tests: pickle round-trip for both classes, fresh and after-use
- [x] Full suite: 976 passed
- [ ] CI passes