### PR TITLE
feat(executor): InlineBackend + ExecutionHandle.result_async() (#223)

### DIFF
--- a/src/toolregistry/executor/__init__.py
+++ b/src/toolregistry/executor/__init__.py
@@ -4,6 +4,7 @@ This package has ZERO imports from toolregistry internals.
 It operates exclusively on ``Callable + dict`` arguments.
 """
 
+from ._inline_backend import InlineBackend
 from ._process_backend import ProcessPoolBackend
 from ._protocol import ExecutionBackend, ExecutionHandle
 from ._thread_backend import ThreadBackend
@@ -24,6 +25,7 @@ __all__ = [
     "ExecutionBackend",
     "ExecutionHandle",
     # Backends
+    "InlineBackend",
     "ProcessPoolBackend",
     "ThreadBackend",
 ]

--- a/src/toolregistry/executor/_inline_backend.py
+++ b/src/toolregistry/executor/_inline_backend.py
@@ -1,0 +1,113 @@
+"""Inline execution backend that runs the target in the current context."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+from collections.abc import Callable
+
+from ._helpers import should_inject_context
+from ._protocol import ExecutionHandle
+from ._types import (
+    CancelledError,
+    ExecutionContext,
+    HandleStatus,
+    ProgressReport,
+)
+
+
+class InlineExecutionHandle(ExecutionHandle):
+    """Handle wrapping an already-completed inline execution.
+
+    ``InlineBackend.submit`` runs the callable eagerly, so the handle
+    is created in a terminal state carrying either a captured return
+    value or a captured exception.
+    """
+
+    def __init__(
+        self,
+        exec_id: str,
+        value: Any = None,
+        exception: BaseException | None = None,
+    ) -> None:
+        self._exec_id = exec_id
+        self._value = value
+        self._exception = exception
+
+    @property
+    def execution_id(self) -> str:
+        return self._exec_id
+
+    def cancel(self) -> bool:
+        # Execution already finished by the time the handle exists.
+        return False
+
+    def status(self) -> HandleStatus:
+        if isinstance(self._exception, CancelledError):
+            return HandleStatus.CANCELLED
+        if self._exception is not None:
+            return HandleStatus.FAILED
+        return HandleStatus.COMPLETED
+
+    def result(self, timeout: float | None = None) -> Any:
+        if self._exception is not None:
+            raise self._exception
+        return self._value
+
+    async def result_async(self, timeout: float | None = None) -> Any:
+        if self._exception is not None:
+            raise self._exception
+        return self._value
+
+    def on_progress(self, callback: Callable[[ProgressReport], None]) -> None:
+        # Inline execution has already finished; no progress to report.
+        pass
+
+
+class InlineBackend:
+    """Execution backend that runs the callable in the current context.
+
+    No thread or process pool is used — the target runs eagerly and
+    synchronously in the calling thread.  This is the "no isolation"
+    backend suited to tools that are already isolated elsewhere
+    (e.g. MCP servers, remote HTTP APIs), where pooling or pickling
+    the target would be wrong or impossible.
+    """
+
+    def submit(
+        self,
+        fn: Callable[..., Any],
+        kwargs: dict[str, Any],
+        *,
+        execution_id: str | None = None,
+        timeout: float | None = None,
+    ) -> ExecutionHandle:
+        exec_id = execution_id or uuid.uuid4().hex
+
+        # Wrap bare async functions so they can run inline.  Tool
+        # wrappers (BaseToolWrapper) handle sync/async internally, so
+        # only wrap bare async callables passed directly.
+        raw_fn = getattr(fn, "fn", fn)
+        if asyncio.iscoroutinefunction(raw_fn) and not hasattr(fn, "call_sync"):
+            async_fn = fn
+
+            def _sync_wrapper(**kw):  # type: ignore[no-untyped-def]
+                return asyncio.run(async_fn(**kw))
+
+            fn = _sync_wrapper
+
+        # Context injection
+        if should_inject_context(fn):
+            ctx = ExecutionContext()
+            kwargs = {**kwargs, "_ctx": ctx}
+
+        try:
+            value = fn(**kwargs)
+        except BaseException as exc:  # noqa: BLE001 - captured, re-raised on result()
+            return InlineExecutionHandle(exec_id, exception=exc)
+        return InlineExecutionHandle(exec_id, value=value)
+
+    def shutdown(self, wait: bool = True) -> None:
+        # Nothing to release — inline execution owns no pool.
+        pass

--- a/src/toolregistry/executor/_inline_backend.py
+++ b/src/toolregistry/executor/_inline_backend.py
@@ -73,6 +73,15 @@ class InlineBackend:
     backend suited to tools that are already isolated elsewhere
     (e.g. MCP servers, remote HTTP APIs), where pooling or pickling
     the target would be wrong or impossible.
+
+    Note:
+        A *bare* async callable (one without a ``call_sync`` method) is
+        driven via ``asyncio.run``, which cannot run while an event loop
+        is already active in the calling thread.  Submitting such a
+        callable from inside a running loop raises ``RuntimeError`` with
+        a clear message — call the coroutine's async path directly
+        instead.  Tool wrappers (``BaseToolWrapper``) expose
+        ``call_sync``/``call_async`` and are unaffected.
     """
 
     def submit(
@@ -83,6 +92,9 @@ class InlineBackend:
         execution_id: str | None = None,
         timeout: float | None = None,
     ) -> ExecutionHandle:
+        # ``timeout`` is part of the backend interface but has no effect
+        # here: inline execution is eager and synchronous, so there is
+        # no pending future to time out against.
         exec_id = execution_id or uuid.uuid4().hex
 
         # Wrap bare async functions so they can run inline.  Tool
@@ -93,7 +105,16 @@ class InlineBackend:
             async_fn = fn
 
             def _sync_wrapper(**kw):  # type: ignore[no-untyped-def]
-                return asyncio.run(async_fn(**kw))
+                try:
+                    asyncio.get_running_loop()
+                except RuntimeError:
+                    return asyncio.run(async_fn(**kw))
+                raise RuntimeError(
+                    "InlineBackend cannot run a bare async callable while an "
+                    "event loop is already running in this thread. Await the "
+                    "coroutine directly (e.g. via the tool's async path) "
+                    "instead of submitting it to InlineBackend."
+                )
 
             fn = _sync_wrapper
 

--- a/src/toolregistry/executor/_process_backend.py
+++ b/src/toolregistry/executor/_process_backend.py
@@ -87,6 +87,16 @@ class ProcessExecutionHandle(ExecutionHandle):
         except FuturesTimeoutError as e:
             raise TimeoutError(str(e)) from e
 
+    async def result_async(self, timeout: float | None = None) -> Any:
+        effective_timeout = timeout if timeout is not None else self._timeout
+        fut = asyncio.wrap_future(self._future)
+        try:
+            if effective_timeout is not None:
+                return await asyncio.wait_for(fut, effective_timeout)
+            return await fut
+        except (asyncio.TimeoutError, FuturesTimeoutError) as e:
+            raise TimeoutError(str(e)) from e
+
     def on_progress(self, callback: Callable[[ProgressReport], None]) -> None:
         # Process backend does not support progress reporting.
         pass

--- a/src/toolregistry/executor/_protocol.py
+++ b/src/toolregistry/executor/_protocol.py
@@ -38,6 +38,22 @@ class ExecutionHandle(abc.ABC):
         ...
 
     @abc.abstractmethod
+    async def result_async(self, timeout: float | None = None) -> Any:
+        """Await the result without blocking the event loop.
+
+        Async counterpart to :meth:`result`.  Lets an async caller
+        drive any backend (thread, process, inline) by bridging the
+        underlying ``concurrent.futures.Future`` via
+        ``asyncio.wrap_future``.
+
+        Raises:
+            TimeoutError: If timeout expires before completion.
+            CancelledError: If the execution was cancelled.
+            Exception: If the execution raised an exception.
+        """
+        ...
+
+    @abc.abstractmethod
     def on_progress(self, callback: Callable[[ProgressReport], None]) -> None:
         """Register a callback for progress updates."""
         ...

--- a/src/toolregistry/executor/_thread_backend.py
+++ b/src/toolregistry/executor/_thread_backend.py
@@ -70,6 +70,16 @@ class ThreadExecutionHandle(ExecutionHandle):
         except FuturesTimeoutError as e:
             raise TimeoutError(str(e)) from e
 
+    async def result_async(self, timeout: float | None = None) -> Any:
+        effective_timeout = timeout if timeout is not None else self._timeout
+        fut = asyncio.wrap_future(self._future)
+        try:
+            if effective_timeout is not None:
+                return await asyncio.wait_for(fut, effective_timeout)
+            return await fut
+        except (asyncio.TimeoutError, FuturesTimeoutError) as e:
+            raise TimeoutError(str(e)) from e
+
     def on_progress(self, callback: Callable[[ProgressReport], None]) -> None:
         if self._ctx is not None:
             self._ctx._add_progress_listener(callback)

--- a/tests/test_executor/test_handle_result_async.py
+++ b/tests/test_executor/test_handle_result_async.py
@@ -1,0 +1,105 @@
+"""Tests for ExecutionHandle.result_async() across all backends."""
+
+import asyncio
+import time
+
+import pytest
+
+from toolregistry.executor import (
+    InlineBackend,
+    ProcessPoolBackend,
+    ThreadBackend,
+)
+
+
+def _add(x: int, y: int) -> int:
+    return x + y
+
+
+def _fail() -> None:
+    raise ValueError("boom")
+
+
+def _slow() -> str:
+    time.sleep(10)
+    return "done"
+
+
+class TestResultAsync:
+    @pytest.mark.asyncio
+    async def test_thread_result_async(self):
+        backend = ThreadBackend(max_workers=2)
+        try:
+            handle = backend.submit(_add, {"x": 3, "y": 4})
+            assert await handle.result_async() == 7
+        finally:
+            backend.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_process_result_async(self):
+        backend = ProcessPoolBackend(max_workers=2)
+        try:
+            handle = backend.submit(_add, {"x": 10, "y": 20})
+            assert await handle.result_async() == 30
+        finally:
+            backend.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_inline_result_async(self):
+        backend = InlineBackend()
+        handle = backend.submit(_add, {"x": 1, "y": 2})
+        assert await handle.result_async() == 3
+
+    @pytest.mark.asyncio
+    async def test_thread_result_async_propagates_exception(self):
+        backend = ThreadBackend(max_workers=2)
+        try:
+            handle = backend.submit(_fail, {})
+            with pytest.raises(ValueError, match="boom"):
+                await handle.result_async()
+        finally:
+            backend.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_inline_result_async_propagates_exception(self):
+        backend = InlineBackend()
+        handle = backend.submit(_fail, {})
+        with pytest.raises(ValueError, match="boom"):
+            await handle.result_async()
+
+    @pytest.mark.asyncio
+    async def test_thread_result_async_timeout(self):
+        backend = ThreadBackend(max_workers=2)
+        try:
+            handle = backend.submit(_slow, {}, timeout=0.05)
+            with pytest.raises(TimeoutError):
+                await handle.result_async()
+        finally:
+            backend.shutdown(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_result_async_does_not_block_loop(self):
+        """Two overlapping thread submits both complete under gather.
+
+        If result_async blocked the event loop, the total wall time
+        would be ~2x a single sleep; gathered it should be ~1x.
+        """
+        backend = ThreadBackend(max_workers=4)
+        try:
+
+            def sleeper(n: int) -> int:
+                time.sleep(0.2)
+                return n
+
+            h1 = backend.submit(sleeper, {"n": 1})
+            h2 = backend.submit(sleeper, {"n": 2})
+
+            start = time.perf_counter()
+            results = await asyncio.gather(h1.result_async(), h2.result_async())
+            elapsed = time.perf_counter() - start
+
+            assert set(results) == {1, 2}
+            # Concurrent execution: well under the 0.4s serial lower bound.
+            assert elapsed < 0.35
+        finally:
+            backend.shutdown()

--- a/tests/test_executor/test_handle_result_async.py
+++ b/tests/test_executor/test_handle_result_async.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from collections.abc import Iterator
 
 import pytest
 
@@ -25,57 +26,52 @@ def _slow() -> str:
     return "done"
 
 
+def _make_backend(name: str):
+    if name == "thread":
+        return ThreadBackend(max_workers=2)
+    if name == "process":
+        return ProcessPoolBackend(max_workers=2)
+    return InlineBackend()
+
+
+@pytest.fixture(params=["thread", "process", "inline"])
+def backend(request) -> Iterator:
+    b = _make_backend(request.param)
+    try:
+        yield b
+    finally:
+        b.shutdown(wait=False)
+
+
+# Pool-only backends: those with a pending future that a timeout can
+# race against. InlineBackend runs eagerly/synchronously, so there is
+# no future to time out.
+@pytest.fixture(params=["thread", "process"])
+def pool_backend(request) -> Iterator:
+    b = _make_backend(request.param)
+    try:
+        yield b
+    finally:
+        b.shutdown(wait=False)
+
+
 class TestResultAsync:
     @pytest.mark.asyncio
-    async def test_thread_result_async(self):
-        backend = ThreadBackend(max_workers=2)
-        try:
-            handle = backend.submit(_add, {"x": 3, "y": 4})
-            assert await handle.result_async() == 7
-        finally:
-            backend.shutdown()
+    async def test_result_async_returns_value(self, backend):
+        handle = backend.submit(_add, {"x": 3, "y": 4})
+        assert await handle.result_async() == 7
 
     @pytest.mark.asyncio
-    async def test_process_result_async(self):
-        backend = ProcessPoolBackend(max_workers=2)
-        try:
-            handle = backend.submit(_add, {"x": 10, "y": 20})
-            assert await handle.result_async() == 30
-        finally:
-            backend.shutdown()
-
-    @pytest.mark.asyncio
-    async def test_inline_result_async(self):
-        backend = InlineBackend()
-        handle = backend.submit(_add, {"x": 1, "y": 2})
-        assert await handle.result_async() == 3
-
-    @pytest.mark.asyncio
-    async def test_thread_result_async_propagates_exception(self):
-        backend = ThreadBackend(max_workers=2)
-        try:
-            handle = backend.submit(_fail, {})
-            with pytest.raises(ValueError, match="boom"):
-                await handle.result_async()
-        finally:
-            backend.shutdown()
-
-    @pytest.mark.asyncio
-    async def test_inline_result_async_propagates_exception(self):
-        backend = InlineBackend()
+    async def test_result_async_propagates_exception(self, backend):
         handle = backend.submit(_fail, {})
         with pytest.raises(ValueError, match="boom"):
             await handle.result_async()
 
     @pytest.mark.asyncio
-    async def test_thread_result_async_timeout(self):
-        backend = ThreadBackend(max_workers=2)
-        try:
-            handle = backend.submit(_slow, {}, timeout=0.05)
-            with pytest.raises(TimeoutError):
-                await handle.result_async()
-        finally:
-            backend.shutdown(wait=False)
+    async def test_result_async_timeout(self, pool_backend):
+        handle = pool_backend.submit(_slow, {}, timeout=0.05)
+        with pytest.raises(TimeoutError):
+            await handle.result_async()
 
     @pytest.mark.asyncio
     async def test_result_async_does_not_block_loop(self):

--- a/tests/test_executor/test_inline_backend.py
+++ b/tests/test_executor/test_inline_backend.py
@@ -1,0 +1,90 @@
+"""Tests for InlineBackend."""
+
+import pytest
+
+from toolregistry.executor import (
+    ExecutionContext,
+    HandleStatus,
+    InlineBackend,
+)
+
+
+class TestInlineBackend:
+    def test_submit_sync_function(self):
+        backend = InlineBackend()
+
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        handle = backend.submit(add, {"x": 3, "y": 4})
+        assert handle.result() == 7
+        assert handle.status() == HandleStatus.COMPLETED
+
+    def test_submit_async_function(self):
+        backend = InlineBackend()
+
+        async def add(x: int, y: int) -> int:
+            return x + y
+
+        handle = backend.submit(add, {"x": 5, "y": 6})
+        assert handle.result() == 11
+
+    def test_context_injection(self):
+        backend = InlineBackend()
+
+        def work(x: int, _ctx: ExecutionContext) -> str:
+            return f"got {x}, ctx={_ctx is not None}"
+
+        handle = backend.submit(work, {"x": 42})
+        assert handle.result() == "got 42, ctx=True"
+
+    def test_status_failed_and_result_reraises(self):
+        backend = InlineBackend()
+
+        def fail() -> None:
+            raise ValueError("boom")
+
+        handle = backend.submit(fail, {})
+        assert handle.status() == HandleStatus.FAILED
+        with pytest.raises(ValueError, match="boom"):
+            handle.result()
+
+    def test_cancel_returns_false(self):
+        backend = InlineBackend()
+        handle = backend.submit(lambda: 1, {})
+        assert handle.cancel() is False
+
+    def test_on_progress_noop(self):
+        backend = InlineBackend()
+        handle = backend.submit(lambda: 1, {})
+        # Should not raise even though inline has no progress support.
+        handle.on_progress(lambda r: None)
+        assert handle.result() == 1
+
+    def test_execution_id_provided(self):
+        backend = InlineBackend()
+        handle = backend.submit(lambda: 1, {}, execution_id="my-id")
+        assert handle.execution_id == "my-id"
+
+    def test_execution_id_generated(self):
+        backend = InlineBackend()
+        handle = backend.submit(lambda: 1, {})
+        assert len(handle.execution_id) > 0
+
+    def test_runs_in_calling_thread(self):
+        import threading
+
+        backend = InlineBackend()
+        caller_thread = threading.get_ident()
+        captured: dict[str, int] = {}
+
+        def work() -> int:
+            captured["thread"] = threading.get_ident()
+            return 1
+
+        backend.submit(work, {}).result()
+        assert captured["thread"] == caller_thread
+
+    def test_shutdown_noop(self):
+        backend = InlineBackend()
+        backend.shutdown()  # should not raise

--- a/tests/test_executor/test_inline_backend.py
+++ b/tests/test_executor/test_inline_backend.py
@@ -88,3 +88,31 @@ class TestInlineBackend:
     def test_shutdown_noop(self):
         backend = InlineBackend()
         backend.shutdown()  # should not raise
+
+    def test_bare_async_from_sync_context_runs(self):
+        """A bare async callable runs fine when no loop is active."""
+        backend = InlineBackend()
+
+        async def double(x: int) -> int:
+            return x * 2
+
+        handle = backend.submit(double, {"x": 21})
+        assert handle.result() == 42
+
+    @pytest.mark.asyncio
+    async def test_bare_async_from_running_loop_raises_clear_error(self):
+        """Submitting a bare async callable inside a running loop raises.
+
+        InlineBackend drives bare coroutines via ``asyncio.run``, which
+        cannot run under an active loop.  It should fail fast with a
+        clear message rather than an opaque RuntimeError.
+        """
+        backend = InlineBackend()
+
+        async def double(x: int) -> int:
+            return x * 2
+
+        # The exception is captured at submit and re-raised on result().
+        handle = backend.submit(double, {"x": 21})
+        with pytest.raises(RuntimeError, match="event loop is already running"):
+            handle.result()


### PR DESCRIPTION
## Summary

Phase 1 of the execution-stack refactor (#222). **Additive only — zero behavior change.** Adds two executor primitives that later phases wire `invoke`/`execute` onto.

- **`InlineBackend` + `InlineExecutionHandle`** (`executor/_inline_backend.py`): runs the target eagerly in the current context with no pool, returning a completed handle. This is the "no isolation" backend for tools already isolated elsewhere (MCP servers, remote HTTP) where pooling/pickling the target is wrong or impossible.
- **`ExecutionHandle.result_async()`**: async result retrieval via `asyncio.wrap_future()`, so an async caller can await a thread/process backend without blocking the loop. Added to the ABC (`_protocol.py`) and all three backends; inline returns its captured value directly.

Both reuse the existing `should_inject_context()` helper and the bare-async-fn guard already used by the thread/process backends, so behavior parity is preserved.

Closes #223.

## Test plan

- [x] `tests/test_executor/test_inline_backend.py` — sync value, exception re-raise, `_ctx` injection, bare-async wrapping, cancel=False, on_progress no-op, runs-in-calling-thread, execution_id
- [x] `tests/test_executor/test_handle_result_async.py` — await returns value (thread/process/inline), exception propagation, timeout→TimeoutError, non-blocking under `gather`
- [x] Full suite: **1052 passed** (additive-only, no regressions)
- [x] `pre-commit run` — ruff, ruff-format, ty, complexipy all pass

## Context

Part of the phased refactor tracked in #222 → #223/#224/#225. AI was used to assist with implementation.