### PR TITLE
refactor: extract PtcController, expose as registry.ptc

### DIFF
--- a/src/toolregistry/runtimes/__init__.py
+++ b/src/toolregistry/runtimes/__init__.py
@@ -5,17 +5,16 @@ This subpackage bridges toolregistry's ``Tool`` model into the
 
 Contents:
 
+- :class:`PtcController` — ``registry.ptc`` controller (enable/disable/track)
 - :class:`ToolProjection` — protocol: how a tool appears in code namespace
 - :class:`DirectProjection` — in-process ToolProjection (wraps bare callable)
 - :func:`validate_namespace` — check key/name consistency
 - :func:`namespace_to_callables` — convert ToolProjection dict to
   plain callable dict for codecell
-- :class:`CodeExecutionTool` — built-in PTC meta-tool (requires
-  ``codecell``: ``pip install toolregistry[ptc]``)
 
 Code execution types (:class:`~codecell.CodeResult`,
 :class:`~codecell.SubprocessRuntime`, etc.) are provided by the
-``codecell`` package.
+``codecell`` package (``pip install toolregistry[ptc]``).
 """
 
 from ._code_execution import CODE_EXECUTION_NAME, CodeExecutionTool
@@ -25,11 +24,13 @@ from ._protocol import (
     namespace_to_callables,
     validate_namespace,
 )
+from ._ptc_controller import PtcController
 
 __all__ = [
     "CODE_EXECUTION_NAME",
     "CodeExecutionTool",
     "DirectProjection",
+    "PtcController",
     "ToolProjection",
     "namespace_to_callables",
     "validate_namespace",

--- a/src/toolregistry/runtimes/_code_execution.py
+++ b/src/toolregistry/runtimes/_code_execution.py
@@ -80,27 +80,33 @@ class CodeExecutionTool:
     Args:
         registry: The tool registry to pull enabled tools from.
         timeout: Default execution timeout in seconds.
+        runtime: Optional codecell runtime instance.  If ``None``,
+            uses ``IpcSubprocessRuntime(PythonValidator())``.
     """
 
     def __init__(
         self,
         registry: ToolRegistry,
         timeout: float = 30,
+        runtime: Any = None,
     ) -> None:
         self._registry = registry
         self._timeout = timeout
         self.last_invocation_id: str | None = None
 
-        try:
-            from codecell import IpcSubprocessRuntime
-            from codecell.python import PythonValidator
+        if runtime is not None:
+            self._runtime = runtime
+        else:
+            try:
+                from codecell import IpcSubprocessRuntime
+                from codecell.python import PythonValidator
 
-            self._runtime = IpcSubprocessRuntime(PythonValidator())
-        except ImportError as exc:
-            raise ImportError(
-                "CodeExecutionTool requires the 'codecell' package. "
-                "Install it with: pip install toolregistry[ptc]"
-            ) from exc
+                self._runtime = IpcSubprocessRuntime(PythonValidator())
+            except ImportError as exc:
+                raise ImportError(
+                    "CodeExecutionTool requires the 'codecell' package. "
+                    "Install it with: pip install toolregistry[ptc]"
+                ) from exc
 
     def _build_namespace(
         self,

--- a/src/toolregistry/runtimes/_ptc_controller.py
+++ b/src/toolregistry/runtimes/_ptc_controller.py
@@ -1,0 +1,107 @@
+"""PTC (Programmatic Tool Calling) controller.
+
+Manages the lifecycle of the ``code_execution`` tool — enable/disable,
+runtime injection, invocation tracking.  Exposed as ``registry.ptc``.
+
+Usage::
+
+    registry.ptc.enable(timeout=30)
+    registry.ptc.disable()
+    registry.ptc.enabled           # bool
+    registry.ptc.last_invocation_id  # str | None
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ._code_execution import CODE_EXECUTION_DESCRIPTION, CODE_EXECUTION_NAME
+
+if TYPE_CHECKING:
+    from ..tool_registry import ToolRegistry
+
+
+class PtcController:
+    """Controller for Programmatic Tool Calling (PTC).
+
+    Always present on :class:`ToolRegistry` as ``registry.ptc``.
+    Call :meth:`enable` to register the ``code_execution`` tool;
+    call :meth:`disable` to unregister it.
+
+    The controller delegates code execution to a ``codecell``
+    runtime (default: ``IpcSubprocessRuntime``).  Tool calls inside
+    the executed code go through ``registry.invoke()`` with full
+    permission and logging enforcement.
+
+    Args:
+        registry: The owning :class:`ToolRegistry` instance.
+    """
+
+    def __init__(self, registry: ToolRegistry) -> None:
+        self._registry = registry
+        self._executor: Any = None  # CodeExecutionTool | None
+        self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        """Whether PTC is currently enabled."""
+        return self._enabled
+
+    @property
+    def last_invocation_id(self) -> str | None:
+        """Invocation ID of the last PTC execution (``tr_ptc_...``).
+
+        Returns ``None`` if PTC has not been used or is disabled.
+        """
+        if self._executor is None:
+            return None
+        return self._executor.last_invocation_id
+
+    def enable(
+        self,
+        *,
+        timeout: float = 30,
+        runtime: Any = None,
+    ) -> None:
+        """Enable PTC and register the ``code_execution`` tool.
+
+        Args:
+            timeout: Default execution timeout in seconds.
+            runtime: Optional codecell runtime instance (must implement
+                ``BaseRuntime``).  If ``None``, uses
+                ``codecell.IpcSubprocessRuntime(PythonValidator())``.
+
+        Raises:
+            ImportError: If the ``codecell`` package is not installed.
+                Install with ``pip install toolregistry[ptc]``.
+        """
+        if self._enabled:
+            return
+
+        from ._code_execution import CodeExecutionTool
+        from ..tool import Tool, ToolMetadata
+
+        executor = CodeExecutionTool(
+            self._registry,
+            timeout=timeout,
+            runtime=runtime,
+        )
+
+        code_tool = Tool.from_function(
+            executor.execute,
+            name=CODE_EXECUTION_NAME,
+            description=CODE_EXECUTION_DESCRIPTION,
+            metadata=ToolMetadata(defer=False),
+        )
+        self._registry.register(code_tool)
+
+        self._executor = executor
+        self._enabled = True
+
+    def disable(self) -> None:
+        """Disable PTC and unregister the ``code_execution`` tool."""
+        if not self._enabled:
+            return
+        self._registry._tools.pop(CODE_EXECUTION_NAME, None)
+        self._executor = None
+        self._enabled = False

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -30,10 +30,7 @@ from .llm.discovery import (
     ToolDiscoveryTool,
     _BASE_DISCOVERY_DESCRIPTION,
 )
-from .runtimes._code_execution import (
-    CODE_EXECUTION_NAME,
-    CODE_EXECUTION_DESCRIPTION,
-)
+from .runtimes._ptc_controller import PtcController
 
 from ._mixins import (
     AdminMixin,
@@ -141,7 +138,7 @@ class ToolRegistry(
         self._name_sep: Literal["-", "."] = name_sep
         self._tool_discovery: ToolDiscoveryTool | None = None
         self._tool_discovery_callback: ChangeCallback | None = None
-        self._code_execution: Any = None  # CodeExecutionTool | None (lazy import)
+        self._ptc = PtcController(self)
 
         if tool_discovery:
             self.enable_tool_discovery()
@@ -317,56 +314,23 @@ class ToolRegistry(
 
         self._tool_discovery = None
 
-    # ============== Code execution toggle ==============
-    def enable_code_execution(
-        self,
-        timeout: float = 30,
-    ) -> Any:
-        """Enable PTC code execution and register a ``code_execution`` tool.
+    # ============== PTC (Programmatic Tool Calling) ==============
+    @property
+    def ptc(self) -> PtcController:
+        """PTC (Programmatic Tool Calling) controller.
 
-        Creates a :class:`~toolregistry.runtimes.CodeExecutionTool`,
-        registers its :meth:`~CodeExecutionTool.execute` method as a
-        callable tool named ``code_execution``.
+        Use ``registry.ptc.enable()`` to register a ``code_execution``
+        tool that lets LLMs write Python code with registered tools
+        callable in the namespace.
 
-        PTC (Programmatic Tool Calling) lets LLMs write Python code
-        that orchestrates multiple tool calls in a single code block,
-        reducing round-trips and token consumption.
+        Example::
 
-        Requires the ``[ptc]`` optional dependency::
-
-            pip install toolregistry[ptc]
-
-        Args:
-            timeout: Default execution timeout in seconds.
-
-        Returns:
-            The :class:`~toolregistry.runtimes.CodeExecutionTool` instance.
+            registry.ptc.enable(timeout=30)
+            registry.ptc.disable()
+            registry.ptc.enabled           # bool
+            registry.ptc.last_invocation_id  # str | None
         """
-        from .runtimes._code_execution import CodeExecutionTool
-        from .tool import Tool, ToolMetadata
-
-        if self._code_execution is not None:
-            return self._code_execution
-
-        executor = CodeExecutionTool(self, timeout=timeout)
-
-        code_tool = Tool.from_function(
-            executor.execute,
-            name=CODE_EXECUTION_NAME,
-            description=CODE_EXECUTION_DESCRIPTION,
-            metadata=ToolMetadata(defer=False),
-        )
-        self.register(code_tool)
-
-        self._code_execution = executor
-        return executor
-
-    def disable_code_execution(self) -> None:
-        """Disable PTC code execution and unregister the tool."""
-        if self._code_execution is None:
-            return
-        self._tools.pop(CODE_EXECUTION_NAME, None)
-        self._code_execution = None
+        return self._ptc
 
     # ============== Execution helpers (shared by invoke + execute_tool_calls) ==
 

--- a/tests/test_code_execution.py
+++ b/tests/test_code_execution.py
@@ -66,9 +66,9 @@ class TestCodeExecutionTool:
 
     def test_namespace_excludes_self(self, registry):
         """code_execution tool should not be in its own namespace."""
-        registry.enable_code_execution()
-        executor = registry._code_execution
-        result = executor.execute(f"print('{CODE_EXECUTION_NAME}' in dir())")
+        registry.ptc.enable()
+        tool = registry.get_tool(CODE_EXECUTION_NAME)
+        result = tool.run({"code": f"print('{CODE_EXECUTION_NAME}' in dir())"})
         assert result.strip() == "False"
 
     def test_tool_doc_accessible(self, registry):
@@ -95,40 +95,40 @@ class TestCodeExecutionTool:
 
 
 class TestRegistryIntegration:
-    def test_enable_code_execution(self, registry):
-        executor = registry.enable_code_execution()
+    def test_enable_ptc(self, registry):
+        registry.ptc.enable()
         assert CODE_EXECUTION_NAME in registry
-        assert executor is not None
+        assert registry.ptc.enabled
 
     def test_enable_idempotent(self, registry):
-        e1 = registry.enable_code_execution()
-        e2 = registry.enable_code_execution()
-        assert e1 is e2
+        registry.ptc.enable()
+        registry.ptc.enable()  # should not raise or re-register
+        assert registry.ptc.enabled
 
     def test_disable_code_execution(self, registry):
-        registry.enable_code_execution()
+        registry.ptc.enable()
         assert CODE_EXECUTION_NAME in registry
-        registry.disable_code_execution()
+        registry.ptc.disable()
         assert CODE_EXECUTION_NAME not in registry
 
     def test_disable_noop_when_not_enabled(self, registry):
-        registry.disable_code_execution()  # should not raise
+        registry.ptc.disable()  # should not raise
 
     def test_code_execution_tool_schema(self, registry):
-        registry.enable_code_execution()
+        registry.ptc.enable()
         tool = registry.get_tool(CODE_EXECUTION_NAME)
         assert tool is not None
         assert "code" in tool.parameters.get("properties", {})
 
     def test_execute_via_registry(self, registry):
-        registry.enable_code_execution()
+        registry.ptc.enable()
         tool = registry.get_tool(CODE_EXECUTION_NAME)
         result = tool.run({"code": "print(42)"})
         assert "42" in result
 
     def test_execute_tool_call_via_registry(self, registry):
         """Full end-to-end: LLM tool call → code execution → tool invocation."""
-        registry.enable_code_execution()
+        registry.ptc.enable()
         tool = registry.get_tool(CODE_EXECUTION_NAME)
         result = tool.run({"code": "print(add(a=100, b=200))"})
         assert "300" in result

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -4,6 +4,7 @@ import pytest
 
 from toolregistry import Tool, ToolRegistry
 from toolregistry.permissions import PermissionPolicy, PermissionResult, PermissionRule
+from toolregistry.runtimes import CODE_EXECUTION_NAME
 from toolregistry.tool import ToolMetadata, ToolTag
 
 
@@ -154,12 +155,12 @@ class TestPtcInvocationId:
         return reg
 
     def test_ptc_generates_invocation_id(self, registry):
-        registry.enable_code_execution()
-        executor = registry._code_execution
-        executor.execute("print(add(a=1, b=2))")
+        registry.ptc.enable()
+        tool = registry.get_tool(CODE_EXECUTION_NAME)
+        tool.run({"code": "print(add(a=1, b=2))"})
 
-        assert executor.last_invocation_id is not None
-        assert executor.last_invocation_id.startswith("tr_ptc_")
+        assert registry.ptc.last_invocation_id is not None
+        assert registry.ptc.last_invocation_id.startswith("tr_ptc_")
 
     def test_ptc_tool_calls_share_id(self, registry):
         def mul(a: int, b: int) -> int:
@@ -167,25 +168,25 @@ class TestPtcInvocationId:
             return a * b
 
         registry.register(mul)
-        registry.enable_code_execution()
-        executor = registry._code_execution
+        registry.ptc.enable()
+        tool = registry.get_tool(CODE_EXECUTION_NAME)
 
-        executor.execute("s = add(a=1, b=2)\np = mul(a=s, b=3)\nprint(p)")
+        tool.run({"code": "s = add(a=1, b=2)\np = mul(a=s, b=3)\nprint(p)"})
 
-        inv_id = executor.last_invocation_id
+        inv_id = registry.ptc.last_invocation_id
         entries = registry.get_execution_log().get_entries(invocation_id=inv_id)
         assert len(entries) == 2
         tool_names = {e.tool_name for e in entries}
         assert tool_names == {"add", "mul"}
 
     def test_separate_executions_have_different_ids(self, registry):
-        registry.enable_code_execution()
-        executor = registry._code_execution
+        registry.ptc.enable()
+        tool = registry.get_tool(CODE_EXECUTION_NAME)
 
-        executor.execute("print(add(a=1, b=2))")
-        id1 = executor.last_invocation_id
+        tool.run({"code": "print(add(a=1, b=2))"})
+        id1 = registry.ptc.last_invocation_id
 
-        executor.execute("print(add(a=3, b=4))")
-        id2 = executor.last_invocation_id
+        tool.run({"code": "print(add(a=3, b=4))"})
+        id2 = registry.ptc.last_invocation_id
 
         assert id1 != id2


### PR DESCRIPTION
## Summary

Replace `enable_code_execution()`/`disable_code_execution()` with `registry.ptc` controller sub-object.

### Before
```python
registry.enable_code_execution(timeout=30)
registry.disable_code_execution()
executor = registry._code_execution
executor.last_invocation_id
```

### After
```python
registry.ptc.enable(timeout=30)
registry.ptc.disable()
registry.ptc.enabled              # bool
registry.ptc.last_invocation_id   # str | None

# Runtime injection
from codecell import IpcSubprocessRuntime
from codecell.python import PythonValidator
registry.ptc.enable(runtime=IpcSubprocessRuntime(PythonValidator()))
```

### Design decisions (from Matrix discussion with @elena-oaklight)
- `registry.ptc` always-present (not nullable) — no guard needed
- Default runtime in controller, user doesn't need to know codecell
- LLM-facing tool name unchanged: `code_execution`
- Future full sandbox → `registry.sandbox`, completely independent
- `BaseRuntime` ABC has no PTC-specific leakage

Closes #199

## Test plan
- [x] 29 PTC/invoke tests pass
- [x] Full suite: 982 passed
- [x] Pre-commit all pass
- [x] CI passes