### PR TITLE
feat(registry): per-tool batch backend + aexecute_tool_calls, drop force_thread (#225)

### DIFF
--- a/src/toolregistry/runtimes/_ptc_controller.py
+++ b/src/toolregistry/runtimes/_ptc_controller.py
@@ -110,7 +110,10 @@ class PtcController:
             executor.execute,
             name=PTC_TOOL_NAME,
             description=PTC_TOOL_DESCRIPTION,
-            metadata=ToolMetadata(defer=False, force_thread=True),
+            # Must run in the main process: its IPC tool callbacks go
+            # through registry.invoke()/_invoke_raw, and it holds a live
+            # registry reference that cannot cross a process boundary.
+            metadata=ToolMetadata(defer=False, natural_backend="inline"),
         )
         self._registry.register(code_tool)
 

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -108,17 +108,6 @@ class ToolMetadata(BaseModel):
     ``"jupyter notebook ipynb cell"``.
     """
 
-    force_thread: bool = False
-    """Force thread-based execution even when process mode is the default.
-
-    When ``True``, ``execute_tool_calls()`` will always use the
-    ``ThreadBackend`` for this tool, regardless of the registry's
-    default execution mode.  This is required for tools that hold
-    references to the registry or other unpicklable state (e.g.
-    PTC's ``programmatic_tool_call`` tool, which needs
-    ``registry.invoke()`` callbacks to run in the main process).
-    """
-
     think_augment: bool | None = None
     """Control thought-augmented tool calling for this tool.
 

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1082,6 +1082,7 @@ class ToolRegistry(
         tc: Any,
         execution_mode: str | None,
         call_arguments: dict[str, dict],
+        backend: Any = None,
     ) -> Any | _ToolError:
         """Submit a single tool call using its resolved backend.
 
@@ -1094,6 +1095,10 @@ class ToolRegistry(
             tc: The tool call to submit.
             execution_mode: Optional caller backend override.
             call_arguments: Map of call ID to parsed arguments.
+            backend: Pre-resolved backend to reuse.  When ``None`` the
+                backend is resolved here; callers that already resolved it
+                (e.g. :meth:`_execute_concurrent` grouping) pass it in to
+                avoid a redundant resolution.
 
         Returns:
             An ExecutionHandle on success, or a ``_ToolError`` on failure.
@@ -1113,9 +1118,10 @@ class ToolRegistry(
             tool_obj.metadata.timeout if tool_obj and tool_obj.metadata else None
         )
 
-        backend = self._resolve_backend(
-            tool_obj, execution_mode, default=self._execution_mode
-        )
+        if backend is None:
+            backend = self._resolve_backend(
+                tool_obj, execution_mode, default=self._execution_mode
+            )
 
         try:
             return backend.submit(
@@ -1267,6 +1273,7 @@ class ToolRegistry(
         pool_handles: list[tuple[Any, ExecutionHandle]] = []
         inline_calls: list[Any] = []
 
+        inline_backends: dict[str, Any] = {}
         for tc in enabled_calls:
             tool_obj = self.get_tool(tc.name)
             backend = self._resolve_backend(
@@ -1274,15 +1281,21 @@ class ToolRegistry(
             )
             if backend is self._inline_backend:
                 inline_calls.append(tc)
+                inline_backends[tc.id] = backend
                 continue
-            handle_or_error = self._submit_tool_call(tc, execution_mode, call_arguments)
+            # Reuse the backend we just resolved instead of re-resolving.
+            handle_or_error = self._submit_tool_call(
+                tc, execution_mode, call_arguments, backend=backend
+            )
             if isinstance(handle_or_error, _ToolError):
                 raw_results[tc.id] = handle_or_error
             else:
                 pool_handles.append((tc, handle_or_error))
 
         for tc in inline_calls:
-            handle_or_error = self._submit_tool_call(tc, execution_mode, call_arguments)
+            handle_or_error = self._submit_tool_call(
+                tc, execution_mode, call_arguments, backend=inline_backends[tc.id]
+            )
             if isinstance(handle_or_error, _ToolError):
                 raw_results[tc.id] = handle_or_error
             else:

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1415,8 +1415,6 @@ class ToolRegistry(
         Returns:
             A :class:`ResultList` in the same order as *tool_calls*.
         """
-        import asyncio
-
         from .utils import generate_invocation_id
 
         batch_inv_id = generate_invocation_id("bat")
@@ -1438,35 +1436,68 @@ class ToolRegistry(
             for tc in enabled_calls
         )
 
-        raw_results: dict[str, Any] = {}
-
         if has_unsafe:
-            for tc in enabled_calls:
-                result = await self._aexecute_one(tc, execution_mode, call_arguments)
-                raw_results[tc.id] = result
-                tool_responses[tc.id] = result
-        else:
-            results = await asyncio.gather(
-                *(
-                    self._aexecute_one(tc, execution_mode, call_arguments)
-                    for tc in enabled_calls
-                ),
-                return_exceptions=True,
+            raw_results = await self._aexecute_sequential(
+                enabled_calls, execution_mode, call_arguments
             )
-            for tc, result in zip(enabled_calls, results):
-                if isinstance(result, BaseException):
-                    result = _ToolError(
-                        message=f"Error executing {tc.name}: {result!s}",
-                        exception_type=type(result).__qualname__,
-                    )
-                raw_results[tc.id] = result
-                tool_responses[tc.id] = result
+        else:
+            raw_results = await self._aexecute_concurrent(
+                enabled_calls, execution_mode, call_arguments
+            )
+        tool_responses.update(raw_results)
 
         self._log_tool_call_results(
             enabled_calls, raw_results, call_start_times, call_arguments, batch_inv_id
         )
 
         return self._wrap_results(generic_tool_calls, tool_responses)
+
+    async def _aexecute_sequential(
+        self,
+        enabled_calls: list[Any],
+        execution_mode: str | None,
+        call_arguments: dict[str, dict],
+    ) -> dict[str, Any]:
+        """Await each call in order (used when an unsafe tool is present)."""
+        raw_results: dict[str, Any] = {}
+        for tc in enabled_calls:
+            raw_results[tc.id] = await self._aexecute_one(
+                tc, execution_mode, call_arguments
+            )
+        return raw_results
+
+    async def _aexecute_concurrent(
+        self,
+        enabled_calls: list[Any],
+        execution_mode: str | None,
+        call_arguments: dict[str, dict],
+    ) -> dict[str, Any]:
+        """Run concurrency-safe calls concurrently via ``asyncio.gather``.
+
+        Inline tools overlap on the caller's loop; pool-backed tools run
+        off-loop and are awaited via ``result_async``.  ``_aexecute_one``
+        catches ``Exception`` internally; ``gather(return_exceptions=True)``
+        is a second layer that also captures anything that leaks (e.g.
+        ``KeyboardInterrupt``).
+        """
+        import asyncio
+
+        raw_results: dict[str, Any] = {}
+        results = await asyncio.gather(
+            *(
+                self._aexecute_one(tc, execution_mode, call_arguments)
+                for tc in enabled_calls
+            ),
+            return_exceptions=True,
+        )
+        for tc, result in zip(enabled_calls, results):
+            if isinstance(result, BaseException):
+                result = _ToolError(
+                    message=f"Error executing {tc.name}: {result!s}",
+                    exception_type=type(result).__qualname__,
+                )
+            raw_results[tc.id] = result
+        return raw_results
 
     @staticmethod
     def _wrap_results(

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -360,8 +360,19 @@ class ToolRegistry(
         """Drop the synthetic ``toolcall_reason`` key before execution."""
         return {k: v for k, v in kwargs.items() if k != "toolcall_reason"}
 
+    def _backend_for(self, name: str) -> "ExecutionBackend":
+        """Map a backend name to its backend instance."""
+        if name == "thread":
+            return self._thread_backend
+        if name == "process":
+            return self._process_backend
+        return self._inline_backend
+
     def _resolve_backend(
-        self, tool: "Tool", execution_mode: str | None = None
+        self,
+        tool: "Tool | None",
+        execution_mode: str | None = None,
+        default: str = "inline",
     ) -> "ExecutionBackend":
         """Resolve the execution backend for a single tool.
 
@@ -370,7 +381,13 @@ class ToolRegistry(
 
         1. Explicit caller ``execution_mode`` (``"thread"``/``"process"``).
         2. The tool's ``metadata.natural_backend`` hint.
-        3. The inline backend (default for single-tool ``invoke``).
+        3. The *default* backend for the calling context.
+
+        The default differs by entry point: single-tool ``invoke`` passes
+        ``"inline"`` (zero overhead, no cross-thread hop), while
+        ``execute_tool_calls`` passes the registry's ``_execution_mode``
+        (``"process"`` by default) so plain Python tools still get CPU
+        isolation in a batch.
 
         Future isolation backends (e.g. a sandbox) plug in here without
         touching ``invoke``/``ainvoke``.
@@ -378,28 +395,21 @@ class ToolRegistry(
         Args:
             tool: The :class:`Tool` to execute.
             execution_mode: Optional caller override.
+            default: Backend name to use when neither an explicit mode nor
+                a ``natural_backend`` hint applies.
 
         Returns:
             An execution backend instance.
         """
-        if execution_mode == "thread":
-            return self._thread_backend
-        if execution_mode == "process":
-            return self._process_backend
+        if execution_mode in ("thread", "process"):
+            return self._backend_for(execution_mode)
 
-        # force_thread still wins until Phase 3 removes it (PTC needs the
-        # main process for registry.invoke() IPC callbacks).
         metadata = getattr(tool, "metadata", None)
-        if metadata is not None and getattr(metadata, "force_thread", False):
-            return self._thread_backend
-
         natural = getattr(metadata, "natural_backend", None) if metadata else None
-        if natural == "thread":
-            return self._thread_backend
-        if natural == "process":
-            return self._process_backend
+        if natural in ("inline", "thread", "process"):
+            return self._backend_for(natural)
 
-        return self._inline_backend
+        return self._backend_for(default)
 
     def _check_tool_access(
         self,
@@ -1070,17 +1080,20 @@ class ToolRegistry(
     def _submit_tool_call(
         self,
         tc: Any,
-        backend: Any,
+        execution_mode: str | None,
         call_arguments: dict[str, dict],
-        mode: str,
     ) -> Any | _ToolError:
-        """Submit a single tool call for execution.
+        """Submit a single tool call using its resolved backend.
+
+        The backend is resolved per tool via :meth:`_resolve_backend`
+        (caller ``execution_mode`` > ``natural_backend`` > registry
+        default), so MCP/OpenAPI tools run inline while plain Python
+        tools use the batch default (process).
 
         Args:
             tc: The tool call to submit.
-            backend: Execution backend (process or thread).
+            execution_mode: Optional caller backend override.
             call_arguments: Map of call ID to parsed arguments.
-            mode: Current execution mode ("process" or "thread").
 
         Returns:
             An ExecutionHandle on success, or a ``_ToolError`` on failure.
@@ -1100,22 +1113,23 @@ class ToolRegistry(
             tool_obj.metadata.timeout if tool_obj and tool_obj.metadata else None
         )
 
-        # Tools with force_thread=True (e.g. PTC) must run in the main
-        # process so they can access the registry for invoke() callbacks.
-        # IPC subprocess isolation is handled inside the tool itself.
-        effective_backend = backend
-        if tool_obj and tool_obj.metadata.force_thread:
-            effective_backend = self._thread_backend
+        backend = self._resolve_backend(
+            tool_obj, execution_mode, default=self._execution_mode
+        )
 
         try:
-            return effective_backend.submit(
+            return backend.submit(
                 callable_func,
                 function_args,
                 execution_id=tc.id,
                 timeout=per_call_timeout,
             )
         except Exception as e:
-            if mode == "process":
+            # Safety net for a plain Python tool that resolved to the
+            # process backend but cannot be pickled (e.g. a closure over
+            # unpicklable state).  MCP/OpenAPI tools never reach here —
+            # they resolve to inline via natural_backend.
+            if backend is self._process_backend:
                 try:
                     return self._thread_backend.submit(
                         callable_func,
@@ -1183,7 +1197,6 @@ class ToolRegistry(
             element is a :class:`ToolCallResult` (success) or
             :class:`ErrorResult` (failure).
         """
-        from .executor import ExecutionHandle
         from .utils import generate_invocation_id
 
         batch_inv_id = generate_invocation_id("bat")
@@ -1196,8 +1209,215 @@ class ToolRegistry(
         if not enabled_calls:
             return self._wrap_results(generic_tool_calls, tool_responses)
 
-        mode = execution_mode or self._execution_mode
-        backend = self._thread_backend if mode == "thread" else self._process_backend
+        has_unsafe = any(
+            (tool_obj := self.get_tool(tc.name)) is not None
+            and not tool_obj.metadata.is_concurrency_safe
+            for tc in enabled_calls
+        )
+
+        if has_unsafe:
+            raw_results = self._execute_sequential(
+                enabled_calls, execution_mode, call_arguments
+            )
+        else:
+            raw_results = self._execute_concurrent(
+                enabled_calls, execution_mode, call_arguments
+            )
+        tool_responses.update(raw_results)
+
+        self._log_tool_call_results(
+            enabled_calls, raw_results, call_start_times, call_arguments, batch_inv_id
+        )
+
+        return self._wrap_results(generic_tool_calls, tool_responses)
+
+    def _execute_sequential(
+        self,
+        enabled_calls: list[Any],
+        execution_mode: str | None,
+        call_arguments: dict[str, dict],
+    ) -> dict[str, Any]:
+        """Submit + collect each call in order (used when an unsafe tool is present)."""
+        raw_results: dict[str, Any] = {}
+        for tc in enabled_calls:
+            handle_or_error = self._submit_tool_call(tc, execution_mode, call_arguments)
+            if isinstance(handle_or_error, _ToolError):
+                raw_results[tc.id] = handle_or_error
+            else:
+                raw_results[tc.id] = self._collect_handle_result(
+                    handle_or_error, tc.name
+                )
+        return raw_results
+
+    def _execute_concurrent(
+        self,
+        enabled_calls: list[Any],
+        execution_mode: str | None,
+        call_arguments: dict[str, dict],
+    ) -> dict[str, Any]:
+        """Run concurrency-safe calls with pool work overlapping inline work.
+
+        Submit pool-backed tools first so their handles run in the
+        background, then execute inline-backed tools, then collect the
+        pool handles — a slow inline tool never stalls submitted pool work.
+        """
+        from .executor import ExecutionHandle
+
+        raw_results: dict[str, Any] = {}
+        pool_handles: list[tuple[Any, ExecutionHandle]] = []
+        inline_calls: list[Any] = []
+
+        for tc in enabled_calls:
+            tool_obj = self.get_tool(tc.name)
+            backend = self._resolve_backend(
+                tool_obj, execution_mode, default=self._execution_mode
+            )
+            if backend is self._inline_backend:
+                inline_calls.append(tc)
+                continue
+            handle_or_error = self._submit_tool_call(tc, execution_mode, call_arguments)
+            if isinstance(handle_or_error, _ToolError):
+                raw_results[tc.id] = handle_or_error
+            else:
+                pool_handles.append((tc, handle_or_error))
+
+        for tc in inline_calls:
+            handle_or_error = self._submit_tool_call(tc, execution_mode, call_arguments)
+            if isinstance(handle_or_error, _ToolError):
+                raw_results[tc.id] = handle_or_error
+            else:
+                raw_results[tc.id] = self._collect_handle_result(
+                    handle_or_error, tc.name
+                )
+
+        for tc, handle in pool_handles:
+            raw_results[tc.id] = self._collect_handle_result(handle, tc.name)
+
+        return raw_results
+
+    async def _aclassify_tool_calls(
+        self,
+        generic_tool_calls: list[Any],
+        invocation_id: str | None = None,
+    ) -> tuple[list[Any], dict[str, Any], dict[str, float], dict[str, dict]]:
+        """Async twin of :meth:`_classify_tool_calls`.
+
+        Uses :meth:`_acheck_tool_access` so async permission handlers are
+        awaited natively instead of bridged through a thread pool.
+        """
+        enabled_calls: list[Any] = []
+        tool_responses: dict[str, Any] = {}
+        call_start_times: dict[str, float] = {}
+        call_arguments: dict[str, dict] = {}
+
+        for tc in generic_tool_calls:
+            try:
+                args = json.loads(tc.arguments)
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+
+            try:
+                await self._acheck_tool_access(tc.name, args, invocation_id)
+            except (KeyError, RuntimeError, PermissionError) as exc:
+                tool_responses[tc.id] = _ToolError(
+                    message=f"Error: {exc}",
+                    exception_type=type(exc).__qualname__,
+                )
+            else:
+                enabled_calls.append(tc)
+                call_start_times[tc.id] = time.perf_counter()
+                call_arguments[tc.id] = args
+
+        return enabled_calls, tool_responses, call_start_times, call_arguments
+
+    async def _aexecute_one(
+        self,
+        tc: Any,
+        execution_mode: str | None,
+        call_arguments: dict[str, dict],
+    ) -> Any:
+        """Execute one classified tool call asynchronously.
+
+        Returns the finalized result (str/content-block list) on success
+        or a :class:`_ToolError` on failure.  Inline-resolved tools are
+        awaited directly on the caller's loop; pool-backed tools submit
+        and await :meth:`ExecutionHandle.result_async`.
+        """
+        tool_obj = self.get_tool(tc.name)
+        if tool_obj is None:
+            return _ToolError(
+                message=f"Error: Tool '{tc.name}' not found or callable is None",
+            )
+
+        clean_kwargs = self._clean_kwargs(call_arguments.get(tc.id, {}))
+        per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
+        backend = self._resolve_backend(
+            tool_obj, execution_mode, default=self._execution_mode
+        )
+
+        try:
+            if backend is self._inline_backend:
+                raw = await tool_obj.arun(clean_kwargs)
+            else:
+                # Bind tool_obj as a default arg to avoid late-binding the
+                # loop variable across concurrent submissions.
+                handle = backend.submit(
+                    lambda _t=tool_obj, **kw: _t.run(kw),
+                    clean_kwargs,
+                    execution_id=tc.id,
+                    timeout=per_call_timeout,
+                )
+                raw = await handle.result_async()
+            return self._finalize_result(raw, tc.name)
+        except TimeoutError:
+            return _ToolError(
+                message=f"Error: Tool '{tc.name}' timed out",
+                exception_type="TimeoutError",
+                is_timeout=True,
+            )
+        except Exception as exc:
+            return _ToolError(
+                message=f"Error executing {tc.name}: {exc!s}",
+                exception_type=type(exc).__qualname__,
+                traceback_str=tb_module.format_exc(),
+            )
+
+    async def aexecute_tool_calls(
+        self,
+        tool_calls: list[Any],
+        execution_mode: Literal["process", "thread"] | None = None,
+    ) -> ResultList:
+        """Async counterpart to :meth:`execute_tool_calls`.
+
+        Runs concurrency-safe calls concurrently via ``asyncio.gather``
+        over the per-tool async pipeline: inline tools (MCP/OpenAPI and
+        async natives) overlap on the caller's loop, while pool-backed
+        tools run off-loop and are awaited via ``result_async``.  If any
+        tool is not concurrency-safe, all calls run sequentially.
+
+        Args:
+            tool_calls: Tool calls in any supported format.
+            execution_mode: Optional backend override.
+
+        Returns:
+            A :class:`ResultList` in the same order as *tool_calls*.
+        """
+        import asyncio
+
+        from .utils import generate_invocation_id
+
+        batch_inv_id = generate_invocation_id("bat")
+
+        generic_tool_calls = convert_tool_calls(tool_calls)
+        (
+            enabled_calls,
+            tool_responses,
+            call_start_times,
+            call_arguments,
+        ) = await self._aclassify_tool_calls(generic_tool_calls, batch_inv_id)
+
+        if not enabled_calls:
+            return self._wrap_results(generic_tool_calls, tool_responses)
 
         has_unsafe = any(
             (tool_obj := self.get_tool(tc.name)) is not None
@@ -1205,29 +1425,29 @@ class ToolRegistry(
             for tc in enabled_calls
         )
 
-        handles: list[tuple[Any, ExecutionHandle]] = []
         raw_results: dict[str, Any] = {}
 
-        for tc in enabled_calls:
-            handle_or_error = self._submit_tool_call(tc, backend, call_arguments, mode)
-            if isinstance(handle_or_error, _ToolError):
-                raw_results[tc.id] = handle_or_error
-                tool_responses[tc.id] = handle_or_error
-                continue
-
-            if has_unsafe:
-                result = self._collect_handle_result(handle_or_error, tc.name)
-                raw_results[tc.id] = (
-                    result if isinstance(result, _ToolError) else result
-                )
+        if has_unsafe:
+            for tc in enabled_calls:
+                result = await self._aexecute_one(tc, execution_mode, call_arguments)
+                raw_results[tc.id] = result
                 tool_responses[tc.id] = result
-            else:
-                handles.append((tc, handle_or_error))
-
-        for tc, handle in handles:
-            result = self._collect_handle_result(handle, tc.name)
-            raw_results[tc.id] = result if isinstance(result, _ToolError) else result
-            tool_responses[tc.id] = result
+        else:
+            results = await asyncio.gather(
+                *(
+                    self._aexecute_one(tc, execution_mode, call_arguments)
+                    for tc in enabled_calls
+                ),
+                return_exceptions=True,
+            )
+            for tc, result in zip(enabled_calls, results):
+                if isinstance(result, BaseException):
+                    result = _ToolError(
+                        message=f"Error executing {tc.name}: {result!s}",
+                        exception_type=type(result).__qualname__,
+                    )
+                raw_results[tc.id] = result
+                tool_responses[tc.id] = result
 
         self._log_tool_call_results(
             enabled_calls, raw_results, call_start_times, call_arguments, batch_inv_id

--- a/tests/test_aexecute_tool_calls.py
+++ b/tests/test_aexecute_tool_calls.py
@@ -1,0 +1,190 @@
+"""Tests for aexecute_tool_calls and per-tool backend resolution in batch."""
+
+import asyncio
+import time
+
+import pytest
+
+from toolregistry import Tool, ToolRegistry
+from toolregistry.llm.tool_calls import ErrorResult, ResultList, ToolCallResult
+from toolregistry.tool import ToolMetadata
+
+
+def _tc(cid: str, name: str, args: str):
+    return {
+        "id": cid,
+        "type": "function",
+        "function": {"name": name, "arguments": args},
+    }
+
+
+@pytest.fixture
+def registry():
+    reg = ToolRegistry()
+
+    def add(a: int, b: int) -> int:
+        """Add."""
+        return a + b
+
+    def mul(a: int, b: int) -> int:
+        """Multiply."""
+        return a * b
+
+    async def aslow(n: int) -> int:
+        """Async slow echo."""
+        await asyncio.sleep(0.2)
+        return n
+
+    reg.register(add)
+    reg.register(mul)
+    reg.register(aslow)
+    return reg
+
+
+class TestAexecuteToolCalls:
+    @pytest.mark.asyncio
+    async def test_basic_batch(self, registry):
+        tcs = [
+            _tc("c1", "add", '{"a": 2, "b": 3}'),
+            _tc("c2", "mul", '{"a": 4, "b": 5}'),
+        ]
+        r = await registry.aexecute_tool_calls(tcs)
+        assert isinstance(r, ResultList)
+        assert r["c1"].result == "5"
+        assert r["c2"].result == "20"
+
+    @pytest.mark.asyncio
+    async def test_ordering_preserved(self, registry):
+        tcs = [
+            _tc("c1", "add", '{"a": 1, "b": 1}'),
+            _tc("c2", "mul", '{"a": 2, "b": 3}'),
+            _tc("c3", "add", '{"a": 5, "b": 5}'),
+        ]
+        r = await registry.aexecute_tool_calls(tcs)
+        assert [x.id for x in r] == ["c1", "c2", "c3"]
+
+    @pytest.mark.asyncio
+    async def test_async_tools_overlap(self, registry):
+        """Two 0.2s async tools should overlap under gather (~0.2s not 0.4s)."""
+        tcs = [
+            _tc("c1", "aslow", '{"n": 1}'),
+            _tc("c2", "aslow", '{"n": 2}'),
+        ]
+        start = time.perf_counter()
+        r = await registry.aexecute_tool_calls(tcs)
+        elapsed = time.perf_counter() - start
+        assert {x.result for x in r} == {"1", "2"}
+        assert elapsed < 0.35
+
+    @pytest.mark.asyncio
+    async def test_tool_error_is_error_result(self, registry):
+        def boom(x: int) -> int:
+            raise ValueError("broken")
+
+        registry.register(boom)
+        tcs = [
+            _tc("c1", "add", '{"a": 1, "b": 2}'),
+            _tc("c2", "boom", '{"x": 1}'),
+        ]
+        r = await registry.aexecute_tool_calls(tcs)
+        assert isinstance(r["c1"], ToolCallResult)
+        assert isinstance(r["c2"], ErrorResult)
+        assert "broken" in r["c2"].message
+
+    @pytest.mark.asyncio
+    async def test_disabled_tool_is_error_result(self, registry):
+        registry.disable("mul", reason="maint")
+        tcs = [
+            _tc("c1", "add", '{"a": 1, "b": 2}'),
+            _tc("c2", "mul", '{"a": 2, "b": 3}'),
+        ]
+        r = await registry.aexecute_tool_calls(tcs)
+        assert isinstance(r["c1"], ToolCallResult)
+        assert isinstance(r["c2"], ErrorResult)
+
+    @pytest.mark.asyncio
+    async def test_concurrency_unsafe_runs_sequentially(self, registry):
+        """An unsafe tool forces the whole batch onto the sequential path.
+
+        Uses async inline tools so timing is observable: under the
+        sequential path two 0.2s sleeps take ~0.4s (no overlap), versus
+        ~0.2s if they had been gathered.
+        """
+
+        async def slow_unsafe(n: int) -> int:
+            await asyncio.sleep(0.2)
+            return n
+
+        async def slow_safe(n: int) -> int:
+            await asyncio.sleep(0.2)
+            return n
+
+        registry.register(
+            Tool.from_function(
+                slow_unsafe, metadata=ToolMetadata(is_concurrency_safe=False)
+            )
+        )
+        registry.register(slow_safe)
+
+        tcs = [
+            _tc("c1", "slow_unsafe", '{"n": 1}'),
+            _tc("c2", "slow_safe", '{"n": 2}'),
+        ]
+        start = time.perf_counter()
+        r = await registry.aexecute_tool_calls(tcs)
+        elapsed = time.perf_counter() - start
+
+        assert r["c1"].result == "1"
+        assert r["c2"].result == "2"
+        # Sequential (no gather): the two 0.2s sleeps do not overlap.
+        assert elapsed >= 0.4
+
+
+class TestBatchBackendResolution:
+    """Per-tool backend resolution in execute_tool_calls (sync)."""
+
+    def test_mixed_inline_and_pool(self, registry):
+        # ping resolves to inline (like MCP/OpenAPI); add uses batch default.
+        def ping(x: int) -> int:
+            """Ping."""
+            return x
+
+        registry.register(
+            Tool.from_function(ping, metadata=ToolMetadata(natural_backend="inline"))
+        )
+        tcs = [
+            _tc("c1", "add", '{"a": 1, "b": 1}'),
+            _tc("c2", "ping", '{"x": 9}'),
+        ]
+        r = registry.execute_tool_calls(tcs)
+        assert r["c1"].result == "2"
+        assert r["c2"].result == "9"
+        assert [x.id for x in r] == ["c1", "c2"]
+
+    def test_execution_mode_override(self, registry):
+        tcs = [_tc("c1", "add", '{"a": 3, "b": 4}')]
+        r = registry.execute_tool_calls(tcs, execution_mode="thread")
+        assert r["c1"].result == "7"
+
+    def test_inline_natural_backend_resolves_inline(self, registry):
+        def ping(x: int) -> int:
+            """Ping."""
+            return x
+
+        registry.register(
+            Tool.from_function(ping, metadata=ToolMetadata(natural_backend="inline"))
+        )
+        tool = registry.get_tool("ping")
+        # batch default is process, but natural_backend wins.
+        backend = registry._resolve_backend(
+            tool, None, default=registry._execution_mode
+        )
+        assert backend is registry._inline_backend
+
+    def test_plain_tool_uses_batch_default(self, registry):
+        tool = registry.get_tool("add")
+        backend = registry._resolve_backend(
+            tool, None, default=registry._execution_mode
+        )
+        # default execution mode is process
+        assert backend is registry._process_backend


### PR DESCRIPTION
## Summary

Phase 3 (final) of the execution-stack refactor (#222). Batch execution now goes through the same `_resolve_backend` seam as `invoke`, gains an async entry point, and the `force_thread` special case is gone. Builds on #223 (primitives) and #224 (invoke seam).

Closes #225.

### Per-tool backend in `execute_tool_calls`
Backend is resolved **per tool**: `caller execution_mode > tool.natural_backend > registry _execution_mode (default process)`. MCP/OpenAPI tools (`natural_backend="inline"`) run inline; plain Python tools keep the process default.

This fixes a latent bug: a process-mode batch previously tried to cloudpickle live MCP/OpenAPI connections, failed, and silently degraded to a thread fallback per call (wasted pickle attempt + lost parallelism + no signal). Now those tools route to inline upfront.

**Root cause (confirmed in discussion):** the blocker was never "single client" — it's that live connection state (MCP `ClientSession` + stdio/socket streams + loop-bound lock; httpx open sockets) is non-picklable and event-loop-bound, so it can't cross a process boundary. Async concurrency on one loop was never blocked (httpx pool is multi-inflight; MCP multiplexes by request-id). Correct parallelism = gather over the async pipeline on the shared loop.

Concurrency-safe batches submit pool work first, then run inline tools, then collect handles — a slow inline tool never stalls already-submitted pool work (Milo's note). Extracted `_execute_sequential` / `_execute_concurrent` to stay under the complexity limit.

### `aexecute_tool_calls`
Async batch = `asyncio.gather` over a per-tool async pipeline: inline tools `await tool.arun()` on the caller's loop (MCP/OpenAPI overlap naturally), pool tools `submit` + `await result_async()`. `return_exceptions=True` matches sync semantics; a non-concurrency-safe tool forces the sequential path. `_aclassify_tool_calls` uses the native async permission check (no thread-pool bridge).

### `force_thread` removed
Deleted from `ToolMetadata`, `_resolve_backend`, and `_submit_tool_call`. PTC's `programmatic_tool_call` tool now carries `natural_backend="inline"` — it must run in the main process for its IPC registry callbacks, which `inline` guarantees. All PTC tests pass unchanged.

The `process → thread` submit fallback is kept only as a safety net for a plain Python tool that resolved to process but isn't picklable; MCP/OpenAPI never reach it now.

## Test plan

- [x] `tests/test_aexecute_tool_calls.py` (new): async batch basics, ordering, async-tool overlap timing, tool-error → ErrorResult, disabled → ErrorResult, concurrency-unsafe forces sequential (timing-verified); sync per-tool backend resolution (mixed inline+pool, execution_mode override, natural_backend precedence, plain-tool default)
- [x] PTC works without force_thread (`test_ptc_tool.py`, `test_ptc_invocation_id.py`)
- [x] Existing batch/executor/integration suites pass
- [x] Full suite: **1079 passed** (2 pre-existing warnings)
- [x] `pre-commit run` — ruff, ruff-format, ty, complexipy all pass

## Notes

- `execute_tool_calls` / `set_default_execution_mode` signatures unchanged. Plain Python tools keep the process default — not a behavior change.
- Breaking only for external code that set `force_thread` (undocumented internal flag).
- Docs (changelog + API pages for `ainvoke`/`aexecute_tool_calls`/Result return type, in both languages) will follow in a consolidated pass covering Phases 1–3.

## Context

Final phase of #222 → #223 (merged) / #224 (merged) / #225 (this). Design and the per-tool-backend decision were confirmed with the team. AI was used to assist with implementation.