### PR TITLE
feat(registry): invoke/ainvoke through backend seam, return Result types (#224)

### DIFF
--- a/src/toolregistry/_mixins/permissions.py
+++ b/src/toolregistry/_mixins/permissions.py
@@ -100,27 +100,31 @@ class PermissionsMixin:
         will be performed on tool calls until a new policy is set."""
         self._permission_policy = None
 
-    def _resolve_permission(
+    def _evaluate_policy(
         self,
         tool: Tool,
         parameters: dict[str, Any],
-    ) -> PermissionResult:
-        """Evaluate the permission policy for a single tool call.
+    ) -> tuple[PermissionResult, Any, Any]:
+        """Evaluate the policy up to (but not including) handler dispatch.
 
-        Returns ``ALLOW`` when no policy is configured.
+        Emits the ``PERMISSION_DENIED`` / ``PERMISSION_ASKED`` events and
+        returns a tuple ``(result, handler, request)``:
 
-        Resolution order for ASK results:
-            1. Policy-level handler
-            2. Registry-level handler (``set_permission_handler``)
-            3. Policy fallback / registry fallback
+        - For ``ALLOW`` / ``DENY`` / a resolved fallback, ``result`` is a
+          terminal :class:`PermissionResult` and ``handler``/``request``
+          are ``None``.
+        - For ``ASK`` with a handler configured, ``result`` is ``ASK`` and
+          ``handler``/``request`` are populated so the caller can dispatch
+          synchronously or asynchronously.
+
+        Shared by :meth:`_resolve_permission` and
+        :meth:`_aresolve_permission` so the policy logic stays in one place.
         """
-        import asyncio
-
         from ..events import ChangeEvent, ChangeEventType
 
         policy = self._permission_policy
         if policy is None:
-            return PermissionResult.ALLOW
+            return PermissionResult.ALLOW, None, None
 
         outcome = policy.evaluate(tool, parameters)
 
@@ -137,7 +141,7 @@ class PermissionsMixin:
             reason = rule.reason
 
         if result == PermissionResult.ALLOW:
-            return PermissionResult.ALLOW
+            return PermissionResult.ALLOW, None, None
 
         if result == PermissionResult.DENY:
             self._emit_change(
@@ -148,7 +152,7 @@ class PermissionsMixin:
                     metadata={"rule_name": rule_name, "parameters": parameters},
                 )
             )
-            return PermissionResult.DENY
+            return PermissionResult.DENY, None, None
 
         # result == ASK — resolve via handler
         handler = policy.handler or self._permission_handler
@@ -174,11 +178,31 @@ class PermissionsMixin:
                 if policy.fallback != PermissionResult.ASK
                 else self._permission_fallback
             )
-            return fallback
+            return fallback, None, None
 
+        return PermissionResult.ASK, handler, request
+
+    def _resolve_permission(
+        self,
+        tool: Tool,
+        parameters: dict[str, Any],
+    ) -> PermissionResult:
+        """Evaluate the permission policy for a single tool call.
+
+        Returns ``ALLOW`` when no policy is configured.
+
+        Resolution order for ASK results:
+            1. Policy-level handler
+            2. Registry-level handler (``set_permission_handler``)
+            3. Policy fallback / registry fallback
+        """
+        import asyncio
         import inspect
-
         from typing import cast
+
+        result, handler, request = self._evaluate_policy(tool, parameters)
+        if result != PermissionResult.ASK or handler is None:
+            return result
 
         if inspect.iscoroutinefunction(handler.handle):
             try:
@@ -191,6 +215,32 @@ class PermissionsMixin:
                     ).result()
             except RuntimeError:
                 decision = asyncio.run(handler.handle(request))
+        else:
+            decision = handler.handle(request)
+
+        return cast(PermissionResult, decision)
+
+    async def _aresolve_permission(
+        self,
+        tool: Tool,
+        parameters: dict[str, Any],
+    ) -> PermissionResult:
+        """Async variant of :meth:`_resolve_permission`.
+
+        Awaits an :class:`AsyncPermissionHandler` directly on the caller's
+        loop and calls a synchronous handler inline — with no
+        ``ThreadPoolExecutor`` / ``asyncio.run`` bridge, since we are
+        already in an async context.
+        """
+        import inspect
+        from typing import cast
+
+        result, handler, request = self._evaluate_policy(tool, parameters)
+        if result != PermissionResult.ASK or handler is None:
+            return result
+
+        if inspect.iscoroutinefunction(handler.handle):
+            decision = await handler.handle(request)
         else:
             decision = handler.handle(request)
 

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -275,6 +275,7 @@ class MCPTool(Tool):
                 is_async=False,
                 source="mcp",
                 source_detail=source_detail,
+                natural_backend="inline",
             ),
         )
 

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -196,6 +196,7 @@ class OpenAPITool(Tool):
                 is_async=False,
                 source="openapi",
                 source_detail=source_detail,
+                natural_backend="inline",
             ),
         )
 

--- a/src/toolregistry/runtimes/_ptc_tool.py
+++ b/src/toolregistry/runtimes/_ptc_tool.py
@@ -125,7 +125,11 @@ class PtcTool:
 
             def _make_invoke_fn(tn: str) -> Callable[..., Any]:
                 def fn(**kwargs: Any) -> Any:
-                    return registry.invoke(tn, kwargs, invocation_id=invocation_id)
+                    # Use the raw path: LLM-authored PTC code composes tool
+                    # outputs as real Python values (e.g. ``s = add(...) + 1``)
+                    # and relies on exceptions, so it must not receive the
+                    # finalized Result that the public invoke() returns.
+                    return registry._invoke_raw(tn, kwargs, invocation_id=invocation_id)
 
                 return fn
 

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -130,6 +130,19 @@ class ToolMetadata(BaseModel):
     Reference: https://arxiv.org/abs/2601.18282
     """
 
+    natural_backend: Literal["inline", "thread", "process"] | None = None
+    """Preferred execution backend for this tool.
+
+    Resolved by ``ToolRegistry`` when no explicit ``execution_mode`` is
+    given by the caller. ``None`` (default) means the registry chooses:
+    single-tool ``invoke``/``ainvoke`` default to the inline backend,
+    while ``execute_tool_calls`` uses the registry's default mode.
+
+    Integration tools that are already isolated (MCP servers, remote
+    HTTP APIs) set this to ``"inline"`` because pooling or pickling
+    their transport would be wrong or impossible.
+    """
+
     @property
     def all_tags(self) -> set[str]:
         """Union of predefined and custom tags (all as str)."""

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 from collections.abc import Callable
 
-from .executor import ProcessPoolBackend, ThreadBackend
+from .executor import InlineBackend, ProcessPoolBackend, ThreadBackend
 from .tool import ToolTag
 from .llm.truncation import truncate_result
 from .llm.content_blocks import is_content_block_list
@@ -143,6 +143,7 @@ class ToolRegistry(
         self.name = name
         self._thread_backend = ThreadBackend()
         self._process_backend = ProcessPoolBackend()
+        self._inline_backend = InlineBackend()
         self._execution_mode: Literal["process", "thread"] = "process"
         self._default_max_result_size = default_max_result_size
         self._think_augment = think_augment
@@ -346,6 +347,45 @@ class ToolRegistry(
 
     # ============== Execution helpers (shared by invoke + execute_tool_calls) ==
 
+    def _resolve_backend(self, tool: Any, execution_mode: str | None = None) -> Any:
+        """Resolve the execution backend for a single tool.
+
+        This is the seam that decouples the calling interface from the
+        execution backend.  Resolution order:
+
+        1. Explicit caller ``execution_mode`` (``"thread"``/``"process"``).
+        2. The tool's ``metadata.natural_backend`` hint.
+        3. The inline backend (default for single-tool ``invoke``).
+
+        Future isolation backends (e.g. a sandbox) plug in here without
+        touching ``invoke``/``ainvoke``.
+
+        Args:
+            tool: The :class:`Tool` to execute.
+            execution_mode: Optional caller override.
+
+        Returns:
+            An execution backend instance.
+        """
+        if execution_mode == "thread":
+            return self._thread_backend
+        if execution_mode == "process":
+            return self._process_backend
+
+        # force_thread still wins until Phase 3 removes it (PTC needs the
+        # main process for registry.invoke() IPC callbacks).
+        metadata = getattr(tool, "metadata", None)
+        if metadata is not None and getattr(metadata, "force_thread", False):
+            return self._thread_backend
+
+        natural = getattr(metadata, "natural_backend", None) if metadata else None
+        if natural == "thread":
+            return self._thread_backend
+        if natural == "process":
+            return self._process_backend
+
+        return self._inline_backend
+
     def _check_tool_access(
         self,
         tool_name: str,
@@ -482,32 +522,47 @@ class ToolRegistry(
             )
 
     # ============== Execution ==============
-    def invoke(
+    def _prepare_call(
+        self,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        invocation_id: str | None,
+    ) -> Any | _ToolError:
+        """Run access control for a single call.
+
+        Returns the :class:`Tool` when access is granted, or a
+        :class:`_ToolError` when the tool is missing, disabled, or denied
+        — so callers can produce an ``ErrorResult`` instead of raising.
+        """
+        try:
+            return self._check_tool_access(tool_name, kwargs, invocation_id)
+        except (KeyError, RuntimeError, PermissionError) as exc:
+            return _ToolError(
+                message=str(exc),
+                exception_type=type(exc).__qualname__,
+            )
+
+    def _invoke_raw(
         self,
         tool_name: str,
         kwargs: dict[str, Any],
         *,
         invocation_id: str | None = None,
+        execution_mode: Literal["thread", "process"] | None = None,
     ) -> Any:
-        """Execute a single tool with full pipeline (permissions, logging).
+        """Execute a single tool and return the **raw** result.
 
-        This is the canonical single-tool execution entry point.  It is
-        used by :class:`PtcTool` for IPC callbacks and can be
-        called directly for programmatic tool invocation.
+        Internal variant of :meth:`invoke` that runs the same pipeline
+        (permission check, backend seam, logging) but returns the tool's
+        raw Python value and **raises** on failure — instead of wrapping
+        into a ``Result``.
 
-        Args:
-            tool_name: Name of the registered tool.
-            kwargs: Keyword arguments to pass to the tool.
-            invocation_id: Optional ID to group related calls.  If
-                ``None``, a ``tr_sig_`` ID is auto-generated.
-
-        Returns:
-            The tool's return value.
+        Used by PTC, whose LLM-authored code composes tool outputs
+        naturally (e.g. ``s = add(a=1, b=2) + tax``) and therefore needs
+        real Python values, not finalized strings.
 
         Raises:
-            KeyError: If the tool is not registered.
-            PermissionError: If the tool is denied by permission policy.
-            RuntimeError: If the tool is disabled.
+            KeyError / RuntimeError / PermissionError: On access failure.
             Exception: Any exception raised by the tool itself.
         """
         from .utils import generate_invocation_id
@@ -515,11 +570,21 @@ class ToolRegistry(
         if invocation_id is None:
             invocation_id = generate_invocation_id("sig")
 
+        # Access control raises here (raw path), matching legacy invoke().
         tool_obj = self._check_tool_access(tool_name, kwargs, invocation_id)
+        backend = self._resolve_backend(tool_obj, execution_mode)
+        clean_kwargs = {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+        per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
 
         start = time.perf_counter()
         try:
-            result = tool_obj.run(kwargs)
+            handle = backend.submit(
+                lambda **kw: tool_obj.run(kw),
+                clean_kwargs,
+                execution_id=invocation_id,
+                timeout=per_call_timeout,
+            )
+            result = handle.result()
             duration_ms = (time.perf_counter() - start) * 1000
             self._log_tool_result(
                 tool_name,
@@ -539,6 +604,262 @@ class ToolRegistry(
                 invocation_id=invocation_id,
             )
             raise
+
+    def invoke(
+        self,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        *,
+        invocation_id: str | None = None,
+        execution_mode: Literal["thread", "process"] | None = None,
+    ) -> ToolCallResult | ErrorResult:
+        """Execute a single tool and return a structured result.
+
+        Canonical single-tool entry point.  Runs the full pipeline
+        (permissions, execution via the resolved backend, logging) and
+        returns a :class:`ToolCallResult` on success or an
+        :class:`ErrorResult` on any failure — including access-control
+        failures (missing/disabled/denied).  **Never raises** for those
+        conditions, mirroring :meth:`execute_tool_calls`.
+
+        Args:
+            tool_name: Name of the registered tool.
+            kwargs: Keyword arguments to pass to the tool.
+            invocation_id: Optional ID to group related calls.  If
+                ``None``, a ``tr_sig_`` ID is auto-generated and used as
+                the result ``id``.
+            execution_mode: Optional backend override
+                (``"thread"``/``"process"``).  Defaults to the tool's
+                natural backend (inline for most single calls).
+
+        Returns:
+            ``ToolCallResult`` on success, ``ErrorResult`` on failure.
+        """
+        from .utils import generate_invocation_id
+
+        if invocation_id is None:
+            invocation_id = generate_invocation_id("sig")
+
+        prepared = self._prepare_call(tool_name, kwargs, invocation_id)
+        if isinstance(prepared, _ToolError):
+            return ErrorResult(
+                id=invocation_id,
+                name=tool_name,
+                message=f"{prepared.exception_type}: {prepared.message}"
+                if prepared.exception_type
+                else prepared.message,
+            )
+
+        tool_obj = prepared
+        backend = self._resolve_backend(tool_obj, execution_mode)
+        clean_kwargs = {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+        per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
+
+        start = time.perf_counter()
+        # Submit tool_obj.run so the sync path is forced regardless of any
+        # ambient event loop (BaseToolWrapper.__call__ would auto-select
+        # async based on a running loop).  The backend calls fn(**kwargs),
+        # so the thunk collects them back into the dict run() expects.
+        handle = backend.submit(
+            lambda **kw: tool_obj.run(kw),
+            clean_kwargs,
+            execution_id=invocation_id,
+            timeout=per_call_timeout,
+        )
+        outcome = self._collect_handle_result(handle, tool_name)
+        duration_ms = (time.perf_counter() - start) * 1000
+
+        if isinstance(outcome, _ToolError):
+            self._log_tool_result(
+                tool_name,
+                kwargs,
+                error=outcome,
+                duration_ms=duration_ms,
+                invocation_id=invocation_id,
+            )
+            return ErrorResult(
+                id=invocation_id,
+                name=tool_name,
+                message=f"{outcome.exception_type}: {outcome.message}"
+                if outcome.exception_type
+                else outcome.message,
+            )
+
+        self._log_tool_result(
+            tool_name,
+            kwargs,
+            result=outcome,
+            duration_ms=duration_ms,
+            invocation_id=invocation_id,
+        )
+        return ToolCallResult(id=invocation_id, name=tool_name, result=outcome)
+
+    async def _acheck_tool_access(
+        self,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        invocation_id: str | None = None,
+    ):
+        """Async access control using :meth:`_aresolve_permission`.
+
+        Mirrors :meth:`_check_tool_access` but awaits async permission
+        handlers natively instead of bridging through a thread pool.
+
+        Returns the :class:`Tool` on success; raises ``KeyError`` /
+        ``RuntimeError`` / ``PermissionError`` on failure.
+        """
+        from .admin import ExecutionStatus
+
+        tool_obj = self.get_tool(tool_name)
+        if tool_obj is None:
+            raise KeyError(f"Tool '{tool_name}' is not registered")
+
+        if not self.is_enabled(tool_name):
+            reason = self.get_disable_reason(tool_name) or "Tool is disabled"
+            self._log_entry(
+                tool_name,
+                ExecutionStatus.DISABLED,
+                0.0,
+                kwargs,
+                error=reason,
+                invocation_id=invocation_id,
+            )
+            raise RuntimeError(f"Tool '{tool_name}' is disabled: {reason}")
+
+        decision = await self._aresolve_permission(tool_obj, kwargs)
+        if decision == PermissionResult.DENY:
+            self._log_entry(
+                tool_name,
+                ExecutionStatus.ERROR,
+                0.0,
+                kwargs,
+                error="Denied by permission policy",
+                invocation_id=invocation_id,
+            )
+            raise PermissionError(f"Tool '{tool_name}' denied by permission policy")
+
+        return tool_obj
+
+    async def _aprepare_call(
+        self,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        invocation_id: str | None,
+    ) -> Any | _ToolError:
+        """Async access control returning ``Tool`` or ``_ToolError``."""
+        try:
+            return await self._acheck_tool_access(tool_name, kwargs, invocation_id)
+        except (KeyError, RuntimeError, PermissionError) as exc:
+            return _ToolError(
+                message=str(exc),
+                exception_type=type(exc).__qualname__,
+            )
+
+    async def ainvoke(
+        self,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        *,
+        invocation_id: str | None = None,
+        execution_mode: Literal["thread", "process"] | None = None,
+    ) -> ToolCallResult | ErrorResult:
+        """Async counterpart to :meth:`invoke`.
+
+        For inline-resolved tools (the default, including MCP/OpenAPI),
+        awaits ``tool.arun()`` directly on the caller's loop — the tool's
+        async transport stays on the running loop without blocking it.
+        For thread/process backends, submits and awaits
+        ``handle.result_async()``.
+
+        Returns a :class:`ToolCallResult` on success or an
+        :class:`ErrorResult` on any failure.  **Never raises** for
+        access-control failures.
+
+        Args:
+            tool_name: Name of the registered tool.
+            kwargs: Keyword arguments to pass to the tool.
+            invocation_id: Optional grouping ID; auto-generated
+                (``tr_sig_``) when ``None`` and used as the result ``id``.
+            execution_mode: Optional backend override.
+
+        Returns:
+            ``ToolCallResult`` on success, ``ErrorResult`` on failure.
+        """
+        from .utils import generate_invocation_id
+
+        if invocation_id is None:
+            invocation_id = generate_invocation_id("sig")
+
+        prepared = await self._aprepare_call(tool_name, kwargs, invocation_id)
+        if isinstance(prepared, _ToolError):
+            return ErrorResult(
+                id=invocation_id,
+                name=tool_name,
+                message=f"{prepared.exception_type}: {prepared.message}"
+                if prepared.exception_type
+                else prepared.message,
+            )
+
+        tool_obj = prepared
+        backend = self._resolve_backend(tool_obj, execution_mode)
+        clean_kwargs = {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+        per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
+
+        start = time.perf_counter()
+        outcome: Any
+        try:
+            if backend is self._inline_backend:
+                # Native async path: await on the caller's loop so the
+                # tool's transport (MCP/OpenAPI) stays non-blocking.
+                raw = await tool_obj.arun(clean_kwargs)
+                outcome = self._finalize_result(raw, tool_name)
+            else:
+                handle = backend.submit(
+                    lambda **kw: tool_obj.run(kw),
+                    clean_kwargs,
+                    execution_id=invocation_id,
+                    timeout=per_call_timeout,
+                )
+                raw = await handle.result_async()
+                outcome = self._finalize_result(raw, tool_name)
+        except TimeoutError:
+            outcome = _ToolError(
+                message=f"Error: Tool '{tool_name}' timed out",
+                exception_type="TimeoutError",
+                is_timeout=True,
+            )
+        except Exception as exc:
+            outcome = _ToolError(
+                message=f"Error executing {tool_name}: {exc!s}",
+                exception_type=type(exc).__qualname__,
+                traceback_str=tb_module.format_exc(),
+            )
+        duration_ms = (time.perf_counter() - start) * 1000
+
+        if isinstance(outcome, _ToolError):
+            self._log_tool_result(
+                tool_name,
+                kwargs,
+                error=outcome,
+                duration_ms=duration_ms,
+                invocation_id=invocation_id,
+            )
+            return ErrorResult(
+                id=invocation_id,
+                name=tool_name,
+                message=f"{outcome.exception_type}: {outcome.message}"
+                if outcome.exception_type
+                else outcome.message,
+            )
+
+        self._log_tool_result(
+            tool_name,
+            kwargs,
+            result=outcome,
+            duration_ms=duration_ms,
+            invocation_id=invocation_id,
+        )
+        return ToolCallResult(id=invocation_id, name=tool_name, result=outcome)
 
     def _finalize_result(self, result: Any, tool_name: str) -> str | list:
         """Convert a raw tool result to a string or content block list.

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -6,11 +6,15 @@ import time
 import traceback as tb_module
 import warnings
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from collections.abc import Callable
 
 from .executor import InlineBackend, ProcessPoolBackend, ThreadBackend
 from .tool import ToolTag
+
+if TYPE_CHECKING:
+    from .executor import ExecutionBackend
+    from .tool import Tool
 from .llm.truncation import truncate_result
 from .llm.content_blocks import is_content_block_list
 from .permissions import (
@@ -61,13 +65,17 @@ class _ToolError:
     traceback_str: str | None = None
     is_timeout: bool = False
 
+    def format(self) -> str:
+        """Return the ``"ExceptionType: message"`` string (or bare message)."""
+        prefix = f"{self.exception_type}: " if self.exception_type else ""
+        return f"{prefix}{self.message}"
+
     def to_error_result(self, tool_call: Any) -> "ErrorResult":
         """Convert to a public ErrorResult."""
-        prefix = f"{self.exception_type}: " if self.exception_type else ""
         return ErrorResult(
             id=tool_call.id,
             name=tool_call.name,
-            message=f"{prefix}{self.message}",
+            message=self.format(),
         )
 
 
@@ -347,7 +355,14 @@ class ToolRegistry(
 
     # ============== Execution helpers (shared by invoke + execute_tool_calls) ==
 
-    def _resolve_backend(self, tool: Any, execution_mode: str | None = None) -> Any:
+    @staticmethod
+    def _clean_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Drop the synthetic ``toolcall_reason`` key before execution."""
+        return {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+
+    def _resolve_backend(
+        self, tool: "Tool", execution_mode: str | None = None
+    ) -> "ExecutionBackend":
         """Resolve the execution backend for a single tool.
 
         This is the seam that decouples the calling interface from the
@@ -391,7 +406,7 @@ class ToolRegistry(
         tool_name: str,
         kwargs: dict[str, Any],
         invocation_id: str | None = None,
-    ):
+    ) -> "Tool":
         """Check that a tool exists, is enabled, and passes permission.
 
         This is the single callsite for access control — both
@@ -573,7 +588,7 @@ class ToolRegistry(
         # Access control raises here (raw path), matching legacy invoke().
         tool_obj = self._check_tool_access(tool_name, kwargs, invocation_id)
         backend = self._resolve_backend(tool_obj, execution_mode)
-        clean_kwargs = {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+        clean_kwargs = self._clean_kwargs(kwargs)
         per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
 
         start = time.perf_counter()
@@ -645,14 +660,12 @@ class ToolRegistry(
             return ErrorResult(
                 id=invocation_id,
                 name=tool_name,
-                message=f"{prepared.exception_type}: {prepared.message}"
-                if prepared.exception_type
-                else prepared.message,
+                message=prepared.format(),
             )
 
         tool_obj = prepared
         backend = self._resolve_backend(tool_obj, execution_mode)
-        clean_kwargs = {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+        clean_kwargs = self._clean_kwargs(kwargs)
         per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
 
         start = time.perf_counter()
@@ -680,9 +693,7 @@ class ToolRegistry(
             return ErrorResult(
                 id=invocation_id,
                 name=tool_name,
-                message=f"{outcome.exception_type}: {outcome.message}"
-                if outcome.exception_type
-                else outcome.message,
+                message=outcome.format(),
             )
 
         self._log_tool_result(
@@ -699,7 +710,7 @@ class ToolRegistry(
         tool_name: str,
         kwargs: dict[str, Any],
         invocation_id: str | None = None,
-    ):
+    ) -> "Tool":
         """Async access control using :meth:`_aresolve_permission`.
 
         Mirrors :meth:`_check_tool_access` but awaits async permission
@@ -795,14 +806,12 @@ class ToolRegistry(
             return ErrorResult(
                 id=invocation_id,
                 name=tool_name,
-                message=f"{prepared.exception_type}: {prepared.message}"
-                if prepared.exception_type
-                else prepared.message,
+                message=prepared.format(),
             )
 
         tool_obj = prepared
         backend = self._resolve_backend(tool_obj, execution_mode)
-        clean_kwargs = {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
+        clean_kwargs = self._clean_kwargs(kwargs)
         per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
 
         start = time.perf_counter()
@@ -847,9 +856,7 @@ class ToolRegistry(
             return ErrorResult(
                 id=invocation_id,
                 name=tool_name,
-                message=f"{outcome.exception_type}: {outcome.message}"
-                if outcome.exception_type
-                else outcome.message,
+                message=outcome.format(),
             )
 
         self._log_tool_result(

--- a/tests/test_ainvoke.py
+++ b/tests/test_ainvoke.py
@@ -1,0 +1,216 @@
+"""Tests for ToolRegistry.ainvoke() and async permission resolution."""
+
+import asyncio
+import threading
+
+import pytest
+
+from toolregistry import Tool, ToolRegistry
+from toolregistry.llm.tool_calls import ErrorResult, ToolCallResult
+from toolregistry.permissions import (
+    PermissionPolicy,
+    PermissionRequest,
+    PermissionResult,
+    PermissionRule,
+)
+from toolregistry.tool import ToolMetadata, ToolTag
+
+
+class TestAinvoke:
+    @pytest.mark.asyncio
+    async def test_ainvoke_sync_tool(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add."""
+            return a + b
+
+        reg.register(add)
+        result = await reg.ainvoke("add", {"a": 3, "b": 4})
+        assert isinstance(result, ToolCallResult)
+        assert result.result == "7"
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_async_tool(self):
+        reg = ToolRegistry()
+
+        async def amul(a: int, b: int) -> int:
+            """Multiply async."""
+            return a * b
+
+        reg.register(amul)
+        result = await reg.ainvoke("amul", {"a": 3, "b": 4})
+        assert isinstance(result, ToolCallResult)
+        assert result.result == "12"
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_nonexistent_returns_error(self):
+        reg = ToolRegistry()
+        result = await reg.ainvoke("nope", {})
+        assert isinstance(result, ErrorResult)
+        assert "not registered" in result.message
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_disabled_returns_error(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        reg.disable("add", reason="maint")
+        result = await reg.ainvoke("add", {"a": 1, "b": 2})
+        assert isinstance(result, ErrorResult)
+        assert "disabled" in result.message
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_tool_error_returns_error(self):
+        reg = ToolRegistry()
+
+        def failing(x: int) -> int:
+            raise ValueError("broken")
+
+        reg.register(failing)
+        result = await reg.ainvoke("failing", {"x": 1})
+        assert isinstance(result, ErrorResult)
+        assert "broken" in result.message
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_does_not_block_loop(self):
+        """Concurrent ainvoke of async tools overlap on the loop."""
+        reg = ToolRegistry()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(0.2)
+            return n
+
+        reg.register(slow)
+
+        start = asyncio.get_event_loop().time()
+        results = await asyncio.gather(
+            reg.ainvoke("slow", {"n": 1}),
+            reg.ainvoke("slow", {"n": 2}),
+        )
+        elapsed = asyncio.get_event_loop().time() - start
+
+        assert {r.result for r in results} == {"1", "2"}
+        # Concurrent: well under the 0.4s serial lower bound.
+        assert elapsed < 0.35
+
+
+class TestBackendResolution:
+    def test_inline_default_for_native(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        tool = reg.get_tool("add")
+        assert reg._resolve_backend(tool) is reg._inline_backend
+
+    def test_execution_mode_override(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        tool = reg.get_tool("add")
+        assert reg._resolve_backend(tool, "thread") is reg._thread_backend
+        assert reg._resolve_backend(tool, "process") is reg._process_backend
+
+    def test_natural_backend_hint(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        tool = Tool.from_function(add, metadata=ToolMetadata(natural_backend="thread"))
+        reg.register(tool)
+        resolved = reg.get_tool("add")
+        assert reg._resolve_backend(resolved) is reg._thread_backend
+
+    def test_override_beats_natural_backend(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        tool = Tool.from_function(add, metadata=ToolMetadata(natural_backend="thread"))
+        reg.register(tool)
+        resolved = reg.get_tool("add")
+        assert reg._resolve_backend(resolved, "process") is reg._process_backend
+
+
+class TestAsyncPermission:
+    @pytest.mark.asyncio
+    async def test_async_handler_resolved_without_thread_bridge(self):
+        """ainvoke awaits an async permission handler on the caller loop.
+
+        The handler records the thread it runs on; it must be the same
+        thread as the test (no ThreadPoolExecutor bridge).
+        """
+        reg = ToolRegistry()
+
+        def dangerous(cmd: str) -> str:
+            return cmd
+
+        tool = Tool.from_function(
+            dangerous, metadata=ToolMetadata(tags={ToolTag.DESTRUCTIVE})
+        )
+        reg.register(tool)
+
+        ask_rule = PermissionRule(
+            name="ask_destructive",
+            match=lambda t, p: ToolTag.DESTRUCTIVE in t.metadata.tags,
+            result=PermissionResult.ASK,
+            reason="confirm",
+        )
+
+        handler_thread: dict[str, int] = {}
+
+        class AllowHandler:
+            async def handle(self, request: PermissionRequest) -> PermissionResult:
+                handler_thread["id"] = threading.get_ident()
+                return PermissionResult.ALLOW
+
+        reg.set_permission_policy(
+            PermissionPolicy(rules=[ask_rule], handler=AllowHandler())
+        )
+
+        result = await reg.ainvoke("dangerous", {"cmd": "ls"})
+        assert isinstance(result, ToolCallResult)
+        assert result.result == "ls"
+        assert handler_thread["id"] == threading.get_ident()
+
+    @pytest.mark.asyncio
+    async def test_async_handler_deny_returns_error(self):
+        reg = ToolRegistry()
+
+        def dangerous(cmd: str) -> str:
+            return cmd
+
+        tool = Tool.from_function(
+            dangerous, metadata=ToolMetadata(tags={ToolTag.DESTRUCTIVE})
+        )
+        reg.register(tool)
+
+        ask_rule = PermissionRule(
+            name="ask_destructive",
+            match=lambda t, p: ToolTag.DESTRUCTIVE in t.metadata.tags,
+            result=PermissionResult.ASK,
+            reason="confirm",
+        )
+
+        class DenyHandler:
+            async def handle(self, request: PermissionRequest) -> PermissionResult:
+                return PermissionResult.DENY
+
+        reg.set_permission_policy(
+            PermissionPolicy(rules=[ask_rule], handler=DenyHandler())
+        )
+
+        result = await reg.ainvoke("dangerous", {"cmd": "rm -rf /"})
+        assert isinstance(result, ErrorResult)
+        assert "denied" in result.message

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -1,10 +1,13 @@
-"""Tests for ToolRegistry.invoke() and invocation_id tracking."""
+"""Tests for ToolRegistry.invoke() and invocation_id tracking.
 
-import pytest
+invoke() returns a structured Result — ``ToolCallResult`` on success,
+``ErrorResult`` on any failure (including access control) — and never
+raises for those conditions.
+"""
 
 from toolregistry import Tool, ToolRegistry
+from toolregistry.llm.tool_calls import ErrorResult, ToolCallResult
 from toolregistry.permissions import PermissionPolicy, PermissionResult, PermissionRule
-from toolregistry.runtimes import PTC_TOOL_NAME
 from toolregistry.tool import ToolMetadata, ToolTag
 
 
@@ -18,14 +21,17 @@ class TestInvoke:
 
         reg.register(add)
         result = reg.invoke("add", {"a": 3, "b": 4})
-        assert result == 7
+        assert isinstance(result, ToolCallResult)
+        assert result.name == "add"
+        assert result.result == "7"
 
-    def test_invoke_nonexistent_raises(self):
+    def test_invoke_nonexistent_returns_error(self):
         reg = ToolRegistry()
-        with pytest.raises(KeyError, match="not registered"):
-            reg.invoke("nonexistent", {})
+        result = reg.invoke("nonexistent", {})
+        assert isinstance(result, ErrorResult)
+        assert "not registered" in result.message
 
-    def test_invoke_disabled_raises(self):
+    def test_invoke_disabled_returns_error(self):
         reg = ToolRegistry()
 
         def add(a: int, b: int) -> int:
@@ -33,10 +39,11 @@ class TestInvoke:
 
         reg.register(add)
         reg.disable("add", reason="maintenance")
-        with pytest.raises(RuntimeError, match="disabled"):
-            reg.invoke("add", {"a": 1, "b": 2})
+        result = reg.invoke("add", {"a": 1, "b": 2})
+        assert isinstance(result, ErrorResult)
+        assert "disabled" in result.message
 
-    def test_invoke_denied_by_permission(self):
+    def test_invoke_denied_by_permission_returns_error(self):
         reg = ToolRegistry()
 
         def dangerous_tool(cmd: str) -> str:
@@ -57,18 +64,30 @@ class TestInvoke:
         )
         reg.set_permission_policy(PermissionPolicy(rules=[deny_destructive]))
 
-        with pytest.raises(PermissionError, match="denied"):
-            reg.invoke("dangerous_tool", {"cmd": "rm -rf /"})
+        result = reg.invoke("dangerous_tool", {"cmd": "rm -rf /"})
+        assert isinstance(result, ErrorResult)
+        assert "denied" in result.message
 
-    def test_invoke_propagates_tool_error(self):
+    def test_invoke_tool_error_returns_error(self):
         reg = ToolRegistry()
 
         def failing(x: int) -> int:
             raise ValueError("broken")
 
         reg.register(failing)
-        with pytest.raises(ValueError, match="broken"):
-            reg.invoke("failing", {"x": 1})
+        result = reg.invoke("failing", {"x": 1})
+        assert isinstance(result, ErrorResult)
+        assert "broken" in result.message
+
+    def test_invoke_result_id_matches_invocation_id(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        result = reg.invoke("add", {"a": 1, "b": 2}, invocation_id="tr_sig_fixed")
+        assert result.id == "tr_sig_fixed"
 
 
 class TestInvocationId:
@@ -131,62 +150,9 @@ class TestInvocationId:
             raise ValueError("broken")
 
         reg.register(failing)
-        with pytest.raises(ValueError):
-            reg.invoke("failing", {"x": 1}, invocation_id="tr_sig_err1")
+        result = reg.invoke("failing", {"x": 1}, invocation_id="tr_sig_err1")
+        assert isinstance(result, ErrorResult)
 
         entries = reg.get_execution_log().get_entries(invocation_id="tr_sig_err1")
         assert len(entries) == 1
         assert entries[0].status.value == "error"
-
-
-class TestPtcInvocationId:
-    """Test that PtcTool generates tr_ptc_ IDs."""
-
-    @pytest.fixture
-    def registry(self):
-        reg = ToolRegistry()
-
-        def add(a: int, b: int) -> int:
-            """Add two numbers."""
-            return a + b
-
-        reg.register(add)
-        reg.enable_logging()
-        return reg
-
-    def test_ptc_generates_invocation_id(self, registry):
-        registry.ptc.enable()
-        tool = registry.get_tool(PTC_TOOL_NAME)
-        tool.run({"code": "print(add(a=1, b=2))"})
-
-        assert registry.ptc.last_invocation_id is not None
-        assert registry.ptc.last_invocation_id.startswith("tr_ptc_")
-
-    def test_ptc_tool_calls_share_id(self, registry):
-        def mul(a: int, b: int) -> int:
-            """Multiply two numbers."""
-            return a * b
-
-        registry.register(mul)
-        registry.ptc.enable()
-        tool = registry.get_tool(PTC_TOOL_NAME)
-
-        tool.run({"code": "s = add(a=1, b=2)\np = mul(a=s, b=3)\nprint(p)"})
-
-        inv_id = registry.ptc.last_invocation_id
-        entries = registry.get_execution_log().get_entries(invocation_id=inv_id)
-        assert len(entries) == 2
-        tool_names = {e.tool_name for e in entries}
-        assert tool_names == {"add", "mul"}
-
-    def test_separate_executions_have_different_ids(self, registry):
-        registry.ptc.enable()
-        tool = registry.get_tool(PTC_TOOL_NAME)
-
-        tool.run({"code": "print(add(a=1, b=2))"})
-        id1 = registry.ptc.last_invocation_id
-
-        tool.run({"code": "print(add(a=3, b=4))"})
-        id2 = registry.ptc.last_invocation_id
-
-        assert id1 != id2

--- a/tests/test_persistent_connection.py
+++ b/tests/test_persistent_connection.py
@@ -370,8 +370,8 @@ class TestToolRegistrySyncMCPIntegration:
 
             r1 = reg.invoke("add", {"a": 5, "b": 3})
             r2 = reg.invoke("add", {"a": 10, "b": 1})
-            assert r1 == '{"result": 8}'
-            assert r2 == '{"result": 11}'
+            assert r1.result == '{"result": 8}'
+            assert r2.result == '{"result": 11}'
 
     def test_sync_register_non_persistent(self):
         """Non-persistent mode should still work in sync."""
@@ -383,7 +383,7 @@ class TestToolRegistrySyncMCPIntegration:
             reg.register_from_mcp(config, persistent=False)
             assert "echo" in reg
             result = reg.invoke("echo", {"message": "hello"})
-            assert result == "hello"
+            assert result.result == "hello"
 
     def test_sync_multiple_registrations_shared_loop(self):
         """Multiple sequential sync registrations share one loop (#217).
@@ -409,8 +409,8 @@ class TestToolRegistrySyncMCPIntegration:
             # Both work and share the same runtime loop.
             r1 = reg.invoke("ns1-add", {"a": 1, "b": 2})
             r2 = reg.invoke("ns2-add", {"a": 3, "b": 4})
-            assert r1 == '{"result": 3}'
-            assert r2 == '{"result": 7}'
+            assert r1.result == '{"result": 3}'
+            assert r2.result == '{"result": 7}'
 
             loop = AsyncRuntime.get_loop()
             assert loop.is_running()

--- a/tests/test_ptc_invocation_id.py
+++ b/tests/test_ptc_invocation_id.py
@@ -1,0 +1,63 @@
+"""Tests that PtcTool generates and groups ``tr_ptc_`` invocation IDs.
+
+These exercise the PTC → ``registry._invoke_raw`` path: PTC-authored code
+calls tools which are logged under a shared ``tr_ptc_`` invocation ID, and
+each ``execute`` gets a fresh ID.
+"""
+
+import pytest
+
+from toolregistry import ToolRegistry
+from toolregistry.runtimes import PTC_TOOL_NAME
+
+
+@pytest.fixture
+def registry():
+    reg = ToolRegistry()
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    reg.register(add)
+    reg.enable_logging()
+    return reg
+
+
+class TestPtcInvocationId:
+    def test_ptc_generates_invocation_id(self, registry):
+        registry.ptc.enable()
+        tool = registry.get_tool(PTC_TOOL_NAME)
+        tool.run({"code": "print(add(a=1, b=2))"})
+
+        assert registry.ptc.last_invocation_id is not None
+        assert registry.ptc.last_invocation_id.startswith("tr_ptc_")
+
+    def test_ptc_tool_calls_share_id(self, registry):
+        def mul(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        registry.register(mul)
+        registry.ptc.enable()
+        tool = registry.get_tool(PTC_TOOL_NAME)
+
+        tool.run({"code": "s = add(a=1, b=2)\np = mul(a=s, b=3)\nprint(p)"})
+
+        inv_id = registry.ptc.last_invocation_id
+        entries = registry.get_execution_log().get_entries(invocation_id=inv_id)
+        assert len(entries) == 2
+        tool_names = {e.tool_name for e in entries}
+        assert tool_names == {"add", "mul"}
+
+    def test_separate_executions_have_different_ids(self, registry):
+        registry.ptc.enable()
+        tool = registry.get_tool(PTC_TOOL_NAME)
+
+        tool.run({"code": "print(add(a=1, b=2))"})
+        id1 = registry.ptc.last_invocation_id
+
+        tool.run({"code": "print(add(a=3, b=4))"})
+        id2 = registry.ptc.last_invocation_id
+
+        assert id1 != id2


### PR DESCRIPTION
## Summary

Phase 2 of the execution-stack refactor (#222). Makes `invoke()` the single atomic tool-execution entry, routed through a backend **seam**, and adds its async twin `ainvoke()`. Builds on the Phase 1 primitives (#223: `InlineBackend`, `result_async()`).

Closes #224.

### The seam
`invoke()`/`ainvoke()` no longer call `tool.run()` directly. They resolve a backend via `_resolve_backend(tool, execution_mode)`:

```
caller execution_mode  >  tool.metadata.natural_backend  >  inline (default)
```

Default inline = zero overhead (no thread hop). The calling interface (sync/async) is now orthogonal to the execution backend (inline/thread/process). A future **sandbox** backend plugs into `_resolve_backend` and `invoke()` auto-honors isolation with no further changes.

### Return contract (BREAKING)
`invoke()`/`ainvoke()` now return a structured `Result` — `ToolCallResult` on success, `ErrorResult` on **any** failure including access control (missing/disabled/denied) — and **never raise** for those conditions, mirroring `execute_tool_calls()`. Previously `invoke()` returned the raw value and raised.

`execute_tool_calls()` (still `ResultList`) and `set_default_execution_mode()` are unchanged.

### Async
- `ainvoke()` awaits `tool.arun()` directly on the caller's loop for inline tools — non-blocking for MCP/OpenAPI whose transports live on that loop. Pool backends use `await handle.result_async()` (Phase 1).
- `_aresolve_permission()` awaits async permission handlers natively. Policy evaluation is factored into a shared `_evaluate_policy()` so the sync and async resolvers can't drift. This removes the `ThreadPoolExecutor + asyncio.run` bridge on the async path.

### PTC
PTC's LLM-authored code composes tool outputs as real Python values (`s = add(...) + tax`, lists of ints), so it can't consume a finalized `Result`. A new internal `_invoke_raw()` runs the **same** pipeline (permission/logging/seam) but returns the raw value and raises on error. PTC uses it; all existing PTC tests pass unchanged.

### Deferred to Phase 3 (#225)
`force_thread` is still honored in `_resolve_backend`; its removal + the batch rebuild (`execute`/`aexecute` as orchestration) land in Phase 3.

## Test plan

- [x] `tests/test_invoke.py` rewritten for the Result contract (success/missing/disabled/denied/tool-error, id matches invocation_id)
- [x] `tests/test_ainvoke.py` (new): ainvoke over sync/async tools; non-blocking gather; backend resolution + override precedence; async permission handler resolves on the caller thread (no thread bridge); deny → ErrorResult
- [x] `tests/test_ptc_tool.py` unchanged, all pass (raw path preserved)
- [x] `tests/test_persistent_connection.py` invoke assertions updated to `.result`
- [x] Full suite: **1066 passed** (2 pre-existing warnings)
- [x] `pre-commit run` — ruff, ruff-format, ty, complexipy all pass

## Context

Part of the phased refactor tracked in #222 → #223 (merged) / #224 (this) / #225. Design decisions (Result return type, access-control → ErrorResult, seam-default-inline, PTC raw path) were made in discussion. AI was used to assist with implementation.