### PR TITLE
feat: unified invocation_id for tool call tracing

### DIFF
--- a/src/toolregistry/admin/execution_log.py
+++ b/src/toolregistry/admin/execution_log.py
@@ -53,6 +53,7 @@ class ExecutionLogEntry:
     error: str | None = None
     exception_type: str | None = None
     traceback: str | None = None
+    invocation_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -66,6 +67,7 @@ class ExecutionLogEntry:
         error: str | None = None,
         exception_type: str | None = None,
         traceback: str | None = None,
+        invocation_id: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> "ExecutionLogEntry":
         """Create a new ExecutionLogEntry with auto-generated id and timestamp.
@@ -79,6 +81,9 @@ class ExecutionLogEntry:
             error: Error message (for failed executions).
             exception_type: Qualified name of the exception class.
             traceback: Formatted traceback string.
+            invocation_id: Groups related tool calls. Prefixes:
+                ``tr_bat_`` (batch), ``tr_ptc_`` (PTC),
+                ``tr_sig_`` (single invoke).
             metadata: Additional metadata.
 
         Returns:
@@ -95,6 +100,7 @@ class ExecutionLogEntry:
             error=error,
             exception_type=exception_type,
             traceback=traceback,
+            invocation_id=invocation_id,
             metadata=metadata or {},
         )
 
@@ -165,6 +171,7 @@ class ExecutionLog:
         tool_name: str | None = None,
         status: ExecutionStatus | None = None,
         since: datetime | None = None,
+        invocation_id: str | None = None,
     ) -> list[ExecutionLogEntry]:
         """Query log entries with optional filters.
 
@@ -176,6 +183,9 @@ class ExecutionLog:
             tool_name: Filter by tool name. If None, matches all tools.
             status: Filter by execution status. If None, matches all statuses.
             since: Filter entries after this timestamp. If None, no time filter.
+            invocation_id: Filter by invocation ID. Use this to retrieve
+                all tool calls from a single batch (``tr_bat_``), PTC
+                execution (``tr_ptc_``), or standalone invoke (``tr_sig_``).
 
         Returns:
             List of matching ExecutionLogEntry objects, newest first.
@@ -192,6 +202,8 @@ class ExecutionLog:
             filtered = [e for e in filtered if e.status == status]
         if since is not None:
             filtered = [e for e in filtered if e.timestamp >= since]
+        if invocation_id is not None:
+            filtered = [e for e in filtered if e.invocation_id == invocation_id]
 
         # Sort by timestamp descending (newest first)
         filtered.sort(key=lambda e: e.timestamp, reverse=True)

--- a/src/toolregistry/runtimes/_code_execution.py
+++ b/src/toolregistry/runtimes/_code_execution.py
@@ -9,13 +9,9 @@ Tool calls from the code are forwarded back to the main process via
 bidirectional JSON-over-pipe IPC — tools retain full access to
 connections, env vars, and process-local state.
 
-PTC reduces latency and token consumption for multi-tool workflows:
-instead of N round-trips (one per tool call), the LLM writes one code
-block that calls N tools and only the final output is returned.
-
-Intermediate tool call results are recorded in a trace log for
-debugging and error pinpointing, but are **not** included in the
-output returned to the LLM.
+All tool calls are logged in the registry's execution log with a
+shared ``invocation_id`` (prefix ``tr_ptc_``) so the complete call
+chain for a single PTC execution can be queried.
 
 Example::
 
@@ -25,20 +21,22 @@ Example::
     registry.register(search)
     registry.register(summarize)
     registry.enable_code_execution()
+    registry.enable_logging()
 
-    # LLM can now generate:
+    # LLM generates:
     # tool_use("code_execution", {
     #     "code": "data = search(query='weather')\\nprint(summarize(data))"
     # })
+
+    # Query all tool calls from the last PTC execution:
+    # log.get_entries(invocation_id=executor.last_invocation_id)
 
 Requires the ``[ptc]`` optional dependency: ``pip install toolregistry[ptc]``
 """
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -58,112 +56,26 @@ CODE_EXECUTION_DESCRIPTION = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Tool call trace
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ToolCallRecord:
-    """Record of a single tool invocation during code execution.
-
-    Attributes:
-        tool_name: Name of the tool that was called.
-        kwargs: Keyword arguments passed to the tool.
-        result: Return value from the tool.
-        error: Exception message if the call failed, or ``None``.
-        duration_ms: Wall-clock time in milliseconds.
-    """
-
-    tool_name: str
-    kwargs: dict[str, Any]
-    result: Any = None
-    error: str | None = None
-    duration_ms: float = 0.0
-
-
-@dataclass
-class ExecutionTrace:
-    """Trace of all tool calls made during a single code execution.
-
-    Attributes:
-        tool_calls: Ordered list of tool call records.
-        code: The source code that was executed.
-    """
-
-    code: str = ""
-    tool_calls: list[ToolCallRecord] = field(default_factory=list)
-
-
-def _make_traced_callable(
-    proj: ToolProjection,
-    trace: ExecutionTrace,
-) -> Callable[..., Any]:
-    """Wrap a ToolProjection with call tracing.
-
-    The wrapper records every call (args, result, duration, errors)
-    into the trace, then returns the result normally.  The LLM code
-    sees no difference — it calls tools as usual.
-    """
-
-    def wrapper(**kwargs: Any) -> Any:
-        t0 = time.perf_counter()
-        try:
-            result = proj(**kwargs)
-            trace.tool_calls.append(
-                ToolCallRecord(
-                    tool_name=proj.name,
-                    kwargs=dict(kwargs),
-                    result=result,
-                    duration_ms=(time.perf_counter() - t0) * 1000,
-                )
-            )
-            return result
-        except Exception as exc:
-            trace.tool_calls.append(
-                ToolCallRecord(
-                    tool_name=proj.name,
-                    kwargs=dict(kwargs),
-                    error=str(exc),
-                    duration_ms=(time.perf_counter() - t0) * 1000,
-                )
-            )
-            raise
-
-    # Preserve name and doc for help() discoverability
-    wrapper.__name__ = proj.name
-    wrapper.__doc__ = proj.doc
-    return wrapper
-
-
-# ---------------------------------------------------------------------------
-# CodeExecutionTool
-# ---------------------------------------------------------------------------
-
-
 class CodeExecutionTool:
     """Built-in PTC meta-tool: execute Python code with tool access.
 
     Executes LLM-generated Python code in an **isolated subprocess**
     via ``codecell.IpcSubprocessRuntime``.  Registered tools are
     callable from the code via bidirectional IPC — tool execution
-    always happens in the main process.
+    always happens in the main process via ``registry.invoke()``.
 
-    Intermediate tool call results are recorded in
-    :attr:`last_trace` for debugging but are **not** returned to the
-    LLM — only ``print()`` output is returned.
-
-    The tool is registered as ``code_execution`` in the registry,
-    similar to how ``ToolDiscoveryTool`` registers ``discover_tools``.
+    Tool calls are logged in the registry's execution log with a
+    shared ``invocation_id`` (prefix ``tr_ptc_``).  Use
+    :attr:`last_invocation_id` to query all calls from the last
+    execution.
 
     Safety model:
         - **Subprocess isolation** — crashes, OOM, infinite loops
           in code cannot affect the main process
         - **AST validation** blocks dangerous constructs before execution
-        - **IPC tool calling** — tools run in main process with full
-          access; code runs in subprocess with no direct access
+        - **IPC tool calling** — tools run in main process via
+          ``registry.invoke()`` with full permissions and logging
         - **No cloudpickle** — tools never cross the process boundary
-        - **Trace logging** records all tool calls for debugging
 
     Args:
         registry: The tool registry to pull enabled tools from.
@@ -177,7 +89,7 @@ class CodeExecutionTool:
     ) -> None:
         self._registry = registry
         self._timeout = timeout
-        self.last_trace: ExecutionTrace | None = None
+        self.last_invocation_id: str | None = None
 
         try:
             from codecell import IpcSubprocessRuntime
@@ -192,12 +104,13 @@ class CodeExecutionTool:
 
     def _build_namespace(
         self,
-        trace: ExecutionTrace,
+        invocation_id: str,
     ) -> dict[str, Callable[..., Any]]:
-        """Build a traced callable namespace from enabled registry tools.
+        """Build a callable namespace from enabled registry tools.
 
-        Each tool is wrapped with :func:`_make_traced_callable` so
-        that every invocation is recorded in *trace*.
+        Each tool call goes through ``registry.invoke()`` with the
+        shared *invocation_id*, ensuring permissions are checked and
+        the call is logged.
 
         The ``code_execution`` tool itself is excluded to prevent
         recursive invocation.
@@ -210,13 +123,12 @@ class CodeExecutionTool:
             tool = registry.get_tool(name)
             if tool is None:
                 continue
-            # Use registry.invoke() so tool calls go through the full
-            # pipeline (permissions, logging) instead of bypassing it.
+
             tool_name = tool.name
 
             def _make_invoke_fn(tn: str) -> Callable[..., Any]:
                 def fn(**kwargs: Any) -> Any:
-                    return registry.invoke(tn, kwargs)
+                    return registry.invoke(tn, kwargs, invocation_id=invocation_id)
 
                 return fn
 
@@ -227,25 +139,18 @@ class CodeExecutionTool:
             )
 
         validate_namespace(projections)
-
-        return {
-            name: _make_traced_callable(proj, trace)
-            for name, proj in projections.items()
-        }
+        return {name: proj for name, proj in projections.items()}
 
     def execute(self, code: str, timeout: float | None = None) -> str:
         """Execute Python code in a subprocess with tool access via IPC.
 
         Tools registered in the registry are available as callable
         functions — the LLM can call them directly in the code.
-        Tool execution happens in the main process via IPC; only the
-        code runs in the subprocess.
+        Tool execution happens in the main process via
+        ``registry.invoke()`` with permissions and logging.
 
         Use ``print()`` to produce output; only stdout is captured
         and returned.
-
-        Intermediate tool call results are recorded in
-        :attr:`last_trace` for debugging and error pinpointing.
 
         Args:
             code: Python source code to execute.
@@ -260,19 +165,19 @@ class CodeExecutionTool:
             ValueError: If AST validation rejects the code.
             SyntaxError: If the code cannot be parsed.
         """
-        trace = ExecutionTrace(code=code)
-        ns = self._build_namespace(trace)
+        from ..utils import generate_invocation_id
 
+        inv_id = generate_invocation_id("ptc")
+        self.last_invocation_id = inv_id
+
+        ns = self._build_namespace(inv_id)
         effective_timeout = timeout if timeout is not None else self._timeout
 
-        try:
-            result = self._runtime.execute(
-                code,
-                namespace=ns,
-                timeout=effective_timeout,
-            )
-        finally:
-            self.last_trace = trace
+        result = self._runtime.execute(
+            code,
+            namespace=ns,
+            timeout=effective_timeout,
+        )
 
         if result.timed_out:
             return "Error: execution timed out"

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -582,11 +582,13 @@ class ToolRegistry(
     def _classify_tool_calls(
         self,
         generic_tool_calls: list[Any],
+        invocation_id: str | None = None,
     ) -> tuple[list[Any], dict[str, str | list], dict[str, float], dict[str, dict]]:
         """Separate tool calls into enabled vs disabled/denied, logging rejections.
 
         Args:
             generic_tool_calls: Normalized tool call list.
+            invocation_id: Invocation ID to attach to log entries.
 
         Returns:
             Tuple of (enabled_calls, tool_responses, call_start_times, call_arguments).
@@ -610,6 +612,7 @@ class ToolRegistry(
                     0.0,
                     {},
                     error=f"Tool is disabled. Reason: {reason}",
+                    invocation_id=invocation_id,
                 )
                 continue
 
@@ -635,6 +638,7 @@ class ToolRegistry(
                     0.0,
                     args,
                     error="Denied by permission policy",
+                    invocation_id=invocation_id,
                 )
             else:
                 enabled_calls.append(tc)
@@ -795,10 +799,13 @@ class ToolRegistry(
             multimodal results (e.g. images).
         """
         from .executor import ExecutionHandle
+        from .utils import generate_invocation_id
+
+        batch_inv_id = generate_invocation_id("bat")
 
         generic_tool_calls = convert_tool_calls(tool_calls)
         enabled_calls, tool_responses, call_start_times, call_arguments = (
-            self._classify_tool_calls(generic_tool_calls)
+            self._classify_tool_calls(generic_tool_calls, batch_inv_id)
         )
 
         if not enabled_calls:
@@ -842,7 +849,7 @@ class ToolRegistry(
 
         # Log executed tool calls and emit error events
         self._log_tool_call_results(
-            enabled_calls, raw_results, call_start_times, call_arguments
+            enabled_calls, raw_results, call_start_times, call_arguments, batch_inv_id
         )
 
         return tool_responses
@@ -853,6 +860,7 @@ class ToolRegistry(
         raw_results: dict[str, Any],
         call_start_times: dict[str, float],
         call_arguments: dict[str, dict],
+        invocation_id: str | None = None,
     ) -> None:
         """Log execution results and emit error events for completed tool calls.
 
@@ -861,6 +869,7 @@ class ToolRegistry(
             raw_results: Map of call ID to raw result (_ToolError or success value).
             call_start_times: Map of call ID to start timestamp.
             call_arguments: Map of call ID to parsed arguments.
+            invocation_id: Invocation ID to attach to log entries.
         """
         from .admin import ExecutionStatus
 
@@ -882,6 +891,7 @@ class ToolRegistry(
                     error=raw.message,
                     exception_type=raw.exception_type,
                     traceback=raw.traceback_str,
+                    invocation_id=invocation_id,
                 )
                 self._emit_change(
                     ChangeEvent(
@@ -901,6 +911,7 @@ class ToolRegistry(
                     duration_ms,
                     call_arguments.get(tc.id, {}),
                     result=str(raw) if raw is not None else None,
+                    invocation_id=invocation_id,
                 )
 
     def build_tool_call_messages(

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -369,7 +369,13 @@ class ToolRegistry(
         self._code_execution = None
 
     # ============== Execution ==============
-    def invoke(self, tool_name: str, kwargs: dict[str, Any]) -> Any:
+    def invoke(
+        self,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        *,
+        invocation_id: str | None = None,
+    ) -> Any:
         """Execute a single tool with full pipeline (permissions, logging).
 
         This is the canonical single-tool execution entry point.  It is
@@ -380,11 +386,15 @@ class ToolRegistry(
             1. Check tool exists and is enabled
             2. Permission check (``_resolve_permission``)
             3. Execute via ``tool.run()``
-            4. Log execution result
+            4. Log execution result with ``invocation_id``
 
         Args:
             tool_name: Name of the registered tool.
             kwargs: Keyword arguments to pass to the tool.
+            invocation_id: Optional ID to group related calls.  If
+                ``None``, a ``tr_sig_`` ID is auto-generated.  PTC
+                and batch callers pass their own ``tr_ptc_`` / ``tr_bat_``
+                IDs to correlate all calls in a single execution.
 
         Returns:
             The tool's return value.
@@ -396,6 +406,10 @@ class ToolRegistry(
             Exception: Any exception raised by the tool itself.
         """
         from .admin import ExecutionStatus
+        from .utils import generate_invocation_id
+
+        if invocation_id is None:
+            invocation_id = generate_invocation_id("sig")
 
         tool_obj = self.get_tool(tool_name)
         if tool_obj is None:
@@ -409,6 +423,7 @@ class ToolRegistry(
                 0.0,
                 kwargs,
                 error=reason,
+                invocation_id=invocation_id,
             )
             raise RuntimeError(f"Tool '{tool_name}' is disabled: {reason}")
 
@@ -420,6 +435,7 @@ class ToolRegistry(
                 0.0,
                 kwargs,
                 error="Denied by permission policy",
+                invocation_id=invocation_id,
             )
             raise PermissionError(f"Tool '{tool_name}' denied by permission policy")
 
@@ -433,6 +449,7 @@ class ToolRegistry(
                 duration_ms,
                 kwargs,
                 result=str(result),
+                invocation_id=invocation_id,
             )
             return result
         except Exception as exc:
@@ -444,6 +461,7 @@ class ToolRegistry(
                 kwargs,
                 error=str(exc),
                 exception_type=type(exc).__qualname__,
+                invocation_id=invocation_id,
             )
             raise
 
@@ -636,6 +654,7 @@ class ToolRegistry(
         error: str | None = None,
         exception_type: str | None = None,
         traceback: str | None = None,
+        invocation_id: str | None = None,
     ) -> None:
         """Append an entry to the execution log if logging is enabled.
 
@@ -648,6 +667,7 @@ class ToolRegistry(
             error: Optional error string.
             exception_type: Optional qualified exception class name.
             traceback: Optional formatted traceback string.
+            invocation_id: Optional invocation ID grouping related calls.
         """
         if self._execution_log is None:
             return
@@ -662,6 +682,7 @@ class ToolRegistry(
             error=error,
             exception_type=exception_type,
             traceback=traceback,
+            invocation_id=invocation_id,
         )
         self._execution_log.add(entry)
 

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -1,8 +1,26 @@
 import re
+import uuid
 import warnings
 from typing import Any, Literal, overload
 
 from ._vendor.httpclient import AsyncClient, Client
+
+
+def generate_invocation_id(prefix: Literal["bat", "ptc", "sig"] = "sig") -> str:
+    """Generate a unique invocation ID for grouping related tool calls.
+
+    Prefixes:
+        - ``tr_bat_`` — batch execution via ``execute_tool_calls()``
+        - ``tr_ptc_`` — PTC code execution via ``CodeExecutionTool``
+        - ``tr_sig_`` — single invocation via ``registry.invoke()``
+
+    Args:
+        prefix: One of ``"bat"``, ``"ptc"``, ``"sig"``.
+
+    Returns:
+        A unique ID like ``"tr_bat_a1b2c3d4"``.
+    """
+    return f"tr_{prefix}_{uuid.uuid4().hex[:8]}"
 
 
 class _BaseUrlClient:

--- a/tests/test_code_execution.py
+++ b/tests/test_code_execution.py
@@ -94,56 +94,6 @@ class TestCodeExecutionTool:
             executor.execute("def")
 
 
-class TestExecutionTrace:
-    def test_trace_records_tool_calls(self, registry):
-        executor = CodeExecutionTool(registry)
-        executor.execute("x = add(a=1, b=2)\ny = multiply(a=x, b=3)\nprint(y)")
-        trace = executor.last_trace
-        assert trace is not None
-        assert len(trace.tool_calls) == 2
-        assert trace.tool_calls[0].tool_name == "add"
-        assert trace.tool_calls[0].kwargs == {"a": 1, "b": 2}
-        assert trace.tool_calls[0].result == 3
-        assert trace.tool_calls[0].error is None
-        assert trace.tool_calls[1].tool_name == "multiply"
-        assert trace.tool_calls[1].result == 9
-
-    def test_trace_records_errors(self, registry):
-        def failing_tool(x: int) -> int:
-            """Always fails."""
-            raise ValueError("broken")
-
-        registry.register(failing_tool)
-        executor = CodeExecutionTool(registry)
-        executor.execute(
-            "try:\n    failing_tool(x=1)\nexcept ValueError:\n    print('caught')"
-        )
-        trace = executor.last_trace
-        assert len(trace.tool_calls) == 1
-        assert trace.tool_calls[0].error == "broken"
-
-    def test_trace_has_duration(self, registry):
-        executor = CodeExecutionTool(registry)
-        executor.execute("add(a=1, b=2)")
-        assert executor.last_trace.tool_calls[0].duration_ms >= 0
-
-    def test_trace_stores_code(self, registry):
-        code = "print(add(a=5, b=5))"
-        executor = CodeExecutionTool(registry)
-        executor.execute(code)
-        assert executor.last_trace.code == code
-
-    def test_no_trace_before_execution(self, registry):
-        executor = CodeExecutionTool(registry)
-        assert executor.last_trace is None
-
-    def test_trace_empty_when_no_tools_called(self, registry):
-        executor = CodeExecutionTool(registry)
-        executor.execute("print(42)")
-        assert executor.last_trace is not None
-        assert len(executor.last_trace.tool_calls) == 0
-
-
 class TestRegistryIntegration:
     def test_enable_code_execution(self, registry):
         executor = registry.enable_code_execution()

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -1,4 +1,4 @@
-"""Tests for ToolRegistry.invoke() — single-tool execution with full pipeline."""
+"""Tests for ToolRegistry.invoke() and invocation_id tracking."""
 
 import pytest
 
@@ -69,7 +69,9 @@ class TestInvoke:
         with pytest.raises(ValueError, match="broken"):
             reg.invoke("failing", {"x": 1})
 
-    def test_invoke_logs_success(self):
+
+class TestInvocationId:
+    def test_auto_generates_sig_id(self):
         reg = ToolRegistry()
         reg.enable_logging()
 
@@ -79,13 +81,48 @@ class TestInvoke:
         reg.register(add)
         reg.invoke("add", {"a": 1, "b": 2})
 
-        log = reg.get_execution_log()
-        entries = log.get_entries()
+        entries = reg.get_execution_log().get_entries()
         assert len(entries) == 1
-        assert entries[0].tool_name == "add"
-        assert entries[0].status.value == "success"
+        assert entries[0].invocation_id.startswith("tr_sig_")
 
-    def test_invoke_logs_error(self):
+    def test_custom_invocation_id(self):
+        reg = ToolRegistry()
+        reg.enable_logging()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        reg.invoke("add", {"a": 1, "b": 2}, invocation_id="tr_ptc_test123")
+
+        entries = reg.get_execution_log().get_entries()
+        assert entries[0].invocation_id == "tr_ptc_test123"
+
+    def test_filter_by_invocation_id(self):
+        reg = ToolRegistry()
+        reg.enable_logging()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        def mul(a: int, b: int) -> int:
+            return a * b
+
+        reg.register(add)
+        reg.register(mul)
+
+        reg.invoke("add", {"a": 1, "b": 2}, invocation_id="tr_ptc_aaa")
+        reg.invoke("mul", {"a": 3, "b": 4}, invocation_id="tr_ptc_aaa")
+        reg.invoke("add", {"a": 5, "b": 6}, invocation_id="tr_sig_bbb")
+
+        log = reg.get_execution_log()
+        ptc_entries = log.get_entries(invocation_id="tr_ptc_aaa")
+        assert len(ptc_entries) == 2
+
+        sig_entries = log.get_entries(invocation_id="tr_sig_bbb")
+        assert len(sig_entries) == 1
+
+    def test_error_logged_with_invocation_id(self):
         reg = ToolRegistry()
         reg.enable_logging()
 
@@ -94,17 +131,15 @@ class TestInvoke:
 
         reg.register(failing)
         with pytest.raises(ValueError):
-            reg.invoke("failing", {"x": 1})
+            reg.invoke("failing", {"x": 1}, invocation_id="tr_sig_err1")
 
-        log = reg.get_execution_log()
-        entries = log.get_entries()
+        entries = reg.get_execution_log().get_entries(invocation_id="tr_sig_err1")
         assert len(entries) == 1
         assert entries[0].status.value == "error"
-        assert "broken" in entries[0].error
 
 
-class TestInvokeWithCodeExecution:
-    """Test that CodeExecutionTool uses invoke() for tool calls."""
+class TestPtcInvocationId:
+    """Test that CodeExecutionTool generates tr_ptc_ IDs."""
 
     @pytest.fixture
     def registry(self):
@@ -118,14 +153,39 @@ class TestInvokeWithCodeExecution:
         reg.enable_logging()
         return reg
 
-    def test_ptc_tool_call_logged(self, registry):
-        """Tool calls via PTC code should appear in execution log."""
+    def test_ptc_generates_invocation_id(self, registry):
         registry.enable_code_execution()
-        tool = registry.get_tool("code_execution")
-        tool.run({"code": "print(add(a=10, b=20))"})
+        executor = registry._code_execution
+        executor.execute("print(add(a=1, b=2))")
 
-        log = registry.get_execution_log()
-        entries = log.get_entries()
-        add_entries = [e for e in entries if e.tool_name == "add"]
-        assert len(add_entries) >= 1
-        assert add_entries[0].status.value == "success"
+        assert executor.last_invocation_id is not None
+        assert executor.last_invocation_id.startswith("tr_ptc_")
+
+    def test_ptc_tool_calls_share_id(self, registry):
+        def mul(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        registry.register(mul)
+        registry.enable_code_execution()
+        executor = registry._code_execution
+
+        executor.execute("s = add(a=1, b=2)\np = mul(a=s, b=3)\nprint(p)")
+
+        inv_id = executor.last_invocation_id
+        entries = registry.get_execution_log().get_entries(invocation_id=inv_id)
+        assert len(entries) == 2
+        tool_names = {e.tool_name for e in entries}
+        assert tool_names == {"add", "mul"}
+
+    def test_separate_executions_have_different_ids(self, registry):
+        registry.enable_code_execution()
+        executor = registry._code_execution
+
+        executor.execute("print(add(a=1, b=2))")
+        id1 = executor.last_invocation_id
+
+        executor.execute("print(add(a=3, b=4))")
+        id2 = executor.last_invocation_id
+
+        assert id1 != id2


### PR DESCRIPTION
## Summary

Replace the dual-logging system (ExecutionTrace + execution_log) with a single unified log using `invocation_id` to group related tool calls.

### Before
- `ExecutionTrace` + `ToolCallRecord` + `_make_traced_callable` — PTC-only trace, separate from registry log
- `execution_log` via `invoke()` — registry-wide audit log
- Same tool call recorded twice in different formats

### After
- Single `execution_log` with `invocation_id` field
- `tr_bat_xxx` — batch execution via `execute_tool_calls()`
- `tr_ptc_xxx` — PTC code execution via `CodeExecutionTool`
- `tr_sig_xxx` — single invocation via `registry.invoke()`
- Query: `log.get_entries(invocation_id="tr_ptc_a1b2c3d4")`

### Changes
- `generate_invocation_id(prefix)` helper in `utils.py`
- `ExecutionLogEntry.invocation_id` field + `create()` param
- `ExecutionLog.get_entries(invocation_id=...)` filter
- `invoke()` accepts optional `invocation_id`, auto-generates `tr_sig_` if not provided
- `CodeExecutionTool` generates `tr_ptc_` ID, passes to all `invoke()` calls
- `last_trace` → `last_invocation_id`
- Removed: `ExecutionTrace`, `ToolCallRecord`, `_make_traced_callable`

Net: **-34 lines** (172 added, 206 removed)

## Test plan
- [x] 12 invocation_id tests (auto-gen, custom, filter, error, PTC shared ID, separate executions)
- [x] 17 code execution tests (tool calling, namespace, registry integration)
- [x] 29 total, all pass
- [ ] CI passes