### PR TITLE
Add headers parameter to register_from_mcp for auth support

### DIFF
--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -92,6 +92,7 @@ class RegistrationMixin:
         transport: str | dict[str, Any] | Path,
         namespace: bool | str = False,
         persistent: bool = True,
+        headers: dict[str, str] | None = None,
         **kwargs,
     ):
         """Register all tools from an MCP server (synchronous entry point).
@@ -110,6 +111,9 @@ class RegistrationMixin:
                 Defaults to False.
             persistent (bool): If True (default), keep the connection open
                 across tool calls. If False, create a new connection per call.
+            headers (Optional[Dict[str, str]]): HTTP headers to send with
+                SSE or streamable-http requests (e.g. for authentication).
+                Ignored for stdio and WebSocket transports.
 
         Examples:
             ```python
@@ -118,6 +122,12 @@ class RegistrationMixin:
 
             # WebSocket server URL
             registry.register_from_mcp("ws://localhost:9000")
+
+            # With authentication
+            registry.register_from_mcp(
+                "https://api.example.com/mcp",
+                headers={"Authorization": "Bearer token"},
+            )
 
             # Path to Python server script
             registry.register_from_mcp("my_mcp_server.py")
@@ -129,7 +139,7 @@ class RegistrationMixin:
         namespace = _resolve_namespace_compat(namespace, kwargs)
         MCPIntegration = _import_mcp_integration()
         mcp = MCPIntegration(cast("ToolRegistry", self))
-        mcp.register_mcp_tools(transport, namespace, persistent)
+        mcp.register_mcp_tools(transport, namespace, persistent, headers=headers)
         self._mcp_integrations.append(mcp)
 
     async def register_from_mcp_async(
@@ -137,6 +147,7 @@ class RegistrationMixin:
         transport: str | dict[str, Any] | Path,
         namespace: bool | str = False,
         persistent: bool = True,
+        headers: dict[str, str] | None = None,
         **kwargs,
     ):
         """Async implementation to register all tools from an MCP server.
@@ -155,6 +166,9 @@ class RegistrationMixin:
                 Defaults to False.
             persistent (bool): If True (default), keep the connection open
                 across tool calls. If False, create a new connection per call.
+            headers (Optional[Dict[str, str]]): HTTP headers to send with
+                SSE or streamable-http requests (e.g. for authentication).
+                Ignored for stdio and WebSocket transports.
 
         Examples:
             ```python
@@ -163,6 +177,12 @@ class RegistrationMixin:
 
             # WebSocket server URL
             await registry.register_from_mcp_async("ws://localhost:9000")
+
+            # With authentication
+            await registry.register_from_mcp_async(
+                "https://api.example.com/mcp",
+                headers={"Authorization": "Bearer token"},
+            )
 
             # Path to Python server script
             await registry.register_from_mcp_async("my_mcp_server.py")
@@ -174,7 +194,9 @@ class RegistrationMixin:
         namespace = _resolve_namespace_compat(namespace, kwargs)
         MCPIntegration = _import_mcp_integration()
         mcp = MCPIntegration(cast("ToolRegistry", self))
-        await mcp.register_mcp_tools_async(transport, namespace, persistent)
+        await mcp.register_mcp_tools_async(
+            transport, namespace, persistent, headers=headers
+        )
         self._mcp_integrations.append(mcp)
 
     def register_from_openapi(

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -287,6 +287,7 @@ class MCPIntegration:
         transport: str | dict[str, Any] | Path,
         namespace: bool | str = False,
         persistent: bool = True,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Async implementation to register all tools from an MCP server.
 
@@ -302,6 +303,8 @@ class MCPIntegration:
                 Defaults to False.
             persistent (bool): If True (default), keep the connection open
                 across tool calls. If False, create a new connection per call.
+            headers (Optional[Dict[str, str]]): HTTP headers for SSE or
+                streamable-http transports (e.g. authentication).
 
         Raises:
             RuntimeError: If connection to server fails.
@@ -309,11 +312,12 @@ class MCPIntegration:
         connection = MCPConnectionManager(
             transport=transport,
             persistent=persistent,
+            headers=headers,
         )
         self._connections.append(connection)
 
         # Use a temporary connection for tool discovery
-        async with MCPClient(transport) as client:
+        async with MCPClient(transport, headers=headers) as client:
             server_info: Implementation | None = client.server_info
 
             if isinstance(namespace, str):
@@ -341,6 +345,7 @@ class MCPIntegration:
         transport: str | dict[str, Any] | Path,
         namespace: bool | str = False,
         persistent: bool = True,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Register all tools from an MCP server (synchronous entry point).
 
@@ -356,11 +361,15 @@ class MCPIntegration:
                 Defaults to False.
             persistent (bool): If True (default), keep the connection open
                 across tool calls. If False, create a new connection per call.
+            headers (Optional[Dict[str, str]]): HTTP headers for SSE or
+                streamable-http transports (e.g. authentication).
         """
         loop = asyncio.new_event_loop()
         try:
             loop.run_until_complete(
-                self.register_mcp_tools_async(transport, namespace, persistent)
+                self.register_mcp_tools_async(
+                    transport, namespace, persistent, headers=headers
+                )
             )
         finally:
             loop.close()


### PR DESCRIPTION
## Summary

Pass `headers` parameter through the full MCP registration chain for authenticated servers.

Chain: `register_from_mcp(headers=)` → `MCPIntegration.register_mcp_tools(headers=)` → `MCPConnectionManager(headers=)` + `MCPClient(headers=)`

## Usage

```python
registry.register_from_mcp(
    "https://api.example.com/mcp",
    namespace="remote",
    headers={"Authorization": "Bearer token"},
)
```

## Test plan

- [x] 110 existing tests pass
- [ ] Manual test with authenticated remote MCP server

Closes #211 (partial — headers support)