### PR TITLE
fix: persistent MCP connection breaks in sync mode

### DIFF
--- a/src/toolregistry/integrations/mcp/connection.py
+++ b/src/toolregistry/integrations/mcp/connection.py
@@ -1,6 +1,7 @@
 """Persistent connection manager for MCP servers."""
 
 import asyncio
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,11 @@ class MCPConnectionManager:
 
     All tools registered from the same server share this connection.
     Supports lazy connect on first call and auto-reconnect on failure.
+
+    For sync callers, a background daemon thread with its own event loop
+    is lazily created on the first ``call_tool_sync()`` call.  This keeps
+    the loop (and therefore the MCP transport) alive across calls.  Async
+    callers use the caller's own loop and are unaffected.
 
     Args:
         transport: MCP server source (URL, dict, or Path).
@@ -37,6 +43,9 @@ class MCPConnectionManager:
         self._client: MCPClient | None = None
         self._lock = asyncio.Lock()
 
+        self._sync_loop: asyncio.AbstractEventLoop | None = None
+        self._sync_thread: threading.Thread | None = None
+
     @property
     def transport(self) -> str | dict | Path:
         """The transport source for the MCP server."""
@@ -46,6 +55,8 @@ class MCPConnectionManager:
     def is_connected(self) -> bool:
         """Whether an active session exists."""
         return self._client is not None and self._client.is_connected
+
+    # -- Async API (unchanged) --------------------------------------
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         """Call a tool on the MCP server.
@@ -110,15 +121,109 @@ class MCPConnectionManager:
         async with MCPClient(self._transport, self._headers) as client:
             return await client.call_tool(name, arguments)
 
+    # -- Sync API (background loop thread) --------------------------
+
+    def _ensure_sync_loop(self) -> asyncio.AbstractEventLoop:
+        """Start the background event-loop thread if not already running.
+
+        Returns:
+            The persistent event loop running in the daemon thread.
+        """
+        if self._sync_loop is not None and self._sync_loop.is_running():
+            return self._sync_loop
+
+        loop = asyncio.new_event_loop()
+        self._sync_loop = loop
+
+        def _run() -> None:
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        self._sync_thread = t
+        return loop
+
+    def call_tool_sync(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        """Call a tool synchronously using a persistent background loop.
+
+        The first call lazily starts a daemon thread whose event loop
+        keeps MCP transport resources alive across calls.
+
+        Args:
+            name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+
+        Returns:
+            CallToolResult from the MCP server.
+        """
+        loop = self._ensure_sync_loop()
+        future = asyncio.run_coroutine_threadsafe(self.call_tool(name, arguments), loop)
+        return future.result()
+
+    # -- Lifecycle --------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the persistent connection and stop the sync loop thread."""
+        async with self._lock:
+            if self._client is not None:
+                try:
+                    await self._client.__aexit__(None, None, None)
+                except Exception:
+                    pass
+                self._client = None
+        self._stop_sync_loop()
+
+    def close_sync(self) -> None:
+        """Close from sync context — tear down background thread and connection."""
+        loop = self._sync_loop
+        if loop is not None and loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(self._close_client(), loop)
+            try:
+                future.result(timeout=10)
+            except Exception:
+                pass
+        self._stop_sync_loop()
+
+    async def _close_client(self) -> None:
+        """Close the MCP client under lock (runs on the sync loop thread)."""
+        async with self._lock:
+            if self._client is not None:
+                try:
+                    await self._client.__aexit__(None, None, None)
+                except Exception:
+                    pass
+                self._client = None
+
+    def _stop_sync_loop(self) -> None:
+        """Stop the background event loop and join its thread."""
+        loop = self._sync_loop
+        thread = self._sync_thread
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+        if thread is not None:
+            thread.join(timeout=5)
+        if loop is not None and not loop.is_closed():
+            loop.close()
+        self._sync_loop = None
+        self._sync_thread = None
+
+    def __del__(self) -> None:
+        """Best-effort cleanup of the background thread."""
+        try:
+            self._stop_sync_loop()
+        except Exception:
+            pass
+
     # -- Pickling support (for ProcessPoolBackend) ------------------
 
     def __getstate__(self) -> dict:
         """Drop live connection state before pickling.
 
         The config (transport, headers, persistent flag) is preserved.
-        The live ``_client`` (holding OS sockets) and ``_lock``
-        (event-loop-bound) are dropped.  The worker process will
-        reconnect lazily on first ``call_tool()``.
+        The live ``_client`` (holding OS sockets), ``_lock``
+        (event-loop-bound), and sync loop thread are dropped.  The
+        worker process will reconnect lazily on first ``call_tool()``.
         """
         return {
             "_transport": self._transport,
@@ -133,13 +238,5 @@ class MCPConnectionManager:
         self._persistent = state["_persistent"]
         self._client = None
         self._lock = asyncio.Lock()
-
-    async def close(self) -> None:
-        """Close the persistent connection."""
-        async with self._lock:
-            if self._client is not None:
-                try:
-                    await self._client.__aexit__(None, None, None)
-                except Exception:
-                    pass
-                self._client = None
+        self._sync_loop = None
+        self._sync_thread = None

--- a/src/toolregistry/integrations/mcp/connection.py
+++ b/src/toolregistry/integrations/mcp/connection.py
@@ -45,6 +45,7 @@ class MCPConnectionManager:
 
         self._sync_loop: asyncio.AbstractEventLoop | None = None
         self._sync_thread: threading.Thread | None = None
+        self._sync_init_lock = threading.Lock()
 
     @property
     def transport(self) -> str | dict | Path:
@@ -126,23 +127,29 @@ class MCPConnectionManager:
     def _ensure_sync_loop(self) -> asyncio.AbstractEventLoop:
         """Start the background event-loop thread if not already running.
 
+        Thread-safe: concurrent callers will not create duplicate loops.
+
         Returns:
             The persistent event loop running in the daemon thread.
         """
         if self._sync_loop is not None and self._sync_loop.is_running():
             return self._sync_loop
 
-        loop = asyncio.new_event_loop()
-        self._sync_loop = loop
+        with self._sync_init_lock:
+            if self._sync_loop is not None and self._sync_loop.is_running():
+                return self._sync_loop
 
-        def _run() -> None:
-            asyncio.set_event_loop(loop)
-            loop.run_forever()
+            loop = asyncio.new_event_loop()
+            self._sync_loop = loop
 
-        t = threading.Thread(target=_run, daemon=True)
-        t.start()
-        self._sync_thread = t
-        return loop
+            def _run() -> None:
+                asyncio.set_event_loop(loop)
+                loop.run_forever()
+
+            t = threading.Thread(target=_run, daemon=True)
+            t.start()
+            self._sync_thread = t
+            return loop
 
     def call_tool_sync(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         """Call a tool synchronously using a persistent background loop.

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -53,6 +53,22 @@ class MCPToolWrapper(BaseToolWrapper):
         """Transport source, for backward compatibility."""
         return self._connection.transport
 
+    def _validate_and_extract(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Validate name and extract parameters from args/kwargs.
+
+        Shared by both ``call_sync`` and ``call_async`` to ensure
+        identical parameter handling.
+        """
+        if not self.name:
+            raise ValueError("Tool name must be set before calling")
+        kwargs = self._process_args(*args, **kwargs)
+        validated: dict[str, Any] = {}
+        if self.params:
+            for param_name in self.params:
+                if param_name in kwargs:
+                    validated[param_name] = kwargs[param_name]
+        return validated
+
     def call_sync(self, *args: Any, **kwargs: Any) -> Any:
         """Synchronous implementation of MCP tool call.
 
@@ -71,18 +87,17 @@ class MCPToolWrapper(BaseToolWrapper):
             ValueError: If name not set.
             Exception: If tool execution fails.
         """
-        if not self.name:
-            raise ValueError("Tool name must be set before calling")
+        try:
+            validated_params = self._validate_and_extract(*args, **kwargs)
+            result = self._connection.call_tool_sync(self.name, validated_params)
+            return self._post_process_result(result)
+        except Exception:
+            import traceback
 
-        kwargs = self._process_args(*args, **kwargs)
-        validated_params: dict[str, Any] = {}
-        if self.params:
-            for param_name in self.params:
-                if param_name in kwargs:
-                    validated_params[param_name] = kwargs[param_name]
-
-        result = self._connection.call_tool_sync(self.name, validated_params)
-        return self._post_process_result(result)
+            logger.error(
+                f"Original Exception happens at {self.name}:\n{traceback.format_exc()}"
+            )
+            raise
 
     async def call_async(self, *args: Any, **kwargs: Any) -> Any:
         """Async implementation of MCP tool call.
@@ -99,19 +114,9 @@ class MCPToolWrapper(BaseToolWrapper):
             Exception: If tool execution fails.
         """
         try:
-            if not self.name:
-                raise ValueError("Tool name must be set before calling")
-
-            validated_params: dict[str, Any] = {}
-            kwargs = self._process_args(*args, **kwargs)
-            if self.params:
-                for param_name in self.params:
-                    if param_name in kwargs:
-                        validated_params[param_name] = kwargs[param_name]
-
+            validated_params = self._validate_and_extract(*args, **kwargs)
             result = await self._connection.call_tool(self.name, validated_params)
             return self._post_process_result(result)
-
         except Exception:
             import traceback
 

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -56,6 +56,10 @@ class MCPToolWrapper(BaseToolWrapper):
     def call_sync(self, *args: Any, **kwargs: Any) -> Any:
         """Synchronous implementation of MCP tool call.
 
+        Delegates to the connection manager's ``call_tool_sync`` which
+        runs the coroutine on a persistent background event loop,
+        keeping the MCP transport alive across calls.
+
         Args:
             args (Any): Positional arguments to pass to the tool.
             kwargs (Any): Keyword arguments to pass to the tool.
@@ -64,16 +68,21 @@ class MCPToolWrapper(BaseToolWrapper):
             Any: Result from tool execution.
 
         Raises:
-            ValueError: If URL or name not set.
+            ValueError: If name not set.
             Exception: If tool execution fails.
         """
-        kwargs = self._process_args(*args, **kwargs)
+        if not self.name:
+            raise ValueError("Tool name must be set before calling")
 
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(self.call_async(**kwargs))
-        finally:
-            loop.close()
+        kwargs = self._process_args(*args, **kwargs)
+        validated_params: dict[str, Any] = {}
+        if self.params:
+            for param_name in self.params:
+                if param_name in kwargs:
+                    validated_params[param_name] = kwargs[param_name]
+
+        result = self._connection.call_tool_sync(self.name, validated_params)
+        return self._post_process_result(result)
 
     async def call_async(self, *args: Any, **kwargs: Any) -> Any:
         """Async implementation of MCP tool call.
@@ -375,7 +384,17 @@ class MCPIntegration:
             loop.close()
 
     async def close(self) -> None:
-        """Close all persistent connections."""
+        """Close all persistent connections (async)."""
         for connection in self._connections:
             await connection.close()
+        self._connections.clear()
+
+    def close_sync(self) -> None:
+        """Close all persistent connections (sync).
+
+        Shuts down background loop threads without requiring an
+        event loop in the calling thread.
+        """
+        for connection in self._connections:
+            connection.close_sync()
         self._connections.clear()

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import random
@@ -209,11 +208,12 @@ class ToolRegistry(
 
     def close(self) -> None:
         """Close all persistent connections (sync)."""
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(self.close_async())
-        finally:
-            loop.close()
+        for integration in self._mcp_integrations:
+            integration.close_sync()
+        self._mcp_integrations.clear()
+        for integration in self._openapi_integrations:
+            integration.close()
+        self._openapi_integrations.clear()
 
     async def __aenter__(self) -> "ToolRegistry":
         return self

--- a/tests/test_persistent_connection.py
+++ b/tests/test_persistent_connection.py
@@ -290,3 +290,126 @@ class TestToolRegistryMCPIntegration:
         assert len(reg._mcp_integrations) == 1
         await reg.close_async()
         assert len(reg._mcp_integrations) == 0
+
+
+# ---------------------------------------------------------------------------
+# Sync-mode persistent connection tests (issue #211)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPConnectionManagerSyncLoop:
+    """Tests for the background event loop thread used by sync callers."""
+
+    def test_sync_loop_starts_lazily(self):
+        """Background thread should not exist until call_tool_sync is used."""
+        mgr = MCPConnectionManager("http://localhost:9999/mcp")
+        assert mgr._sync_loop is None
+        assert mgr._sync_thread is None
+
+    def test_close_sync_without_loop(self):
+        """close_sync() should be safe when no sync loop was started."""
+        mgr = MCPConnectionManager("http://localhost:9999/mcp")
+        mgr.close_sync()
+
+    def test_sync_multiple_calls_reuse_connection(self):
+        """Sync tool calls should reuse the persistent connection (no reconnect)."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        mgr = MCPConnectionManager(config, persistent=True)
+        try:
+            r1 = mgr.call_tool_sync("add", {"a": 1, "b": 2})
+            assert mgr._sync_loop is not None
+            assert mgr._sync_thread is not None
+            assert mgr._sync_thread.is_alive()
+            assert mgr.is_connected
+
+            r2 = mgr.call_tool_sync("add", {"a": 10, "b": 20})
+            assert mgr.is_connected
+
+            assert json.loads(r1.content[0].text) == {"result": 3}
+            assert json.loads(r2.content[0].text) == {"result": 30}
+        finally:
+            mgr.close_sync()
+
+        assert mgr._sync_loop is None
+        assert mgr._sync_thread is None
+
+    def test_close_sync_stops_thread(self):
+        """close_sync() should stop the background thread and close the loop."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        mgr = MCPConnectionManager(config, persistent=True)
+        mgr.call_tool_sync("echo", {"message": "hi"})
+        thread = mgr._sync_thread
+        assert thread is not None and thread.is_alive()
+
+        mgr.close_sync()
+        assert not thread.is_alive()
+        assert mgr._sync_loop is None
+
+    def test_pickling_drops_sync_loop(self):
+        """Pickle round-trip should drop sync loop state."""
+        import pickle
+
+        mgr = MCPConnectionManager("http://localhost:9999/mcp")
+        data = pickle.dumps(mgr)
+        restored = pickle.loads(data)
+        assert restored._sync_loop is None
+        assert restored._sync_thread is None
+
+
+class TestToolRegistrySyncMCPIntegration:
+    """End-to-end sync-mode MCP integration tests (issue #211)."""
+
+    def test_sync_register_and_call(self):
+        """register_from_mcp + invoke should work without reconnecting."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(config, persistent=True)
+            assert "add" in reg
+            assert "echo" in reg
+
+            r1 = reg.invoke("add", {"a": 5, "b": 3})
+            r2 = reg.invoke("add", {"a": 10, "b": 1})
+            assert r1 == '{"result": 8}'
+            assert r2 == '{"result": 11}'
+
+    def test_sync_register_non_persistent(self):
+        """Non-persistent mode should still work in sync."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(config, persistent=False)
+            assert "echo" in reg
+            result = reg.invoke("echo", {"message": "hello"})
+            assert result == "hello"
+
+    def test_sync_close_cleans_up(self):
+        """close() should clean up MCP integrations and background threads."""
+        config = {
+            "command": sys.executable,
+            "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+        }
+        reg = ToolRegistry()
+        reg.register_from_mcp(config, persistent=True)
+        assert len(reg._mcp_integrations) == 1
+
+        reg.invoke("echo", {"message": "test"})
+
+        connections = list(reg._mcp_integrations[0]._connections)
+        threads = [c._sync_thread for c in connections if c._sync_thread]
+        assert len(threads) > 0
+
+        reg.close()
+        assert len(reg._mcp_integrations) == 0
+        for t in threads:
+            assert not t.is_alive()


### PR DESCRIPTION
Closes #211

## Summary

- `MCPConnectionManager` now lazily starts a daemon thread with a persistent event loop on first `call_tool_sync()` call, keeping the MCP transport alive across sync calls
- `MCPToolWrapper.call_sync()` delegates to `connection.call_tool_sync()` instead of creating/destroying ephemeral event loops
- `ToolRegistry.close()` uses `close_sync()` path for MCP integrations — no ephemeral loop needed
- Async callers are completely unaffected (no thread overhead)

## Root cause

Each sync tool call created `asyncio.new_event_loop()`, ran the coroutine, then closed the loop. The persistent `MCPConnectionManager` held async resources (Lock, MCPClient streams) bound to the registration loop. When that loop closed, the connection died → every subsequent call triggered a full MCP server reconnect.

## Test plan

- [x] 8 new sync-mode tests covering connection reuse, thread lifecycle, cleanup, and pickling
- [x] Full test suite passes (1010/1010)