### PR TITLE
fix: convert_tool_calls short-circuit + ToolCall.to_ir/from_ir

### DIFF
--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -98,6 +98,31 @@ class ToolCall(BaseModel):
     type: Literal["function", "custom"] = "function"
     """The type of the tool call."""
 
+    def to_ir(self) -> dict[str, Any]:
+        """Convert to a rosetta IR ``ToolCallPart`` dict."""
+        return {
+            "type": "tool_call",
+            "tool_call_id": self.id,
+            "tool_name": self.name,
+            "tool_input": json.loads(self.arguments),
+            "tool_type": self.type,
+        }
+
+    @classmethod
+    def from_ir(cls, ir: dict[str, Any]) -> "ToolCall":
+        """Create from a rosetta IR ``ToolCallPart`` dict."""
+        tool_input = ir.get("tool_input", {})
+        raw_type = ir.get("tool_type", "function")
+        tc_type = raw_type if raw_type in ("function", "custom") else "function"
+        return cls(
+            id=ir["tool_call_id"],
+            name=ir["tool_name"],
+            arguments=json.dumps(tool_input)
+            if isinstance(tool_input, dict)
+            else str(tool_input),
+            type=tc_type,
+        )
+
     @classmethod
     def from_tool_call(cls, tool_call: Any) -> "ToolCall":
         """Convert any provider tool call format to ToolCall.
@@ -263,38 +288,13 @@ class ResultList(list):
 
 
 def _toolcall_to_ir(tc: ToolCall) -> dict[str, Any]:
-    """Convert a ToolCall to a rosetta IR ToolCallPart dict.
-
-    Currently a near-identity transform since the structures are
-    intentionally similar.
-    """
-    return {
-        "type": "tool_call",
-        "tool_call_id": tc.id,
-        "tool_name": tc.name,
-        "tool_input": json.loads(tc.arguments),
-        "tool_type": tc.type,
-    }
+    """Convert a ToolCall to a rosetta IR ToolCallPart dict."""
+    return tc.to_ir()
 
 
 def _ir_to_toolcall(ir: dict[str, Any]) -> ToolCall:
-    """Convert a rosetta IR ToolCallPart dict to a ToolCall.
-
-    Currently a near-identity transform since the structures are
-    intentionally similar.  tool_type values outside the ToolCall
-    Literal ("function" | "custom") are normalized to "function".
-    """
-    tool_input = ir.get("tool_input", {})
-    raw_type = ir.get("tool_type", "function")
-    tc_type = raw_type if raw_type in ("function", "custom") else "function"
-    return ToolCall(
-        id=ir["tool_call_id"],
-        name=ir["tool_name"],
-        arguments=json.dumps(tool_input)
-        if isinstance(tool_input, dict)
-        else str(tool_input),
-        type=tc_type,
-    )
+    """Convert a rosetta IR ToolCallPart dict to a ToolCall."""
+    return ToolCall.from_ir(ir)
 
 
 def _to_dict(obj: Any) -> Any:
@@ -318,7 +318,10 @@ def convert_tool_calls(tool_calls: list[Any]) -> list[ToolCall]:
     Returns:
         Normalized ToolCall list.
     """
-    return [ToolCall.from_tool_call(tc) for tc in tool_calls]
+    return [
+        tc if isinstance(tc, ToolCall) else ToolCall.from_tool_call(tc)
+        for tc in tool_calls
+    ]
 
 
 def build_assistant_message(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -92,6 +92,52 @@ class TestToolCall:
         with pytest.raises(TypeError, match="Unsupported tool call format"):
             ToolCall.from_tool_call("not_a_tool_call")
 
+    def test_to_ir(self):
+        """Test converting ToolCall to rosetta IR ToolCallPart."""
+        tc = ToolCall(id="c1", name="fn", arguments='{"x": 1}')
+        ir = tc.to_ir()
+
+        assert ir["type"] == "tool_call"
+        assert ir["tool_call_id"] == "c1"
+        assert ir["tool_name"] == "fn"
+        assert ir["tool_input"] == {"x": 1}
+        assert ir["tool_type"] == "function"
+
+    def test_from_ir(self):
+        """Test creating ToolCall from rosetta IR ToolCallPart."""
+        ir = {
+            "type": "tool_call",
+            "tool_call_id": "c1",
+            "tool_name": "fn",
+            "tool_input": {"x": 1},
+            "tool_type": "function",
+        }
+        tc = ToolCall.from_ir(ir)
+
+        assert tc.id == "c1"
+        assert tc.name == "fn"
+        assert tc.arguments == '{"x": 1}'
+        assert tc.type == "function"
+
+    def test_to_ir_from_ir_roundtrip(self):
+        """Test that to_ir -> from_ir preserves data."""
+        tc = ToolCall(id="c1", name="fn", arguments='{"a": 1, "b": "hello"}')
+        tc2 = ToolCall.from_ir(tc.to_ir())
+
+        assert tc2.id == tc.id
+        assert tc2.name == tc.name
+        assert tc2.arguments == tc.arguments
+
+    def test_convert_tool_calls_shortcircuit(self):
+        """Test that convert_tool_calls passes through ToolCall instances."""
+        from toolregistry.llm.tool_calls import convert_tool_calls
+
+        tc = ToolCall(id="c1", name="fn", arguments='{"x": 42}')
+        converted = convert_tool_calls([tc])
+
+        assert converted[0] is tc
+        assert converted[0].arguments == '{"x": 42}'
+
 
 # ---------------------------------------------------------------------------
 # ToolCallResult


### PR DESCRIPTION
## Summary

- `convert_tool_calls()` now short-circuits for `ToolCall` instances — fixes argument loss when passing already-normalized objects (#205)
- `ToolCall.to_ir()` / `ToolCall.from_ir()` for direct rosetta IR `ToolCallPart` conversion (#204)
- `_toolcall_to_ir` / `_ir_to_toolcall` delegated to the new methods

## Test plan

- [x] `pytest tests/ -v` — 996 passed
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Roundtrip test: `ToolCall → to_ir() → from_ir()` preserves all fields
- [x] Short-circuit test: `convert_tool_calls([ToolCall(...)])` returns same object with intact arguments

Closes #204, closes #205