### PR TITLE
refactor(executor): lazy InlineBackend, eliminate ainvoke Handle bypass (#229)

### DIFF
--- a/src/toolregistry/executor/_inline_backend.py
+++ b/src/toolregistry/executor/_inline_backend.py
@@ -66,6 +66,7 @@ class InlineExecutionHandle(ExecutionHandle):
         if self._executed:
             return False
         self._cancelled = True
+        self._fn = self._kwargs = None
         return True
 
     def status(self) -> HandleStatus:

--- a/src/toolregistry/executor/_inline_backend.py
+++ b/src/toolregistry/executor/_inline_backend.py
@@ -1,8 +1,9 @@
-"""Inline execution backend that runs the target in the current context."""
+"""Inline execution backend — lazy capture, deferred execution."""
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import uuid
 from typing import Any
 from collections.abc import Callable
@@ -18,32 +19,60 @@ from ._types import (
 
 
 class InlineExecutionHandle(ExecutionHandle):
-    """Handle wrapping an already-completed inline execution.
+    """Handle for a lazily-captured inline execution.
 
-    ``InlineBackend.submit`` runs the callable eagerly, so the handle
-    is created in a terminal state carrying either a captured return
-    value or a captured exception.
+    ``InlineBackend.submit`` only captures the callable and arguments;
+    execution is deferred to :meth:`result` (sync) or
+    :meth:`result_async` (async).
+
+    While the handle is in the PENDING state, :meth:`cancel` can
+    prevent execution entirely.
+
+    Note:
+        This handle is **not thread-safe**.  It is designed for
+        single-context use (one thread or one coroutine at a time).
+        ``ThreadExecutionHandle`` gets thread safety from
+        ``concurrent.futures.Future``; this class has no internal
+        locking because inline execution inherently runs in the
+        caller's own context.
     """
 
     def __init__(
         self,
         exec_id: str,
-        value: Any = None,
-        exception: BaseException | None = None,
+        fn: Callable[..., Any],
+        kwargs: dict[str, Any],
+        is_async: bool,
     ) -> None:
         self._exec_id = exec_id
-        self._value = value
-        self._exception = exception
+        self._fn: Callable[..., Any] | None = fn
+        self._kwargs: dict[str, Any] | None = kwargs
+        self._is_async = is_async
+        self._executed = False
+        self._cancelled = False
+        self._value: Any = None
+        self._exception: BaseException | None = None
 
     @property
     def execution_id(self) -> str:
         return self._exec_id
 
     def cancel(self) -> bool:
-        # Execution already finished by the time the handle exists.
-        return False
+        """Cancel before execution.
+
+        Returns ``True`` if the handle was still pending and is now
+        cancelled; ``False`` if it has already been executed.
+        """
+        if self._executed:
+            return False
+        self._cancelled = True
+        return True
 
     def status(self) -> HandleStatus:
+        if self._cancelled:
+            return HandleStatus.CANCELLED
+        if not self._executed:
+            return HandleStatus.PENDING
         if isinstance(self._exception, CancelledError):
             return HandleStatus.CANCELLED
         if self._exception is not None:
@@ -51,37 +80,115 @@ class InlineExecutionHandle(ExecutionHandle):
         return HandleStatus.COMPLETED
 
     def result(self, timeout: float | None = None) -> Any:
+        """Execute synchronously and return the result.
+
+        Inline execution does not support ``timeout`` — the callable
+        runs in the calling thread with no way to interrupt it
+        externally.  The parameter is accepted for interface
+        compatibility but is ignored.
+        """
+        if self._cancelled:
+            raise CancelledError("Execution was cancelled before it started")
+        if not self._executed:
+            self._run_sync()
+            # A non-async-def callable (e.g. lambda wrapping tool.arun)
+            # may have returned a coroutine. Drive it via asyncio.run()
+            # so the caller gets a real value, not a leaked coroutine.
+            if self._exception is None and asyncio.iscoroutine(self._value):
+                try:
+                    self._value = asyncio.run(self._value)
+                except BaseException as exc:  # noqa: BLE001
+                    self._exception = exc
         if self._exception is not None:
             raise self._exception
         return self._value
 
     async def result_async(self, timeout: float | None = None) -> Any:
+        """Execute and return the result, awaiting if the callable is async.
+
+        For async callables (``tool.arun``), the coroutine is awaited
+        directly on the caller's event loop — no ``asyncio.run()`` and
+        no new loop.  For sync callables (``tool.run``), the function
+        is called inline in the current thread.
+
+        Detection is two-layered: ``_is_async`` (set at submit time via
+        ``iscoroutinefunction``) handles ``async def`` callables, and a
+        runtime ``iscoroutine`` check on the return value catches
+        non-``async def`` callables that return coroutines (e.g. a
+        lambda wrapping ``tool.arun``).
+
+        Like :meth:`result`, ``timeout`` is accepted for interface
+        compatibility but is not enforced — inline execution has no
+        external mechanism to interrupt a running callable.
+        """
+        if self._cancelled:
+            raise CancelledError("Execution was cancelled before it started")
+        if not self._executed:
+            if self._is_async:
+                await self._run_async()
+            else:
+                self._run_sync()
+                # A non-async-def callable (e.g. lambda wrapping
+                # tool.arun) may have returned a coroutine — await it
+                # on the caller's loop instead of asyncio.run().
+                if self._exception is None and asyncio.iscoroutine(self._value):
+                    try:
+                        self._value = await self._value
+                    except BaseException as exc:  # noqa: BLE001
+                        self._exception = exc
         if self._exception is not None:
             raise self._exception
         return self._value
 
     def on_progress(self, callback: Callable[[ProgressReport], None]) -> None:
-        # Inline execution has already finished; no progress to report.
         pass
+
+    def _run_sync(self) -> None:
+        """Drive execution synchronously.
+
+        For async callables, ``asyncio.run()`` is used to create a
+        temporary event loop — matching the behavior of
+        ``_FunctionToolWrapper.call_sync()`` for async functions.
+
+        Coroutines returned by non-async-def callables (e.g. lambdas)
+        are left in ``_value`` for the caller (``result`` or
+        ``result_async``) to handle with the appropriate driver.
+        """
+        assert self._fn is not None and self._kwargs is not None
+        try:
+            if self._is_async:
+                self._value = asyncio.run(self._fn(**self._kwargs))
+            else:
+                self._value = self._fn(**self._kwargs)
+        except BaseException as exc:  # noqa: BLE001
+            self._exception = exc
+        self._executed = True
+        self._fn = self._kwargs = None
+
+    async def _run_async(self) -> None:
+        """Drive execution by awaiting the callable."""
+        assert self._fn is not None and self._kwargs is not None
+        try:
+            self._value = await self._fn(**self._kwargs)
+        except BaseException as exc:  # noqa: BLE001
+            self._exception = exc
+        self._executed = True
+        self._fn = self._kwargs = None
 
 
 class InlineBackend:
     """Execution backend that runs the callable in the current context.
 
-    No thread or process pool is used — the target runs eagerly and
-    synchronously in the calling thread.  This is the "no isolation"
-    backend suited to tools that are already isolated elsewhere
+    No thread or process pool is used.  ``submit()`` captures the
+    callable and arguments without executing them; execution is
+    deferred to ``handle.result()`` (sync) or ``handle.result_async()``
+    (async).  This makes the backend usable from both sync and async
+    callers without losing native async semantics.
+
+    Inline execution does not provide process or thread isolation.
+    It is suited to tools that are already isolated elsewhere
     (e.g. MCP servers, remote HTTP APIs), where pooling or pickling
     the target would be wrong or impossible.
-
-    Note:
-        A *bare* async callable (one without a ``call_sync`` method) is
-        driven via ``asyncio.run``, which cannot run while an event loop
-        is already active in the calling thread.  Submitting such a
-        callable from inside a running loop raises ``RuntimeError`` with
-        a clear message — call the coroutine's async path directly
-        instead.  Tool wrappers (``BaseToolWrapper``) expose
-        ``call_sync``/``call_async`` and are unaffected.
     """
 
     def submit(
@@ -92,43 +199,19 @@ class InlineBackend:
         execution_id: str | None = None,
         timeout: float | None = None,
     ) -> ExecutionHandle:
-        # ``timeout`` is part of the backend interface but has no effect
-        # here: inline execution is eager and synchronous, so there is
-        # no pending future to time out against.
         exec_id = execution_id or uuid.uuid4().hex
 
-        # Wrap bare async functions so they can run inline.  Tool
-        # wrappers (BaseToolWrapper) handle sync/async internally, so
-        # only wrap bare async callables passed directly.
+        # Detect whether the callable is async so the handle can choose
+        # between await and direct call at execution time.
         raw_fn = getattr(fn, "fn", fn)
-        if asyncio.iscoroutinefunction(raw_fn) and not hasattr(fn, "call_sync"):
-            async_fn = fn
-
-            def _sync_wrapper(**kw):  # type: ignore[no-untyped-def]
-                try:
-                    asyncio.get_running_loop()
-                except RuntimeError:
-                    return asyncio.run(async_fn(**kw))
-                raise RuntimeError(
-                    "InlineBackend cannot run a bare async callable while an "
-                    "event loop is already running in this thread. Await the "
-                    "coroutine directly (e.g. via the tool's async path) "
-                    "instead of submitting it to InlineBackend."
-                )
-
-            fn = _sync_wrapper
+        is_async = inspect.iscoroutinefunction(raw_fn)
 
         # Context injection
         if should_inject_context(fn):
             ctx = ExecutionContext()
             kwargs = {**kwargs, "_ctx": ctx}
 
-        try:
-            value = fn(**kwargs)
-        except BaseException as exc:  # noqa: BLE001 - captured, re-raised on result()
-            return InlineExecutionHandle(exec_id, exception=exc)
-        return InlineExecutionHandle(exec_id, value=value)
+        return InlineExecutionHandle(exec_id, fn, kwargs, is_async)
 
     def shutdown(self, wait: bool = True) -> None:
-        # Nothing to release — inline execution owns no pool.
         pass

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -827,20 +827,22 @@ class ToolRegistry(
         start = time.perf_counter()
         outcome: Any
         try:
+            # Inline backend: pass tool.arun so result_async() can
+            # await the coroutine natively on the caller's loop.
+            # Pool backends: pass tool.run (sync) for execution in
+            # the worker thread/process.
             if backend is self._inline_backend:
-                # Native async path: await on the caller's loop so the
-                # tool's transport (MCP/OpenAPI) stays non-blocking.
-                raw = await tool_obj.arun(clean_kwargs)
-                outcome = self._finalize_result(raw, tool_name)
+                submit_fn = lambda **kw: tool_obj.arun(kw)  # noqa: E731
             else:
-                handle = backend.submit(
-                    lambda **kw: tool_obj.run(kw),
-                    clean_kwargs,
-                    execution_id=invocation_id,
-                    timeout=per_call_timeout,
-                )
-                raw = await handle.result_async()
-                outcome = self._finalize_result(raw, tool_name)
+                submit_fn = lambda **kw: tool_obj.run(kw)  # noqa: E731
+            handle = backend.submit(
+                submit_fn,
+                clean_kwargs,
+                execution_id=invocation_id,
+                timeout=per_call_timeout,
+            )
+            raw = await handle.result_async()
+            outcome = self._finalize_result(raw, tool_name)
         except TimeoutError:
             outcome = _ToolError(
                 message=f"Error: Tool '{tool_name}' timed out",
@@ -1369,18 +1371,20 @@ class ToolRegistry(
         )
 
         try:
+            # Inline: pass tool.arun (async) so result_async can await.
+            # Pool: pass tool.run (sync) for worker execution.
+            # Bind tool_obj as default arg to avoid closure-over-loop.
             if backend is self._inline_backend:
-                raw = await tool_obj.arun(clean_kwargs)
+                submit_fn = lambda _t=tool_obj, **kw: _t.arun(kw)  # noqa: E731
             else:
-                # Bind tool_obj as a default arg to avoid late-binding the
-                # loop variable across concurrent submissions.
-                handle = backend.submit(
-                    lambda _t=tool_obj, **kw: _t.run(kw),
-                    clean_kwargs,
-                    execution_id=tc.id,
-                    timeout=per_call_timeout,
-                )
-                raw = await handle.result_async()
+                submit_fn = lambda _t=tool_obj, **kw: _t.run(kw)  # noqa: E731
+            handle = backend.submit(
+                submit_fn,
+                clean_kwargs,
+                execution_id=tc.id,
+                timeout=per_call_timeout,
+            )
+            raw = await handle.result_async()
             return self._finalize_result(raw, tc.name)
         except TimeoutError:
             return _ToolError(

--- a/tests/test_executor/test_inline_backend.py
+++ b/tests/test_executor/test_inline_backend.py
@@ -1,8 +1,11 @@
-"""Tests for InlineBackend."""
+"""Tests for InlineBackend (lazy capture, deferred execution)."""
+
+import threading
 
 import pytest
 
 from toolregistry.executor import (
+    CancelledError,
     ExecutionContext,
     HandleStatus,
     InlineBackend,
@@ -10,6 +13,22 @@ from toolregistry.executor import (
 
 
 class TestInlineBackend:
+    def test_submit_does_not_execute(self):
+        """submit() only captures — status is PENDING until result()."""
+        backend = InlineBackend()
+        executed = []
+
+        def work() -> int:
+            executed.append(True)
+            return 42
+
+        handle = backend.submit(work, {})
+        assert handle.status() == HandleStatus.PENDING
+        assert executed == []
+        assert handle.result() == 42
+        assert handle.status() == HandleStatus.COMPLETED
+        assert executed == [True]
+
     def test_submit_sync_function(self):
         backend = InlineBackend()
 
@@ -20,7 +39,8 @@ class TestInlineBackend:
         assert handle.result() == 7
         assert handle.status() == HandleStatus.COMPLETED
 
-    def test_submit_async_function(self):
+    def test_submit_async_function_sync_result(self):
+        """Async fn driven via result() uses asyncio.run internally."""
         backend = InlineBackend()
 
         async def add(x: int, y: int) -> int:
@@ -28,6 +48,29 @@ class TestInlineBackend:
 
         handle = backend.submit(add, {"x": 5, "y": 6})
         assert handle.result() == 11
+
+    @pytest.mark.asyncio
+    async def test_submit_async_function_async_result(self):
+        """Async fn driven via result_async() is awaited natively."""
+        backend = InlineBackend()
+
+        async def add(x: int, y: int) -> int:
+            return x + y
+
+        handle = backend.submit(add, {"x": 5, "y": 6})
+        assert await handle.result_async() == 11
+
+    @pytest.mark.asyncio
+    async def test_lambda_wrapping_async_fn_via_result_async(self):
+        """A lambda returning a coroutine is awaited by result_async."""
+        backend = InlineBackend()
+
+        async def inner(x: int) -> int:
+            return x * 2
+
+        # Simulates ainvoke's lambda **kw: tool.arun(kw) pattern.
+        handle = backend.submit(lambda **kw: inner(**kw), {"x": 21})
+        assert await handle.result_async() == 42
 
     def test_context_injection(self):
         backend = InlineBackend()
@@ -45,19 +88,37 @@ class TestInlineBackend:
             raise ValueError("boom")
 
         handle = backend.submit(fail, {})
-        assert handle.status() == HandleStatus.FAILED
+        # Not yet executed (lazy) — status is PENDING.
+        assert handle.status() == HandleStatus.PENDING
         with pytest.raises(ValueError, match="boom"):
             handle.result()
+        assert handle.status() == HandleStatus.FAILED
 
-    def test_cancel_returns_false(self):
+    def test_cancel_before_execution(self):
+        """cancel() in PENDING state prevents execution."""
+        backend = InlineBackend()
+        executed = []
+
+        def work() -> int:
+            executed.append(True)
+            return 1
+
+        handle = backend.submit(work, {})
+        assert handle.cancel() is True
+        assert handle.status() == HandleStatus.CANCELLED
+        with pytest.raises(CancelledError):
+            handle.result()
+        assert executed == []
+
+    def test_cancel_after_execution_returns_false(self):
         backend = InlineBackend()
         handle = backend.submit(lambda: 1, {})
+        handle.result()  # execute
         assert handle.cancel() is False
 
     def test_on_progress_noop(self):
         backend = InlineBackend()
         handle = backend.submit(lambda: 1, {})
-        # Should not raise even though inline has no progress support.
         handle.on_progress(lambda r: None)
         assert handle.result() == 1
 
@@ -72,8 +133,6 @@ class TestInlineBackend:
         assert len(handle.execution_id) > 0
 
     def test_runs_in_calling_thread(self):
-        import threading
-
         backend = InlineBackend()
         caller_thread = threading.get_ident()
         captured: dict[str, int] = {}
@@ -87,32 +146,18 @@ class TestInlineBackend:
 
     def test_shutdown_noop(self):
         backend = InlineBackend()
-        backend.shutdown()  # should not raise
+        backend.shutdown()
 
-    def test_bare_async_from_sync_context_runs(self):
-        """A bare async callable runs fine when no loop is active."""
+    def test_result_idempotent(self):
+        """Calling result() twice returns the same value, no re-execution."""
         backend = InlineBackend()
+        count = []
 
-        async def double(x: int) -> int:
-            return x * 2
+        def work() -> int:
+            count.append(1)
+            return 42
 
-        handle = backend.submit(double, {"x": 21})
+        handle = backend.submit(work, {})
         assert handle.result() == 42
-
-    @pytest.mark.asyncio
-    async def test_bare_async_from_running_loop_raises_clear_error(self):
-        """Submitting a bare async callable inside a running loop raises.
-
-        InlineBackend drives bare coroutines via ``asyncio.run``, which
-        cannot run under an active loop.  It should fail fast with a
-        clear message rather than an opaque RuntimeError.
-        """
-        backend = InlineBackend()
-
-        async def double(x: int) -> int:
-            return x * 2
-
-        # The exception is captured at submit and re-raised on result().
-        handle = backend.submit(double, {"x": 21})
-        with pytest.raises(RuntimeError, match="event loop is already running"):
-            handle.result()
+        assert handle.result() == 42
+        assert len(count) == 1

--- a/tests/test_executor/test_inline_backend.py
+++ b/tests/test_executor/test_inline_backend.py
@@ -60,6 +60,16 @@ class TestInlineBackend:
         handle = backend.submit(add, {"x": 5, "y": 6})
         assert await handle.result_async() == 11
 
+    def test_lambda_wrapping_async_fn_via_result(self):
+        """A lambda returning a coroutine is driven by result() via asyncio.run."""
+        backend = InlineBackend()
+
+        async def inner(x: int) -> int:
+            return x * 2
+
+        handle = backend.submit(lambda **kw: inner(**kw), {"x": 21})
+        assert handle.result() == 42
+
     @pytest.mark.asyncio
     async def test_lambda_wrapping_async_fn_via_result_async(self):
         """A lambda returning a coroutine is awaited by result_async."""


### PR DESCRIPTION
## Summary

Makes `InlineBackend` lazy — `submit()` captures `fn + kwargs` without executing; execution is deferred to `handle.result()` (sync) or `handle.result_async()` (async). This eliminates the structural bypass where `ainvoke`'s inline path skipped the `ExecutionHandle` seam.

Closes #229. Follow-up to the execution-stack refactor (#222).

### What changed

**InlineBackend** (`_inline_backend.py`):
- `submit()` no longer runs the callable — it returns a PENDING handle
- `result()` drives execution synchronously (`asyncio.run` for async callables)
- `result_async()` awaits async callables natively on the caller's loop; also catches lambdas that return coroutines (the `lambda **kw: tool.arun(kw)` pattern)
- `cancel()` works in PENDING state (prevents execution, raises `CancelledError`)

**ainvoke / _aexecute_one** (`tool_registry.py`):
- Removed `if backend is self._inline_backend` bypass
- Inline passes `tool.arun` to submit, pool passes `tool.run`; both go through `submit → handle.result_async()` uniformly
- No more "bypass ④ Handle" arrow in the architecture diagram

### Why

The bypass was a structural inconsistency: `invoke()` went through the handle seam, but `ainvoke()` inline didn't. A future sandbox backend or handle-level observability (metrics, tracing) would need ainvoke-specific special cases — every new backend would add an `if` branch in the caller instead of just implementing the protocol.

### Design (group consensus)

- Lazy submit captures, result/result_async drives (Elena, Clementine, Milo)
- `_is_async` flag at submit time + runtime `iscoroutine` fallback for lambda wrappers (Milo, Clementine)
- `cancel()` works in PENDING state (Milo)
- Strict: ainvoke only passes async callables (Clementine)

## Test plan

- [x] `test_inline_backend.py` rewritten for lazy semantics (PENDING after submit, COMPLETED after result, cancel works, idempotent result, lambda-wrapping-async via result_async)
- [x] `test_handle_result_async.py` — inline still passes (result_async on lazy handle)
- [x] ainvoke/aexecute/PTC suites pass (now through handle, no bypass)
- [x] Full suite: **1082 passed** (2 pre-existing warnings)
- [x] `pre-commit run` — ruff, ruff-format, ty, complexipy all pass