### PR TITLE
refactor: rename LLM builder functions for clarity

### DIFF
--- a/src/toolregistry/llm/__init__.py
+++ b/src/toolregistry/llm/__init__.py
@@ -14,8 +14,10 @@ from .content_blocks import (
     ImageBlock,
     TextBlock,
     build_expanded_user_message,
+    build_multimodal_user_message,
     content_blocks_to_text,
     expand_content_blocks,
+    extract_multimodal_content,
     is_content_block_list,
 )
 from .tool_calls import (
@@ -27,7 +29,9 @@ from .tool_calls import (
     ToolCallResult,
     _normalize_api_format,
     build_assistant_message,
+    build_assistant_messages,
     build_tool_response,
+    build_tool_result_messages,
     convert_tool_calls,
 )
 
@@ -41,7 +45,9 @@ __all__ = [
     "ToolCallResult",
     "_normalize_api_format",
     "build_assistant_message",
+    "build_assistant_messages",
     "build_tool_response",
+    "build_tool_result_messages",
     "convert_tool_calls",
     # Content block types
     "Base64ImageSource",
@@ -49,7 +55,9 @@ __all__ = [
     "ImageBlock",
     "TextBlock",
     "build_expanded_user_message",
+    "build_multimodal_user_message",
     "content_blocks_to_text",
     "expand_content_blocks",
+    "extract_multimodal_content",
     "is_content_block_list",
 ]

--- a/src/toolregistry/llm/content_blocks.py
+++ b/src/toolregistry/llm/content_blocks.py
@@ -6,13 +6,14 @@ mirrors the Anthropic API format.
 
 All API formats receive text-only tool results.  Multimodal content
 is delivered via a subsequent user message produced by
-:func:`expand_content_blocks`.  This uniform approach eliminates
+:func:`extract_multimodal_content`.  This uniform approach eliminates
 per-provider differences in tool result handling.
 """
 
 from __future__ import annotations
 
 import base64
+import warnings
 from typing import Any, Literal, TypedDict, Union
 
 
@@ -94,7 +95,7 @@ def content_blocks_to_text(blocks: list[ContentBlock]) -> str:
     return "\n".join(parts)
 
 
-def expand_content_blocks(
+def extract_multimodal_content(
     tool_responses: dict[str, str | list],
 ) -> tuple[dict[str, str | list], list[dict[str, Any]]]:
     """Separate multimodal content from tool responses for uniform handling.
@@ -142,7 +143,7 @@ def expand_content_blocks(
     return text_only, extra_parts
 
 
-def build_expanded_user_message(
+def build_multimodal_user_message(
     content_parts: list[dict[str, Any]],
     api_format: str,
 ) -> dict[str, Any]:
@@ -153,7 +154,7 @@ def build_expanded_user_message(
 
     Args:
         content_parts: List of content block dicts produced by
-            :func:`expand_content_blocks`.
+            :func:`extract_multimodal_content`.
         api_format: Target API format (e.g. ``"openai-chat"``,
             ``"anthropic"``, ``"gemini"``).
 
@@ -195,3 +196,28 @@ def build_expanded_user_message(
     # Fallback: text only
     texts = [p["text"] for p in content_parts if p.get("type") == "text"]
     return {"role": "user", "content": "\n".join(texts)}
+
+
+# ── Deprecated aliases ─────────────────────────────────────────────
+
+
+def expand_content_blocks(
+    tool_responses: dict[str, str | list],
+) -> tuple[dict[str, str | list], list[dict[str, Any]]]:
+    """Deprecated: use :func:`extract_multimodal_content` instead."""
+    warnings.warn(
+        "expand_content_blocks() is deprecated, use extract_multimodal_content() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return extract_multimodal_content(tool_responses)
+
+
+def build_expanded_user_message(extra_content: list, api_format: Any) -> dict[str, Any]:
+    """Deprecated: use :func:`build_multimodal_user_message` instead."""
+    warnings.warn(
+        "build_expanded_user_message() is deprecated, use build_multimodal_user_message() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return build_multimodal_user_message(extra_content, api_format)

--- a/src/toolregistry/llm/content_blocks.py
+++ b/src/toolregistry/llm/content_blocks.py
@@ -213,11 +213,13 @@ def expand_content_blocks(
     return extract_multimodal_content(tool_responses)
 
 
-def build_expanded_user_message(extra_content: list, api_format: Any) -> dict[str, Any]:
+def build_expanded_user_message(
+    content_parts: list[dict[str, Any]], api_format: str
+) -> dict[str, Any]:
     """Deprecated: use :func:`build_multimodal_user_message` instead."""
     warnings.warn(
         "build_expanded_user_message() is deprecated, use build_multimodal_user_message() instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return build_multimodal_user_message(extra_content, api_format)
+    return build_multimodal_user_message(content_parts, api_format)

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -339,7 +339,7 @@ def convert_tool_calls(tool_calls: list[Any]) -> list[ToolCall]:
     ]
 
 
-def build_assistant_message(
+def build_assistant_messages(
     tool_calls: list[ToolCall],
     *,
     api_format: API_FORMATS = "openai-chat",
@@ -373,7 +373,7 @@ def build_assistant_message(
     raise ValueError(f"Unsupported API format: {api_format}")
 
 
-def build_tool_response(
+def build_tool_result_messages(
     tool_responses: dict[str, str | list],
     *,
     api_format: API_FORMATS = "openai-chat",
@@ -442,13 +442,13 @@ def recover_assistant_message(
     *,
     api_format: API_FORMATS = "openai-chat",
 ) -> list[dict[str, Any]]:
-    """Deprecated: use :func:`build_assistant_message` instead."""
+    """Deprecated: use :func:`build_assistant_messages` instead."""
     warnings.warn(
-        "recover_assistant_message() is deprecated, use build_assistant_message() instead.",
+        "recover_assistant_message() is deprecated, use build_assistant_messages() instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return build_assistant_message(tool_calls, api_format=api_format)
+    return build_assistant_messages(tool_calls, api_format=api_format)
 
 
 def recover_tool_message(
@@ -457,12 +457,43 @@ def recover_tool_message(
     api_format: API_FORMATS = "openai-chat",
     tool_calls: list[ToolCall] | None = None,
 ) -> list[dict[str, Any]]:
-    """Deprecated: use :func:`build_tool_response` instead."""
+    """Deprecated: use :func:`build_tool_result_messages` instead."""
     warnings.warn(
-        "recover_tool_message() is deprecated, use build_tool_response() instead.",
+        "recover_tool_message() is deprecated, use build_tool_result_messages() instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return build_tool_response(
+    return build_tool_result_messages(
+        tool_responses, api_format=api_format, tool_calls=tool_calls
+    )
+
+
+def build_assistant_message(
+    tool_calls: list[ToolCall],
+    *,
+    api_format: API_FORMATS = "openai-chat",
+) -> list[dict[str, Any]]:
+    """Deprecated: use :func:`build_assistant_messages` instead."""
+    warnings.warn(
+        "build_assistant_message() is deprecated, use build_assistant_messages() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return build_assistant_messages(tool_calls, api_format=api_format)
+
+
+def build_tool_response(
+    tool_responses: dict[str, str | list],
+    *,
+    api_format: API_FORMATS = "openai-chat",
+    tool_calls: list[ToolCall] | None = None,
+) -> list[dict[str, Any]]:
+    """Deprecated: use :func:`build_tool_result_messages` instead."""
+    warnings.warn(
+        "build_tool_response() is deprecated, use build_tool_result_messages() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return build_tool_result_messages(
         tool_responses, api_format=api_format, tool_calls=tool_calls
     )

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -22,8 +22,8 @@ from .llm.tool_calls import (
     ErrorResult,
     ResultList,
     ToolCallResult,
-    build_assistant_message,
-    build_tool_response,
+    build_assistant_messages,
+    build_tool_result_messages,
     convert_tool_calls,
 )
 
@@ -991,8 +991,8 @@ class ToolRegistry(
         """
         from .llm.tool_calls import _normalize_api_format
         from .llm.content_blocks import (
-            build_expanded_user_message,
-            expand_content_blocks,
+            build_multimodal_user_message,
+            extract_multimodal_content,
         )
 
         api_format = _normalize_api_format(api_format)
@@ -1022,20 +1022,22 @@ class ToolRegistry(
                 {"role": "tool", "parts": ir_results},
             ]
 
-        text_responses, extra_user_content = expand_content_blocks(response_dict)
+        text_responses, extra_user_content = extract_multimodal_content(response_dict)
 
         messages: list[dict[str, Any]] = []
         messages.extend(
-            build_assistant_message(generic_tool_calls, api_format=api_format)
+            build_assistant_messages(generic_tool_calls, api_format=api_format)
         )
         messages.extend(
-            build_tool_response(
+            build_tool_result_messages(
                 text_responses, api_format=api_format, tool_calls=generic_tool_calls
             )
         )
 
         if extra_user_content:
-            messages.append(build_expanded_user_message(extra_user_content, api_format))
+            messages.append(
+                build_multimodal_user_message(extra_user_content, api_format)
+            )
 
         return messages
 

--- a/tests/test_anthropic_gemini_formats.py
+++ b/tests/test_anthropic_gemini_formats.py
@@ -1,7 +1,7 @@
 """Tests for Anthropic, Gemini, and rosetta-based OpenAI schema format support.
 
 Covers get_schema(), ToolCall.from_tool_call(),
-build_assistant_message(), and build_tool_response().
+build_assistant_messages(), and build_tool_result_messages().
 """
 
 import json
@@ -10,8 +10,8 @@ import json
 from toolregistry import Tool
 from toolregistry.llm.tool_calls import (
     ToolCall,
-    build_assistant_message,
-    build_tool_response,
+    build_assistant_messages,
+    build_tool_result_messages,
 )
 
 
@@ -234,7 +234,7 @@ class TestFromToolCallGemini:
 
 
 # ---------------------------------------------------------------------------
-# build_assistant_message — Anthropic
+# build_assistant_messages — Anthropic
 # ---------------------------------------------------------------------------
 
 
@@ -247,7 +247,7 @@ class TestRecoverAssistantMessageAnthropic:
                 arguments=json.dumps({"a": 1, "b": 2}),
             )
         ]
-        result = build_assistant_message(tool_calls, api_format="anthropic")
+        result = build_assistant_messages(tool_calls, api_format="anthropic")
         assert len(result) == 1
         msg = result[0]
         assert msg["role"] == "assistant"
@@ -263,7 +263,7 @@ class TestRecoverAssistantMessageAnthropic:
             ToolCall(id="t1", name="add", arguments=json.dumps({"a": 1, "b": 2})),
             ToolCall(id="t2", name="sub", arguments=json.dumps({"x": 5})),
         ]
-        result = build_assistant_message(tool_calls, api_format="anthropic")
+        result = build_assistant_messages(tool_calls, api_format="anthropic")
         assert len(result) == 1
         assert len(result[0]["content"]) == 2
 
@@ -271,12 +271,12 @@ class TestRecoverAssistantMessageAnthropic:
         tool_calls = [
             ToolCall(id="t1", name="", arguments="{}"),
         ]
-        result = build_assistant_message(tool_calls, api_format="anthropic")
+        result = build_assistant_messages(tool_calls, api_format="anthropic")
         assert result[0]["content"] == []
 
 
 # ---------------------------------------------------------------------------
-# build_assistant_message — Gemini
+# build_assistant_messages — Gemini
 # ---------------------------------------------------------------------------
 
 
@@ -289,7 +289,7 @@ class TestRecoverAssistantMessageGemini:
                 arguments=json.dumps({"a": 1, "b": 2}),
             )
         ]
-        result = build_assistant_message(tool_calls, api_format="gemini")
+        result = build_assistant_messages(tool_calls, api_format="gemini")
         assert len(result) == 1
         msg = result[0]
         assert msg["role"] == "model"
@@ -301,14 +301,14 @@ class TestRecoverAssistantMessageGemini:
 
 
 # ---------------------------------------------------------------------------
-# build_tool_response — Anthropic
+# build_tool_result_messages — Anthropic
 # ---------------------------------------------------------------------------
 
 
 class TestRecoverToolMessageAnthropic:
     def test_basic_structure(self):
         responses = {"toolu_1": "3"}
-        result = build_tool_response(responses, api_format="anthropic")
+        result = build_tool_result_messages(responses, api_format="anthropic")
         assert len(result) == 1
         msg = result[0]
         assert msg["role"] == "user"
@@ -320,13 +320,13 @@ class TestRecoverToolMessageAnthropic:
 
     def test_multiple_results(self):
         responses = {"t1": "result1", "t2": "result2"}
-        result = build_tool_response(responses, api_format="anthropic")
+        result = build_tool_result_messages(responses, api_format="anthropic")
         assert len(result) == 1
         assert len(result[0]["content"]) == 2
 
 
 # ---------------------------------------------------------------------------
-# build_tool_response — Gemini
+# build_tool_result_messages — Gemini
 # ---------------------------------------------------------------------------
 
 
@@ -334,7 +334,9 @@ class TestRecoverToolMessageGemini:
     def test_basic_structure(self):
         responses = {"fc_1": "42"}
         tcs = [ToolCall(id="fc_1", name="add", arguments="{}")]
-        result = build_tool_response(responses, api_format="gemini", tool_calls=tcs)
+        result = build_tool_result_messages(
+            responses, api_format="gemini", tool_calls=tcs
+        )
         assert len(result) == 1
         msg = result[0]
         assert msg["role"] == "user"
@@ -346,14 +348,14 @@ class TestRecoverToolMessageGemini:
 
     def test_fallback_to_call_id_when_no_tool_calls(self):
         responses = {"fc_1": "42"}
-        result = build_tool_response(responses, api_format="gemini")
+        result = build_tool_result_messages(responses, api_format="gemini")
         # Without tool_calls, falls back to call_id as function name
         part = result[0]["parts"][0]
         assert part["functionResponse"]["name"] == "fc_1"
 
 
 # ---------------------------------------------------------------------------
-# Round-trip: from_tool_call -> build_assistant_message
+# Round-trip: from_tool_call -> build_assistant_messages
 # ---------------------------------------------------------------------------
 
 
@@ -367,7 +369,7 @@ class TestRoundTrip:
             "input": {"a": 10, "b": 20},
         }
         tc = ToolCall.from_tool_call(original)
-        recovered = build_assistant_message([tc], api_format="anthropic")
+        recovered = build_assistant_messages([tc], api_format="anthropic")
         block = recovered[0]["content"][0]
         assert block["type"] == original["type"]
         assert block["id"] == original["id"]
@@ -383,7 +385,7 @@ class TestRoundTrip:
             }
         }
         tc = ToolCall.from_tool_call(original)
-        recovered = build_assistant_message([tc], api_format="gemini")
+        recovered = build_assistant_messages([tc], api_format="gemini")
         part = recovered[0]["parts"][0]
         assert part["functionCall"]["name"] == original["functionCall"]["name"]
         assert part["functionCall"]["args"] == original["functionCall"]["args"]

--- a/tests/test_content_blocks.py
+++ b/tests/test_content_blocks.py
@@ -8,13 +8,13 @@ from toolregistry import ToolRegistry
 from toolregistry.tool import Tool, ToolMetadata
 from toolregistry.llm.content_blocks import (
     ContentBlock,
-    build_expanded_user_message,
+    build_multimodal_user_message,
     content_blocks_to_text,
-    expand_content_blocks,
+    extract_multimodal_content,
     is_content_block_list,
 )
 from toolregistry.llm.tool_calls import (
-    build_tool_response,
+    build_tool_result_messages,
 )
 
 # ---------------------------------------------------------------------------
@@ -115,16 +115,16 @@ class TestContentBlocksToText:
 
 
 # ---------------------------------------------------------------------------
-# expand_content_blocks
+# extract_multimodal_content
 # ---------------------------------------------------------------------------
 
 
 class TestExpandContentBlocks:
-    """Tests for expand_content_blocks()."""
+    """Tests for extract_multimodal_content()."""
 
     def test_multimodal_response_gets_placeholder(self):
         responses = {"call_1": _make_multimodal_blocks()}
-        text_only, extra = expand_content_blocks(responses)
+        text_only, extra = extract_multimodal_content(responses)
 
         assert isinstance(text_only["call_1"], str)
         assert '<tool-content call-id="call_1">' in text_only["call_1"]
@@ -132,14 +132,14 @@ class TestExpandContentBlocks:
 
     def test_string_response_passes_through(self):
         responses = {"call_1": "plain text"}
-        text_only, extra = expand_content_blocks(responses)
+        text_only, extra = extract_multimodal_content(responses)
 
         assert text_only["call_1"] == "plain text"
         assert extra == []
 
     def test_extra_content_has_xml_tags(self):
         responses = {"call_1": _make_multimodal_blocks()}
-        _, extra = expand_content_blocks(responses)
+        _, extra = extract_multimodal_content(responses)
 
         # Opening tag
         assert extra[0]["type"] == "text"
@@ -151,7 +151,7 @@ class TestExpandContentBlocks:
     def test_extra_content_contains_blocks(self):
         blocks = _make_multimodal_blocks()
         responses = {"call_1": blocks}
-        _, extra = expand_content_blocks(responses)
+        _, extra = extract_multimodal_content(responses)
 
         # Between open/close tags: text block + image block
         assert extra[1]["type"] == "text"
@@ -164,7 +164,7 @@ class TestExpandContentBlocks:
             "call_2": _make_multimodal_blocks(),
             "call_3": "more text",
         }
-        text_only, extra = expand_content_blocks(responses)
+        text_only, extra = extract_multimodal_content(responses)
 
         assert text_only["call_1"] == "plain text"
         assert text_only["call_3"] == "more text"
@@ -172,13 +172,13 @@ class TestExpandContentBlocks:
         assert len(extra) > 0
 
     def test_empty_responses(self):
-        text_only, extra = expand_content_blocks({})
+        text_only, extra = extract_multimodal_content({})
         assert text_only == {}
         assert extra == []
 
     def test_non_string_non_list_response(self):
         responses = {"call_1": 42}
-        text_only, extra = expand_content_blocks(responses)
+        text_only, extra = extract_multimodal_content(responses)
 
         assert text_only["call_1"] == "42"
         assert extra == []
@@ -188,7 +188,7 @@ class TestExpandContentBlocks:
             "call_1": _make_multimodal_blocks(),
             "call_2": [_make_image_block()],
         }
-        text_only, extra = expand_content_blocks(responses)
+        text_only, extra = extract_multimodal_content(responses)
 
         assert '<tool-content call-id="call_1">' in text_only["call_1"]
         assert '<tool-content call-id="call_2">' in text_only["call_2"]
@@ -202,12 +202,12 @@ class TestExpandContentBlocks:
 
 
 # ---------------------------------------------------------------------------
-# build_expanded_user_message
+# build_multimodal_user_message
 # ---------------------------------------------------------------------------
 
 
 class TestBuildExpandedUserMessage:
-    """Tests for build_expanded_user_message()."""
+    """Tests for build_multimodal_user_message()."""
 
     @pytest.fixture()
     def sample_parts(self) -> list[dict]:
@@ -219,7 +219,7 @@ class TestBuildExpandedUserMessage:
         ]
 
     def test_openai_chat_format(self, sample_parts):
-        msg = build_expanded_user_message(sample_parts, "openai-chat")
+        msg = build_multimodal_user_message(sample_parts, "openai-chat")
         assert msg["role"] == "user"
         content = msg["content"]
         assert isinstance(content, list)
@@ -232,20 +232,20 @@ class TestBuildExpandedUserMessage:
         assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
 
     def test_openai_response_format(self, sample_parts):
-        msg = build_expanded_user_message(sample_parts, "openai-responses")
+        msg = build_multimodal_user_message(sample_parts, "openai-responses")
         assert msg["role"] == "user"
         # Same format as openai-chat
         image_parts = [p for p in msg["content"] if p["type"] == "image_url"]
         assert len(image_parts) == 1
 
     def test_anthropic_format(self, sample_parts):
-        msg = build_expanded_user_message(sample_parts, "anthropic")
+        msg = build_multimodal_user_message(sample_parts, "anthropic")
         assert msg["role"] == "user"
         # Anthropic uses canonical format directly
         assert msg["content"] is sample_parts
 
     def test_gemini_format(self, sample_parts):
-        msg = build_expanded_user_message(sample_parts, "gemini")
+        msg = build_multimodal_user_message(sample_parts, "gemini")
         assert msg["role"] == "user"
         parts = msg["parts"]
         text_parts = [p for p in parts if "text" in p]
@@ -255,7 +255,7 @@ class TestBuildExpandedUserMessage:
         assert image_parts[0]["inline_data"]["mime_type"] == "image/png"
 
     def test_unknown_format_text_fallback(self, sample_parts):
-        msg = build_expanded_user_message(sample_parts, "unknown-api")
+        msg = build_multimodal_user_message(sample_parts, "unknown-api")
         assert msg["role"] == "user"
         assert isinstance(msg["content"], str)
 
@@ -371,19 +371,21 @@ class TestExecuteToolCallsMultimodal:
 
 
 # ---------------------------------------------------------------------------
-# build_tool_response — all formats now use text fallback
+# build_tool_result_messages — all formats now use text fallback
 # ---------------------------------------------------------------------------
 
 
 class TestBuildToolResponseMultimodal:
-    """Tests for build_tool_response() — all formats use text fallback."""
+    """Tests for build_tool_result_messages() — all formats use text fallback."""
 
     @pytest.fixture()
     def multimodal_responses(self) -> dict[str, list]:
         return {"call_1": _make_multimodal_blocks()}
 
     def test_anthropic_uses_text_fallback(self, multimodal_responses):
-        messages = build_tool_response(multimodal_responses, api_format="anthropic")
+        messages = build_tool_result_messages(
+            multimodal_responses, api_format="anthropic"
+        )
         tool_result = messages[0]["content"][0]
         assert tool_result["type"] == "tool_result"
         # Now returns text, not content blocks
@@ -392,14 +394,16 @@ class TestBuildToolResponseMultimodal:
         assert "[Image:" in tool_result["content"]
 
     def test_openai_chat_uses_text_fallback(self, multimodal_responses):
-        messages = build_tool_response(multimodal_responses, api_format="openai-chat")
+        messages = build_tool_result_messages(
+            multimodal_responses, api_format="openai-chat"
+        )
         content = messages[0]["content"]
         assert isinstance(content, str)
         assert "Here is an image:" in content
         assert "[Image:" in content
 
     def test_openai_response_uses_text_fallback(self, multimodal_responses):
-        messages = build_tool_response(
+        messages = build_tool_result_messages(
             multimodal_responses, api_format="openai-responses"
         )
         output = messages[0]["output"]
@@ -410,7 +414,7 @@ class TestBuildToolResponseMultimodal:
         from toolregistry.llm.tool_calls import ToolCall
 
         tc = ToolCall(id="call_1", name="image_tool", arguments="{}")
-        messages = build_tool_response(
+        messages = build_tool_result_messages(
             multimodal_responses, api_format="gemini", tool_calls=[tc]
         )
         output = messages[0]["parts"][0]["functionResponse"]["response"]["output"]
@@ -419,13 +423,13 @@ class TestBuildToolResponseMultimodal:
 
     def test_anthropic_string_result_unchanged(self):
         responses = {"call_1": "plain text result"}
-        messages = build_tool_response(responses, api_format="anthropic")
+        messages = build_tool_result_messages(responses, api_format="anthropic")
         tool_result = messages[0]["content"][0]
         assert tool_result["content"] == "plain text result"
 
     def test_openai_string_result_unchanged(self):
         responses = {"call_1": "plain text result"}
-        messages = build_tool_response(responses, api_format="openai-chat")
+        messages = build_tool_result_messages(responses, api_format="openai-chat")
         assert messages[0]["content"] == "plain text result"
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,8 +6,8 @@ from toolregistry.llm.tool_calls import (
     ResultList,
     ToolCall,
     ToolCallResult,
-    build_assistant_message,
-    build_tool_response,
+    build_assistant_messages,
+    build_tool_result_messages,
     convert_tool_calls,
 )
 
@@ -284,19 +284,19 @@ class TestConvertToolCalls:
 
 
 # ---------------------------------------------------------------------------
-# build_assistant_message
+# build_assistant_messages
 # ---------------------------------------------------------------------------
 
 
 class TestBuildAssistantMessage:
-    """Test cases for the build_assistant_message function."""
+    """Test cases for the build_assistant_messages function."""
 
     def test_openai_chat_format(self):
         tool_calls = [
             ToolCall(id="call_1", name="test_function", arguments='{"param": "value"}')
         ]
 
-        messages = build_assistant_message(tool_calls, api_format="openai-chat")
+        messages = build_assistant_messages(tool_calls, api_format="openai-chat")
 
         assert len(messages) == 1
         assert messages[0]["role"] == "assistant"
@@ -308,7 +308,7 @@ class TestBuildAssistantMessage:
             ToolCall(id="call_1", name="test_function", arguments='{"param": "value"}')
         ]
 
-        messages = build_assistant_message(tool_calls, api_format="openai-responses")
+        messages = build_assistant_messages(tool_calls, api_format="openai-responses")
 
         assert len(messages) == 1
         assert messages[0]["call_id"] == "call_1"
@@ -320,7 +320,7 @@ class TestBuildAssistantMessage:
             ToolCall(id="call_1", name="test_function", arguments='{"param": "value"}')
         ]
 
-        messages = build_assistant_message(tool_calls, api_format="anthropic")
+        messages = build_assistant_messages(tool_calls, api_format="anthropic")
 
         assert len(messages) == 1
         assert messages[0]["role"] == "assistant"
@@ -332,7 +332,7 @@ class TestBuildAssistantMessage:
             ToolCall(id="call_1", name="test_function", arguments='{"param": "value"}')
         ]
 
-        messages = build_assistant_message(tool_calls, api_format="gemini")
+        messages = build_assistant_messages(tool_calls, api_format="gemini")
 
         assert len(messages) == 1
         assert messages[0]["role"] == "model"
@@ -346,7 +346,7 @@ class TestBuildAssistantMessage:
             ToolCall(id="call_3", name="valid2", arguments=""),
         ]
 
-        messages = build_assistant_message(tool_calls, api_format="openai-chat")
+        messages = build_assistant_messages(tool_calls, api_format="openai-chat")
 
         assert len(messages[0]["tool_calls"]) == 1
         assert messages[0]["tool_calls"][0]["id"] == "call_1"
@@ -355,19 +355,19 @@ class TestBuildAssistantMessage:
         tool_calls = [ToolCall(id="call_1", name="test", arguments="{}")]
 
         with pytest.raises(ValueError, match="Unsupported API format"):
-            build_assistant_message(tool_calls, api_format="unsupported")
+            build_assistant_messages(tool_calls, api_format="unsupported")
 
 
 # ---------------------------------------------------------------------------
-# build_tool_response
+# build_tool_result_messages
 # ---------------------------------------------------------------------------
 
 
 class TestBuildToolResponse:
-    """Test cases for the build_tool_response function."""
+    """Test cases for the build_tool_result_messages function."""
 
     def test_openai_chat_format(self):
-        messages = build_tool_response(
+        messages = build_tool_result_messages(
             {"call_1": "Result 1", "call_2": "Result 2"}, api_format="openai-chat"
         )
 
@@ -381,13 +381,15 @@ class TestBuildToolResponse:
         assert "call_2" in call_ids
 
     def test_openai_chat_content(self):
-        messages = build_tool_response({"call_1": "Result"}, api_format="openai-chat")
+        messages = build_tool_result_messages(
+            {"call_1": "Result"}, api_format="openai-chat"
+        )
 
         assert messages[0]["tool_call_id"] == "call_1"
         assert messages[0]["content"] == "Result"
 
     def test_openai_response_format(self):
-        messages = build_tool_response(
+        messages = build_tool_result_messages(
             {"call_1": "Result"}, api_format="openai-responses"
         )
 
@@ -397,7 +399,9 @@ class TestBuildToolResponse:
         assert messages[0]["output"] == "Result"
 
     def test_anthropic_format(self):
-        messages = build_tool_response({"call_1": "result"}, api_format="anthropic")
+        messages = build_tool_result_messages(
+            {"call_1": "result"}, api_format="anthropic"
+        )
 
         assert messages[0]["role"] == "user"
         assert messages[0]["content"][0]["type"] == "tool_result"
@@ -405,7 +409,7 @@ class TestBuildToolResponse:
 
     def test_gemini_format(self):
         tool_calls = [ToolCall(id="call_1", name="my_func", arguments="{}")]
-        messages = build_tool_response(
+        messages = build_tool_result_messages(
             {"call_1": "result"}, api_format="gemini", tool_calls=tool_calls
         )
 
@@ -414,7 +418,7 @@ class TestBuildToolResponse:
         assert messages[0]["parts"][0]["functionResponse"]["name"] == "my_func"
 
     def test_non_string_results_converted(self):
-        messages = build_tool_response(
+        messages = build_tool_result_messages(
             {"call_1": 42, "call_2": {"key": "val"}, "call_3": [1, 2, 3]},
             api_format="openai-chat",
         )
@@ -425,7 +429,7 @@ class TestBuildToolResponse:
 
     def test_unsupported_format_raises_error(self):
         with pytest.raises(ValueError, match="Unsupported API format"):
-            build_tool_response({"call_1": "result"}, api_format="unsupported")
+            build_tool_result_messages({"call_1": "result"}, api_format="unsupported")
 
     def test_empty_responses(self):
-        assert build_tool_response({}, api_format="openai-chat") == []
+        assert build_tool_result_messages({}, api_format="openai-chat") == []

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -433,3 +433,38 @@ class TestBuildToolResponse:
 
     def test_empty_responses(self):
         assert build_tool_result_messages({}, api_format="openai-chat") == []
+
+
+# ---------------------------------------------------------------------------
+# Deprecated aliases
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedAliases:
+    """Verify deprecated function aliases emit DeprecationWarning."""
+
+    def test_build_assistant_message_deprecated(self):
+        from toolregistry.llm.tool_calls import build_assistant_message
+
+        tc = [ToolCall(id="c1", name="fn", arguments='{"x": 1}')]
+        with pytest.warns(DeprecationWarning, match="build_assistant_messages"):
+            build_assistant_message(tc, api_format="openai-chat")
+
+    def test_build_tool_response_deprecated(self):
+        from toolregistry.llm.tool_calls import build_tool_response
+
+        with pytest.warns(DeprecationWarning, match="build_tool_result_messages"):
+            build_tool_response({"c1": "ok"}, api_format="openai-chat")
+
+    def test_expand_content_blocks_deprecated(self):
+        from toolregistry.llm.content_blocks import expand_content_blocks
+
+        with pytest.warns(DeprecationWarning, match="extract_multimodal_content"):
+            expand_content_blocks({"c1": "text"})
+
+    def test_build_expanded_user_message_deprecated(self):
+        from toolregistry.llm.content_blocks import build_expanded_user_message
+
+        parts = [{"type": "text", "text": "hello"}]
+        with pytest.warns(DeprecationWarning, match="build_multimodal_user_message"):
+            build_expanded_user_message(parts, "openai-chat")


### PR DESCRIPTION
## Summary

Rename internal LLM builder functions for consistency and clarity:

| Old | New | Reason |
|-----|-----|--------|
| `build_assistant_message` | `build_assistant_messages` | Returns `list`, use plural |
| `build_tool_response` | `build_tool_result_messages` | Align with rosetta `tool_result` |
| `expand_content_blocks` | `extract_multimodal_content` | Accurate verb |
| `build_expanded_user_message` | `build_multimodal_user_message` | More intuitive |

Old names preserved as deprecated aliases with `DeprecationWarning`.

## Test plan

- [x] `pytest tests/ -v` — 998 passed
- [x] `pre-commit run --all-files` — all hooks pass