### PR TITLE
feat: add registry.invoke() — unified single-tool execution

### DIFF
--- a/src/toolregistry/runtimes/_code_execution.py
+++ b/src/toolregistry/runtimes/_code_execution.py
@@ -203,15 +203,26 @@ class CodeExecutionTool:
         recursive invocation.
         """
         projections: dict[str, ToolProjection] = {}
-        for name in self._registry.list_tools():
+        registry = self._registry
+        for name in registry.list_tools():
             if name == CODE_EXECUTION_NAME:
                 continue
-            tool = self._registry.get_tool(name)
+            tool = registry.get_tool(name)
             if tool is None:
                 continue
-            projections[tool.name] = DirectProjection(
-                name=tool.name,
-                fn=tool.fn,
+            # Use registry.invoke() so tool calls go through the full
+            # pipeline (permissions, logging) instead of bypassing it.
+            tool_name = tool.name
+
+            def _make_invoke_fn(tn: str) -> Callable[..., Any]:
+                def fn(**kwargs: Any) -> Any:
+                    return registry.invoke(tn, kwargs)
+
+                return fn
+
+            projections[tool_name] = DirectProjection(
+                name=tool_name,
+                fn=_make_invoke_fn(tool_name),
                 doc=tool.description,
             )
 

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -369,6 +369,84 @@ class ToolRegistry(
         self._code_execution = None
 
     # ============== Execution ==============
+    def invoke(self, tool_name: str, kwargs: dict[str, Any]) -> Any:
+        """Execute a single tool with full pipeline (permissions, logging).
+
+        This is the canonical single-tool execution entry point.  It is
+        used by :class:`CodeExecutionTool` for IPC callbacks and can be
+        called directly for programmatic tool invocation.
+
+        Pipeline:
+            1. Check tool exists and is enabled
+            2. Permission check (``_resolve_permission``)
+            3. Execute via ``tool.run()``
+            4. Log execution result
+
+        Args:
+            tool_name: Name of the registered tool.
+            kwargs: Keyword arguments to pass to the tool.
+
+        Returns:
+            The tool's return value.
+
+        Raises:
+            KeyError: If the tool is not registered.
+            PermissionError: If the tool is denied by permission policy.
+            RuntimeError: If the tool is disabled.
+            Exception: Any exception raised by the tool itself.
+        """
+        from .admin import ExecutionStatus
+
+        tool_obj = self.get_tool(tool_name)
+        if tool_obj is None:
+            raise KeyError(f"Tool '{tool_name}' is not registered")
+
+        if not self.is_enabled(tool_name):
+            reason = self.get_disable_reason(tool_name) or "Tool is disabled"
+            self._log_entry(
+                tool_name,
+                ExecutionStatus.DISABLED,
+                0.0,
+                kwargs,
+                error=reason,
+            )
+            raise RuntimeError(f"Tool '{tool_name}' is disabled: {reason}")
+
+        decision = self._resolve_permission(tool_obj, kwargs)
+        if decision == PermissionResult.DENY:
+            self._log_entry(
+                tool_name,
+                ExecutionStatus.ERROR,
+                0.0,
+                kwargs,
+                error="Denied by permission policy",
+            )
+            raise PermissionError(f"Tool '{tool_name}' denied by permission policy")
+
+        start = time.perf_counter()
+        try:
+            result = tool_obj.run(kwargs)
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._log_entry(
+                tool_name,
+                ExecutionStatus.SUCCESS,
+                duration_ms,
+                kwargs,
+                result=str(result),
+            )
+            return result
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._log_entry(
+                tool_name,
+                ExecutionStatus.ERROR,
+                duration_ms,
+                kwargs,
+                error=str(exc),
+                exception_type=type(exc).__qualname__,
+            )
+            raise
+
     def _finalize_result(self, result: Any, tool_name: str) -> str | list:
         """Convert a raw tool result to a string or content block list.
 

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -1,0 +1,131 @@
+"""Tests for ToolRegistry.invoke() — single-tool execution with full pipeline."""
+
+import pytest
+
+from toolregistry import Tool, ToolRegistry
+from toolregistry.permissions import PermissionPolicy, PermissionResult, PermissionRule
+from toolregistry.tool import ToolMetadata, ToolTag
+
+
+class TestInvoke:
+    def test_basic_invoke(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        reg.register(add)
+        result = reg.invoke("add", {"a": 3, "b": 4})
+        assert result == 7
+
+    def test_invoke_nonexistent_raises(self):
+        reg = ToolRegistry()
+        with pytest.raises(KeyError, match="not registered"):
+            reg.invoke("nonexistent", {})
+
+    def test_invoke_disabled_raises(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        reg.disable("add", reason="maintenance")
+        with pytest.raises(RuntimeError, match="disabled"):
+            reg.invoke("add", {"a": 1, "b": 2})
+
+    def test_invoke_denied_by_permission(self):
+        reg = ToolRegistry()
+
+        def dangerous_tool(cmd: str) -> str:
+            """Execute a command."""
+            return cmd
+
+        tool = Tool.from_function(
+            dangerous_tool,
+            metadata=ToolMetadata(tags={ToolTag.DESTRUCTIVE}),
+        )
+        reg.register(tool)
+
+        deny_destructive = PermissionRule(
+            name="deny_destructive",
+            match=lambda t, p: ToolTag.DESTRUCTIVE in t.metadata.tags,
+            result=PermissionResult.DENY,
+            reason="Destructive tools blocked",
+        )
+        reg.set_permission_policy(PermissionPolicy(rules=[deny_destructive]))
+
+        with pytest.raises(PermissionError, match="denied"):
+            reg.invoke("dangerous_tool", {"cmd": "rm -rf /"})
+
+    def test_invoke_propagates_tool_error(self):
+        reg = ToolRegistry()
+
+        def failing(x: int) -> int:
+            raise ValueError("broken")
+
+        reg.register(failing)
+        with pytest.raises(ValueError, match="broken"):
+            reg.invoke("failing", {"x": 1})
+
+    def test_invoke_logs_success(self):
+        reg = ToolRegistry()
+        reg.enable_logging()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        reg.invoke("add", {"a": 1, "b": 2})
+
+        log = reg.get_execution_log()
+        entries = log.get_entries()
+        assert len(entries) == 1
+        assert entries[0].tool_name == "add"
+        assert entries[0].status.value == "success"
+
+    def test_invoke_logs_error(self):
+        reg = ToolRegistry()
+        reg.enable_logging()
+
+        def failing(x: int) -> int:
+            raise ValueError("broken")
+
+        reg.register(failing)
+        with pytest.raises(ValueError):
+            reg.invoke("failing", {"x": 1})
+
+        log = reg.get_execution_log()
+        entries = log.get_entries()
+        assert len(entries) == 1
+        assert entries[0].status.value == "error"
+        assert "broken" in entries[0].error
+
+
+class TestInvokeWithCodeExecution:
+    """Test that CodeExecutionTool uses invoke() for tool calls."""
+
+    @pytest.fixture
+    def registry(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        reg.register(add)
+        reg.enable_logging()
+        return reg
+
+    def test_ptc_tool_call_logged(self, registry):
+        """Tool calls via PTC code should appear in execution log."""
+        registry.enable_code_execution()
+        tool = registry.get_tool("code_execution")
+        tool.run({"code": "print(add(a=10, b=20))"})
+
+        log = registry.get_execution_log()
+        entries = log.get_entries()
+        add_entries = [e for e in entries if e.tool_name == "add"]
+        assert len(add_entries) >= 1
+        assert add_entries[0].status.value == "success"


### PR DESCRIPTION
## Summary

Add `ToolRegistry.invoke(tool_name, kwargs)` — the canonical single-tool execution entry point with full pipeline (permissions, logging). Wire `CodeExecutionTool` through it to fix the IPC permission bypass.

### Problem

PTC tool calls via IPC went through `DirectProjection(fn=tool.fn)` → direct function call, bypassing:
- Permission checks (`_resolve_permission`)
- Execution logging (`_log_entry`)

An LLM could call destructive tools via PTC code even when permission policy would deny them.

### Fix

```
Before:  PTC code → IPC → DirectProjection → tool.fn()  ← no permissions
After:   PTC code → IPC → DirectProjection → registry.invoke() → permissions → execute → log
```

`invoke()` is also useful standalone for programmatic tool execution.

### API

```python
# Single-tool execution with full pipeline
result = registry.invoke("add", {"a": 1, "b": 2})

# Raises:
# - KeyError if tool not registered
# - RuntimeError if tool disabled
# - PermissionError if denied by policy
# - Exception from tool itself
```

Closes #194

## Test plan

- [x] 8 new tests: basic invoke, not found, disabled, permission denied, error propagation, logging (success + error), PTC integration
- [x] Full suite passes
- [ ] CI passes