### PR TITLE
feat: support api_format="rosetta-ir" for direct IR output

### DIFF
--- a/examples/hub_related/openai_calculator_example_response_api.py
+++ b/examples/hub_related/openai_calculator_example_response_api.py
@@ -48,7 +48,7 @@ def handle_tool_calls_response(response, messages):
 
         # Construct assistant messages with results
         assistant_tool_messages = tool_registry.build_tool_call_messages(
-            tool_calls, results, api_format="openai-response"
+            tool_calls, results, api_format="openai-responses"
         )
 
         messages.extend(assistant_tool_messages)
@@ -57,7 +57,7 @@ def handle_tool_calls_response(response, messages):
         response = client.responses.create(
             model=model_name,
             input=messages,
-            tools=tool_registry.get_schemas(api_format="openai-response"),
+            tools=tool_registry.get_schemas(api_format="openai-responses"),
             tool_choice="auto",
         )
     return response
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     response = client.responses.create(
         model=model_name,
         input=messages,
-        tools=tool_registry.get_schemas(api_format="openai-response"),
+        tools=tool_registry.get_schemas(api_format="openai-responses"),
         tool_choice="auto",
     )
     response = handle_tool_calls_response(response, messages)

--- a/examples/providers/openai_responses.py
+++ b/examples/providers/openai_responses.py
@@ -27,7 +27,7 @@ def subtract(a: int, b: int) -> int:
     return a - b
 
 
-print(json.dumps(registry.get_schemas(api_format="openai-response"), indent=2))
+print(json.dumps(registry.get_schemas(api_format="openai-responses"), indent=2))
 
 # Set up OpenAI client
 client = OpenAI(
@@ -47,7 +47,7 @@ messages = [
 response = client.responses.create(
     model=model_name,
     input=messages,
-    tools=registry.get_schemas(api_format="openai-response"),
+    tools=registry.get_schemas(api_format="openai-responses"),
     tool_choice="auto",
 )
 
@@ -63,7 +63,7 @@ print(results)
 
 # Construct assistant messages with results
 assistant_tool_messages = registry.build_tool_call_messages(
-    tool_calls, results, api_format="openai-response"
+    tool_calls, results, api_format="openai-responses"
 )
 print(json.dumps(assistant_tool_messages, indent=2))
 
@@ -73,7 +73,7 @@ messages.extend(assistant_tool_messages)
 response = client.responses.create(
     model=model_name,
     input=messages,
-    tools=registry.get_schemas(api_format="openai-response"),
+    tools=registry.get_schemas(api_format="openai-responses"),
     tool_choice="auto",
 )
 

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -945,7 +945,7 @@ def _get_schema(request: Request) -> Response:
     # --- LLM schema formats ---
     from ..llm.tool_calls import API_FORMATS
 
-    valid = {"openai-chat", "openai-responses", "anthropic", "gemini"}
+    valid = {"openai-chat", "openai-responses", "anthropic", "gemini", "rosetta-ir"}
     if fmt_str not in valid:
         return _error_response(
             400,

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -945,7 +945,7 @@ def _get_schema(request: Request) -> Response:
     # --- LLM schema formats ---
     from ..llm.tool_calls import API_FORMATS
 
-    valid = {"openai-chat", "openai-response", "anthropic", "gemini"}
+    valid = {"openai-chat", "openai-responses", "anthropic", "gemini"}
     if fmt_str not in valid:
         return _error_response(
             400,

--- a/src/toolregistry/admin/static.py
+++ b/src/toolregistry/admin/static.py
@@ -1744,7 +1744,7 @@ ADMIN_HTML: str = """<!DOCTYPE html>
                             <div style="display:flex;gap:8px;align-items:center;">
                                 <select id="schema-format-select" class="btn btn-secondary btn-sm" style="padding:4px 8px;cursor:pointer;" onchange="loadSchema(this.value)">
                                     <option value="openai-chat">openai-chat</option>
-                                    <option value="openai-response">openai-response</option>
+                                    <option value="openai-responses">openai-responses</option>
                                     <option value="anthropic">anthropic</option>
                                     <option value="gemini">gemini</option>
                                 </select>

--- a/src/toolregistry/admin/static.py
+++ b/src/toolregistry/admin/static.py
@@ -1747,6 +1747,7 @@ ADMIN_HTML: str = """<!DOCTYPE html>
                                     <option value="openai-responses">openai-responses</option>
                                     <option value="anthropic">anthropic</option>
                                     <option value="gemini">gemini</option>
+                                    <option value="rosetta-ir">rosetta-ir</option>
                                 </select>
                                 <button class="btn btn-secondary btn-sm" onclick="loadSchema(document.getElementById('schema-format-select').value)" data-i18n="btn.refresh">Refresh</button>
                                 <button class="btn btn-secondary btn-sm" onclick="copySchemaContent('schema-content')" data-i18n="btn.copy">Copy</button>

--- a/src/toolregistry/llm/content_blocks.py
+++ b/src/toolregistry/llm/content_blocks.py
@@ -160,7 +160,7 @@ def build_expanded_user_message(
     Returns:
         A user message dict ready to append to the conversation.
     """
-    if api_format in ("openai-chat", "openai-response"):
+    if api_format in ("openai-chat", "openai-responses"):
         parts = []
         for part in content_parts:
             if part.get("type") == "text":

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -21,6 +21,7 @@ API_FORMATS = Literal[
     "openai-response",
     "anthropic",
     "gemini",
+    "rosetta-ir",
 ]
 
 _DEPRECATED_API_FORMATS: dict[str, API_FORMATS] = {

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -18,8 +18,9 @@ API_FORMATS = Literal[
     "openai",  # deprecated alias for openai-chat
     "openai-chat",
     "openai-chatcompletion",  # deprecated alias for openai-chat
-    "openai-response",
-    "open-responses",  # alias for openai-response
+    "openai-response",  # deprecated alias for openai-responses
+    "openai-responses",
+    "open-responses",  # alias for openai-responses
     "anthropic",
     "gemini",
     "rosetta-ir",
@@ -28,11 +29,12 @@ API_FORMATS = Literal[
 _DEPRECATED_API_FORMATS: dict[str, API_FORMATS] = {
     "openai": "openai-chat",
     "openai-chatcompletion": "openai-chat",
+    "openai-response": "openai-responses",
 }
 
 
 _API_FORMAT_ALIASES: dict[str, API_FORMATS] = {
-    "open-responses": "openai-response",
+    "open-responses": "openai-responses",
 }
 
 
@@ -77,7 +79,7 @@ def _get_tool_ops(api_format: API_FORMATS) -> Any:
         from llm_rosetta.converters.openai_chat import OpenAIChatToolOps
 
         return OpenAIChatToolOps
-    elif api_format == "openai-response":
+    elif api_format == "openai-responses":
         from llm_rosetta.converters.openai_responses import OpenAIResponsesToolOps
 
         return OpenAIResponsesToolOps
@@ -159,7 +161,7 @@ class ToolCall(BaseModel):
         # Vendor-specific formats (anthropic, gemini) are tried before generic
         # OpenAI formats because the OpenAI parsers are lenient and may
         # successfully (but incorrectly) parse Anthropic/Gemini dicts.
-        for fmt in ("anthropic", "gemini", "openai-chat", "openai-response"):
+        for fmt in ("anthropic", "gemini", "openai-chat", "openai-responses"):
             try:
                 ops = _get_tool_ops(fmt)
                 ir = ops.p_tool_call_to_ir(tc_dict)
@@ -362,7 +364,7 @@ def build_assistant_message(
 
     if api_format == "openai-chat":
         return [{"role": "assistant", "tool_calls": provider_calls}]
-    elif api_format == "openai-response":
+    elif api_format == "openai-responses":
         return provider_calls
     elif api_format == "anthropic":
         return [{"role": "assistant", "content": provider_calls}]
@@ -423,7 +425,7 @@ def build_tool_response(
     if api_format == "openai-chat":
         # Each tool result is a separate message
         return provider_results
-    elif api_format == "openai-response":
+    elif api_format == "openai-responses":
         return provider_results
     elif api_format == "anthropic":
         return [{"role": "user", "content": provider_results}]

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -19,6 +19,7 @@ API_FORMATS = Literal[
     "openai-chat",
     "openai-chatcompletion",  # deprecated alias for openai-chat
     "openai-response",
+    "open-responses",  # alias for openai-response
     "anthropic",
     "gemini",
     "rosetta-ir",
@@ -30,11 +31,22 @@ _DEPRECATED_API_FORMATS: dict[str, API_FORMATS] = {
 }
 
 
+_API_FORMAT_ALIASES: dict[str, API_FORMATS] = {
+    "open-responses": "openai-response",
+}
+
+
 def _normalize_api_format(api_format: API_FORMATS) -> API_FORMATS:
-    """Map deprecated format names to their canonical equivalents.
+    """Map deprecated and aliased format names to their canonical equivalents.
 
     Emits a ``DeprecationWarning`` when a deprecated name is used.
+    Aliases are resolved silently.
     """
+    # Silent aliases (no warning)
+    aliased = _API_FORMAT_ALIASES.get(api_format)
+    if aliased is not None:
+        return aliased
+    # Deprecated names (with warning)
     canonical = _DEPRECATED_API_FORMATS.get(api_format)
     if canonical is not None:
         warnings.warn(

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -431,7 +431,9 @@ class Tool(BaseModel):
         )
         ir_tool = _make_ir_tool_definition(self.name, self.description, params)
 
-        if api_format == "openai-chat":
+        if api_format == "rosetta-ir":
+            return ir_tool
+        elif api_format == "openai-chat":
             from .llm._rosetta import _get_openai_chat_tool_ops
 
             return _get_openai_chat_tool_ops().ir_tool_definition_to_p(ir_tool)

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -400,7 +400,7 @@ class Tool(BaseModel):
 
         Args:
             api_format: Target API format. One of ``"openai-chat"``,
-                ``"openai-response"``, ``"anthropic"``, ``"gemini"``.
+                ``"openai-responses"``, ``"anthropic"``, ``"gemini"``.
             _think_augment: Internal override for toolcall_reason injection.
                 When ``None`` (default), falls back to
                 ``self.metadata.think_augment``.  Used by
@@ -437,7 +437,7 @@ class Tool(BaseModel):
             from .llm._rosetta import _get_openai_chat_tool_ops
 
             return _get_openai_chat_tool_ops().ir_tool_definition_to_p(ir_tool)
-        elif api_format == "openai-response":
+        elif api_format == "openai-responses":
             from .llm._rosetta import _get_openai_responses_tool_ops
 
             return _get_openai_responses_tool_ops().ir_tool_definition_to_p(ir_tool)

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1014,6 +1014,14 @@ class ToolRegistry(
             else:
                 response_dict[r.id] = r.result
 
+        if api_format == "rosetta-ir":
+            ir_calls = [tc.to_ir() for tc in generic_tool_calls]
+            ir_results = [r.to_ir() for r in results]
+            return [
+                {"role": "assistant", "parts": ir_calls},
+                {"role": "tool", "parts": ir_results},
+            ]
+
         text_responses, extra_user_content = expand_content_blocks(response_dict)
 
         messages: list[dict[str, Any]] = []

--- a/tests/test_anthropic_gemini_formats.py
+++ b/tests/test_anthropic_gemini_formats.py
@@ -112,7 +112,7 @@ class TestGetJsonSchemaOpenAI:
 
     def test_openai_response_format(self):
         tool = _sample_tool()
-        schema = tool.get_schema(api_format="openai-response")
+        schema = tool.get_schema(api_format="openai-responses")
         assert schema["type"] == "function"
         assert schema["name"] == "add"
         assert "Add two numbers" in schema["description"]

--- a/tests/test_content_blocks.py
+++ b/tests/test_content_blocks.py
@@ -232,7 +232,7 @@ class TestBuildExpandedUserMessage:
         assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
 
     def test_openai_response_format(self, sample_parts):
-        msg = build_expanded_user_message(sample_parts, "openai-response")
+        msg = build_expanded_user_message(sample_parts, "openai-responses")
         assert msg["role"] == "user"
         # Same format as openai-chat
         image_parts = [p for p in msg["content"] if p["type"] == "image_url"]
@@ -400,7 +400,7 @@ class TestBuildToolResponseMultimodal:
 
     def test_openai_response_uses_text_fallback(self, multimodal_responses):
         messages = build_tool_response(
-            multimodal_responses, api_format="openai-response"
+            multimodal_responses, api_format="openai-responses"
         )
         output = messages[0]["output"]
         assert isinstance(output, str)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -344,7 +344,7 @@ class TestToolRegistryIntegration:
         # Test different API formats
         openai_format = registry.get_schemas(api_format="openai-chat")
         openai_chat_format = registry.get_schemas(api_format="openai-chat")
-        response_format = registry.get_schemas(api_format="openai-response")
+        response_format = registry.get_schemas(api_format="openai-responses")
         anthropic_format = registry.get_schemas(api_format="anthropic")
         gemini_format = registry.get_schemas(api_format="gemini")
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -109,7 +109,7 @@ class TestTool:
 
     def test_get_json_schema_openai_response_format(self, sample_tool):
         """Test getting JSON schema in OpenAI response format."""
-        schema = sample_tool.get_schema("openai-response")
+        schema = sample_tool.get_schema("openai-responses")
 
         assert schema["type"] == "function"
         assert schema["name"] == sample_tool.name

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -168,7 +168,7 @@ class TestToolRegistry:
     def test_get_schemas_different_api_formats(self, populated_registry):
         """Test getting JSON schema in different API formats."""
         openai_format = populated_registry.get_schemas(api_format="openai-chat")
-        response_format = populated_registry.get_schemas(api_format="openai-response")
+        response_format = populated_registry.get_schemas(api_format="openai-responses")
 
         assert len(openai_format) == len(response_format)
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -195,6 +195,38 @@ class TestToolRegistry:
         assert "name" in gemini_format[0]
         assert "parameters" in gemini_format[0]
 
+    def test_get_schemas_rosetta_ir_format(self, populated_registry):
+        """Test getting schemas in rosetta IR format."""
+        ir_format = populated_registry.get_schemas(api_format="rosetta-ir")
+
+        assert len(ir_format) >= 2
+        assert ir_format[0]["type"] == "function"
+        assert "name" in ir_format[0]
+        assert "description" in ir_format[0]
+        assert "parameters" in ir_format[0]
+
+    def test_build_tool_call_messages_rosetta_ir(self, populated_registry):
+        """Test building messages in rosetta IR format."""
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "add_numbers", "arguments": '{"a": 5, "b": 3}'},
+            }
+        ]
+        results = populated_registry.execute_tool_calls(tool_calls)
+        messages = populated_registry.build_tool_call_messages(
+            tool_calls, results, api_format="rosetta-ir"
+        )
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "assistant"
+        assert messages[0]["parts"][0]["type"] == "tool_call"
+        assert messages[0]["parts"][0]["tool_name"] == "add_numbers"
+        assert messages[1]["role"] == "tool"
+        assert messages[1]["parts"][0]["type"] == "tool_result"
+        assert messages[1]["parts"][0]["result"] == "8"
+
     def test_get_tool(self, populated_registry):
         """Test getting a tool by name."""
         tool = populated_registry.get_tool("add_numbers")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -308,7 +308,7 @@ class TestBuildAssistantMessage:
             ToolCall(id="call_1", name="test_function", arguments='{"param": "value"}')
         ]
 
-        messages = build_assistant_message(tool_calls, api_format="openai-response")
+        messages = build_assistant_message(tool_calls, api_format="openai-responses")
 
         assert len(messages) == 1
         assert messages[0]["call_id"] == "call_1"
@@ -388,7 +388,7 @@ class TestBuildToolResponse:
 
     def test_openai_response_format(self):
         messages = build_tool_response(
-            {"call_1": "Result"}, api_format="openai-response"
+            {"call_1": "Result"}, api_format="openai-responses"
         )
 
         assert len(messages) == 1


### PR DESCRIPTION
## Summary

Add `"rosetta-ir"` as a supported `api_format` value for provider-agnostic IR output.

- `get_schemas(api_format="rosetta-ir")` → returns `list[ToolDefinition]` directly
- `build_tool_call_messages(..., api_format="rosetta-ir")` → returns IR `ToolCallPart`/`ToolResultPart` messages

The IR is already built internally — this just skips the final provider conversion step.

## Test plan

- [x] `pytest tests/ -v` — 994 passed
- [x] `pre-commit run --all-files` — all hooks pass

Closes #207