### PR TITLE
refactor(mcp): add v1/v2 compat layer for client-side integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.0.0,<2.0.0", "httpx>=0.28.1"]
+mcp = ["mcp>=1.24.0,<2.0.0", "httpx>=0.28.1"]
 openapi = []
 langchain = ["langchain-core>=0.3,<0.4", "langchain-community>=0.3,<0.4"]
 ptc = ["codecell>=0.2.1,<0.3.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.24.0,<2.0.0", "httpx>=0.28.1"]
+mcp = ["mcp>=1.24.0,<3", "httpx>=0.28.1"]
 openapi = []
 langchain = ["langchain-core>=0.3,<0.4", "langchain-community>=0.3,<0.4"]
 ptc = ["codecell>=0.2.1,<0.3.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
-exclude = ["src/toolregistry/_vendor"]
+exclude = [
+    "src/toolregistry/_vendor",
+    "src/toolregistry/integrations/mcp/_compat.py",
+]
 
 [tool.ty.rules]
 unresolved-import = "ignore"

--- a/src/toolregistry/_vendor/jsonx.py
+++ b/src/toolregistry/_vendor/jsonx.py
@@ -1,23 +1,25 @@
 # /// zerodep
-# version = "0.3.0"
+# version = "1.0.0"
 # deps = []
 # tier = "simple"
-# category = "data"
-# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# category = "serialization"
+# note = "Install/update via `zerodep add jsonx`"
 # ///
 
-"""JSONC (JSON with Comments) parser — zero dependencies, stdlib only, Python 3.10+.
+"""Extended JSON parser — zero dependencies, stdlib only, Python 3.10+.
 
 Part of zerodep: https://github.com/Oaklight/zerodep
 Copyright (c) 2026 Peng Ding. MIT License.
 
-Drop-in replacement for commentjson / stdlib json with JSONC support.
+Drop-in replacement for commentjson / stdlib json with JSONC support,
+plus JSONL (JSON Lines) helpers.
 
 Supports:
     - Single-line comments: ``//`` and ``#``
     - Block comments: ``/* ... */``
     - Trailing commas in objects and arrays
     - All standard JSON types
+    - JSONL (one JSON value per line, with optional comments)
 
 Example::
 
@@ -25,6 +27,10 @@ Example::
     # {'a': 1, 'b': 2}
     load(open("config.jsonc"))
     # {...}
+
+    # JSONL with comments
+    loads_lines('{"a":1}\n// skip\n{"b":2}')
+    # [{'a': 1}, {'b': 2}]
 """
 
 from __future__ import annotations
@@ -39,6 +45,10 @@ __all__ = [
     "load",
     "dumps",
     "dump",
+    "loads_lines",
+    "load_lines",
+    "dumps_lines",
+    "dump_lines",
 ]
 
 # ── Comment stripping ─────────────────────────────────────────────────────────
@@ -350,3 +360,117 @@ def dump(
         sort_keys=sort_keys,
         **kwargs,
     )
+
+
+# ── JSONL (JSON Lines) API ────────────────────────────────────────────────────────────
+
+# JSONL = one JSON value per line.  Each line is preprocessed through the
+# JSONC comment/trailing-comma stripper, so "JSONL with comments" works
+# out of the box.
+
+
+def _is_blank_or_comment(line: str) -> bool:
+    """Return *True* if *line* is empty or a pure-comment line."""
+    s = line.strip()
+    return s == "" or s.startswith("//") or s.startswith("#")
+
+
+def loads_lines(
+    text: str,
+    **kwargs: Any,
+) -> list[Any]:
+    """Deserialize a JSONL string to a list of Python objects.
+
+    Uses a batch fast-path for clean JSONL: non-empty lines are joined
+    into a JSON array and parsed in a single :func:`json.loads` call,
+    matching ``ndjson``-level performance.  If that fails (comments,
+    trailing commas, etc.), falls back to per-line JSONC processing.
+
+    Args:
+        text: JSONL source string (one JSON value per line).
+        **kwargs: Keyword arguments forwarded to :func:`json.loads`
+            (or :func:`loads` on fallback).
+
+    Returns:
+        List of deserialized Python objects.
+
+    Raises:
+        JSONCDecodeError: If any line contains invalid JSON/JSONC.
+    """
+    lines = text.split("\n")
+    stripped = [ln for ln in lines if ln.strip()]
+    if not stripped:
+        return []
+    # Fast path: join non-empty lines into a JSON array, single parse.
+    # This avoids per-line Python overhead and lets the C json parser
+    # handle everything in one call.
+    _json_loads = json.loads
+    try:
+        return _json_loads("[" + ",".join(stripped) + "]", **kwargs)
+    except json.JSONDecodeError:
+        pass
+    # Slow path: comments, trailing commas, or JSONC syntax present.
+    results: list[Any] = []
+    for line in lines:
+        if _is_blank_or_comment(line):
+            continue
+        try:
+            results.append(_json_loads(line, **kwargs))
+        except json.JSONDecodeError:
+            results.append(loads(line, **kwargs))
+    return results
+
+
+def load_lines(
+    fp: IO[str],
+    **kwargs: Any,
+) -> list[Any]:
+    """Deserialize a JSONL file to a list of Python objects.
+
+    Args:
+        fp: A text file-like object containing JSONL.
+        **kwargs: Keyword arguments forwarded to :func:`loads`.
+
+    Returns:
+        List of deserialized Python objects.
+
+    Raises:
+        JSONCDecodeError: If any line contains invalid JSON/JSONC.
+    """
+    return loads_lines(fp.read(), **kwargs)
+
+
+def dumps_lines(
+    objects: list[Any],
+    **kwargs: Any,
+) -> str:
+    """Serialize a list of Python objects to a JSONL string.
+
+    Each object is serialized on its own line using :func:`json.dumps`.
+    No trailing newline is emitted (consistent with ``"\\n".join(...)``
+    semantics).
+
+    Args:
+        objects: Iterable of Python objects to serialize.
+        **kwargs: Keyword arguments forwarded to :func:`json.dumps`.
+
+    Returns:
+        JSONL string (one JSON value per line).
+    """
+    return "\n".join(json.dumps(obj, **kwargs) for obj in objects)
+
+
+def dump_lines(
+    objects: list[Any],
+    fp: IO[str],
+    **kwargs: Any,
+) -> None:
+    """Serialize a list of Python objects to a JSONL file.
+
+    Args:
+        objects: Iterable of Python objects to serialize.
+        fp: A text file-like object to write to.
+        **kwargs: Keyword arguments forwarded to :func:`json.dumps`.
+    """
+    fp.write(dumps_lines(objects, **kwargs))
+    fp.write("\n")

--- a/src/toolregistry/config/_loader.py
+++ b/src/toolregistry/config/_loader.py
@@ -101,7 +101,7 @@ def _detect_format(path: Path) -> Literal["jsonc", "yaml"]:
 def _parse_file(path: Path, fmt: Literal["jsonc", "yaml"]) -> dict[str, Any]:
     text = path.read_text(encoding="utf-8")
     if fmt == "jsonc":
-        from .._vendor.jsonc import loads as jsonc_loads
+        from .._vendor.jsonx import loads as jsonc_loads
 
         data = jsonc_loads(text)
     else:

--- a/src/toolregistry/integrations/mcp/_compat.py
+++ b/src/toolregistry/integrations/mcp/_compat.py
@@ -93,13 +93,17 @@ def get_websocket_client() -> Any:
 # ---------------------------------------------------------------------------
 
 
+_MISSING = object()
+
+
 def get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -> Any:
     """Access a field that may be snake_case (v2) or camelCase (v1).
 
-    Tries snake_case first (v2 attribute access), then camelCase (v1).
+    Uses a sentinel so that legitimate ``None`` values (e.g. optional
+    ``mime_type``) are not confused with "attribute missing".
     """
-    val = getattr(obj, snake_name, None)
-    if val is not None:
+    val = getattr(obj, snake_name, _MISSING)
+    if val is not _MISSING:
         return val
     return getattr(obj, camel_name, default)
 

--- a/src/toolregistry/integrations/mcp/_compat.py
+++ b/src/toolregistry/integrations/mcp/_compat.py
@@ -1,0 +1,90 @@
+"""MCP SDK v1/v2 compatibility layer (client side).
+
+Abstracts the breaking changes between mcp v1.x and v2.x so that
+client.py, integration.py, and connection.py work with either version.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_mcp_version() -> int:
+    try:
+        from mcp.shared.exceptions import MCPError  # noqa: F811
+
+        del MCPError
+        return 2
+    except ImportError:
+        return 1
+
+
+MCP_VERSION: int = _detect_mcp_version()
+
+# ---------------------------------------------------------------------------
+# HTTP client factory — httpx (v1) vs httpx2 (v2)
+# ---------------------------------------------------------------------------
+
+
+def make_async_http_client(**kwargs: Any) -> Any:
+    """Create an async HTTP client compatible with the installed mcp version.
+
+    v1 uses ``httpx.AsyncClient``, v2 uses ``httpx2.AsyncClient``.
+    """
+    if MCP_VERSION >= 2:
+        import httpx2  # type: ignore[import-untyped]
+
+        return httpx2.AsyncClient(**kwargs)
+    else:
+        import httpx
+
+        return httpx.AsyncClient(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket transport — removed in v2
+# ---------------------------------------------------------------------------
+
+
+def get_websocket_client() -> Any:
+    """Return the websocket_client transport function.
+
+    Raises:
+        ImportError: On mcp v2 where WebSocket transport was removed.
+    """
+    if MCP_VERSION >= 2:
+        raise ImportError(
+            "WebSocket transport was removed in mcp v2. "
+            "Use streamable-http (http://) or SSE (/sse) instead."
+        )
+    from mcp.client.websocket import websocket_client
+
+    return websocket_client
+
+
+# ---------------------------------------------------------------------------
+# Field accessor
+# ---------------------------------------------------------------------------
+
+
+def get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -> Any:
+    """Access a field that may be snake_case (v2) or camelCase (v1).
+
+    Tries snake_case first (v2 attribute access), then camelCase (v1).
+    """
+    val = getattr(obj, snake_name, None)
+    if val is not None:
+        return val
+    return getattr(obj, camel_name, default)
+
+
+__all__ = [
+    "MCP_VERSION",
+    "get_field",
+    "get_websocket_client",
+    "make_async_http_client",
+]

--- a/src/toolregistry/integrations/mcp/_compat.py
+++ b/src/toolregistry/integrations/mcp/_compat.py
@@ -46,6 +46,28 @@ def make_async_http_client(**kwargs: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Streamable HTTP transport — renamed across versions
+# ---------------------------------------------------------------------------
+
+
+def get_streamable_http_client() -> Any:
+    """Return the streamable HTTP client transport function.
+
+    - v1.0–v1.23: ``streamablehttp_client`` only
+    - v1.24–v1.29: both names (alias)
+    - v2.0+: ``streamable_http_client`` only (old name removed)
+    """
+    try:
+        from mcp.client.streamable_http import streamable_http_client
+
+        return streamable_http_client
+    except ImportError:
+        from mcp.client.streamable_http import streamablehttp_client  # type: ignore[attr-defined]
+
+        return streamablehttp_client
+
+
+# ---------------------------------------------------------------------------
 # WebSocket transport — removed in v2
 # ---------------------------------------------------------------------------
 
@@ -85,6 +107,7 @@ def get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -
 __all__ = [
     "MCP_VERSION",
     "get_field",
+    "get_streamable_http_client",
     "get_websocket_client",
     "make_async_http_client",
 ]

--- a/src/toolregistry/integrations/mcp/client.py
+++ b/src/toolregistry/integrations/mcp/client.py
@@ -75,11 +75,9 @@ class MCPClient:
                     else None
                 )
                 _streamable_http = get_streamable_http_client()
-                async with _streamable_http(src, http_client=http_client) as (
-                    r,
-                    w,
-                    _,
-                ):
+                # v1 yields (read, write, get_session_id); v2 yields (read, write)
+                async with _streamable_http(src, http_client=http_client) as streams:
+                    r, w = streams[0], streams[1]
                     yield r, w
         elif isinstance(src, str) and src.startswith(("ws://", "wss://")):
             ws_client = get_websocket_client()

--- a/src/toolregistry/integrations/mcp/client.py
+++ b/src/toolregistry/integrations/mcp/client.py
@@ -161,13 +161,12 @@ class MCPClient:
         """
         if self._session is None:
             return None
-        # Try v1 camelCase first, then v2 snake_case
         init_result = getattr(self._session, "initialize_result", None)
         if init_result is None:
             return None
-        return getattr(init_result, "serverInfo", None) or getattr(
-            init_result, "server_info", None
-        )
+        from ._compat import get_field
+
+        return get_field(init_result, "server_info", "serverInfo")
 
     @property
     def initialize_result(self):

--- a/src/toolregistry/integrations/mcp/client.py
+++ b/src/toolregistry/integrations/mcp/client.py
@@ -13,11 +13,14 @@ from urllib.parse import urlparse
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamable_http_client
 from mcp.types import CallToolResult
 from mcp.types import Tool as ToolSpec
 
-from ._compat import get_websocket_client, make_async_http_client
+from ._compat import (
+    get_streamable_http_client,
+    get_websocket_client,
+    make_async_http_client,
+)
 
 
 class MCPClient:
@@ -71,7 +74,8 @@ class MCPClient:
                     if self._headers
                     else None
                 )
-                async with streamable_http_client(src, http_client=http_client) as (
+                _streamable_http = get_streamable_http_client()
+                async with _streamable_http(src, http_client=http_client) as (
                     r,
                     w,
                     _,

--- a/src/toolregistry/integrations/mcp/client.py
+++ b/src/toolregistry/integrations/mcp/client.py
@@ -10,14 +10,14 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-import httpx
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
-from mcp.client.websocket import websocket_client
 from mcp.types import CallToolResult
 from mcp.types import Tool as ToolSpec
+
+from ._compat import get_websocket_client, make_async_http_client
 
 
 class MCPClient:
@@ -67,7 +67,9 @@ class MCPClient:
                     yield r, w
             else:
                 http_client = (
-                    httpx.AsyncClient(headers=self._headers) if self._headers else None
+                    make_async_http_client(headers=self._headers)
+                    if self._headers
+                    else None
                 )
                 async with streamable_http_client(src, http_client=http_client) as (
                     r,
@@ -76,7 +78,8 @@ class MCPClient:
                 ):
                     yield r, w
         elif isinstance(src, str) and src.startswith(("ws://", "wss://")):
-            async with websocket_client(src) as (r, w):
+            ws_client = get_websocket_client()
+            async with ws_client(src) as (r, w):
                 yield r, w
         else:
             params = _to_stdio_params(src)

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -1,6 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from collections.abc import Callable
 
 from mcp.types import (
     BlobResourceContents,
@@ -13,6 +13,7 @@ from mcp.types import (
 from mcp.types import Tool as ToolSpec
 
 from ..._vendor.structlog import get_logger
+from ._compat import get_field
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
@@ -144,9 +145,7 @@ class MCPToolWrapper(BaseToolWrapper):
         if isinstance(result, list):
             contents = result
         else:
-            is_error = getattr(result, "is_error", None) or getattr(
-                result, "isError", False
-            )
+            is_error = get_field(result, "is_error", "isError", False)
             if is_error or not result.content:
                 return result
             contents = result.content
@@ -161,7 +160,7 @@ class MCPToolWrapper(BaseToolWrapper):
                 "type": "image",
                 "source": {
                     "type": "base64",
-                    "media_type": content.mimeType,
+                    "media_type": get_field(content, "mime_type", "mimeType"),
                     "data": content.data,
                 },
             }
@@ -170,7 +169,7 @@ class MCPToolWrapper(BaseToolWrapper):
             if isinstance(content.resource, TextResourceContents):
                 return {"type": "text", "text": content.resource.text}
             elif isinstance(content.resource, BlobResourceContents):
-                mime = content.resource.mimeType or ""
+                mime = get_field(content.resource, "mime_type", "mimeType") or ""
                 if mime.startswith(_IMAGE_MIME_PREFIXES):
                     return {
                         "type": "image",
@@ -240,9 +239,7 @@ class MCPTool(Tool):
         """
         name = tool_spec.name
         description = tool_spec.description or ""
-        input_schema = getattr(tool_spec, "input_schema", None) or getattr(
-            tool_spec, "inputSchema", {}
-        )
+        input_schema = get_field(tool_spec, "input_schema", "inputSchema", {})
         if not isinstance(input_schema, dict) or input_schema.get("type") != "object":
             input_schema = {"type": "object", "properties": {}}
         else:

--- a/tests/_mcp_test_server.py
+++ b/tests/_mcp_test_server.py
@@ -13,10 +13,17 @@ Usage:
 import argparse
 import json
 
-from mcp.server.fastmcp import FastMCP
+try:
+    from mcp.server.mcpserver import MCPServer as _ServerClass
+
+    _MCP_V2 = True
+except ImportError:
+    from mcp.server.fastmcp import FastMCP as _ServerClass
+
+    _MCP_V2 = False
 
 
-def create_server(host: str = "127.0.0.1", port: int = 8000) -> FastMCP:
+def create_server(host: str = "127.0.0.1", port: int = 8000):
     """Create a minimal MCP server with test tools.
 
     Args:
@@ -24,9 +31,12 @@ def create_server(host: str = "127.0.0.1", port: int = 8000) -> FastMCP:
         port: Port to bind to for network transports.
 
     Returns:
-        Configured FastMCP server instance.
+        Configured server instance.
     """
-    mcp = FastMCP("test-server", host=host, port=port)
+    if _MCP_V2:
+        mcp = _ServerClass("test-server")
+    else:
+        mcp = _ServerClass("test-server", host=host, port=port)
 
     @mcp.tool()
     def add(a: int, b: int) -> str:
@@ -58,7 +68,11 @@ def main():
     args = parser.parse_args()
 
     mcp = create_server(host=args.host, port=args.port)
-    mcp.run(transport=args.transport)
+
+    if _MCP_V2:
+        mcp.run(transport=args.transport, host=args.host, port=args.port)
+    else:
+        mcp.run(transport=args.transport)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Introduce `integrations/mcp/_compat.py` that abstracts breaking changes between mcp SDK v1.x and v2.x
- Refactor `client.py` to use compat for HTTP client creation (`httpx`→`httpx2`), streamable HTTP transport rename, and WebSocket removal
- Refactor `integration.py` to use `get_field()` for all v1/v2 field name differences
- Correct minimum mcp pin from `>=1.0.0` to `>=1.24.0` (pre-existing bug: `streamable_http_client` + `http_client=` kwarg requires 1.24+)

This is internal refactoring + pin correction. The actual pin widening to `mcp>=1.24,<3` is a coordinated follow-up after both this and the server side (Oaklight/toolregistry-server#56) are merged.

**Note:** Core minimum (`>=1.24.0`) is higher than server's (`>=1.17.0`) because core uses `streamable_http_client(src, http_client=...)` which requires both the renamed function and the kwarg.

### What `_compat.py` abstracts

| Concern | v1 | v2 |
|---|---|---|
| HTTP client | `httpx.AsyncClient` | `httpx2.AsyncClient` |
| Streamable HTTP | `streamablehttp_client` (v1.0–1.23) / `streamable_http_client` (v1.24+) | `streamable_http_client` only |
| WebSocket transport | `mcp.client.websocket.websocket_client` | Removed |
| Field: error flag | `result.isError` | `result.is_error` |
| Field: MIME type | `content.mimeType` | `content.mime_type` |
| Field: input schema | `tool.inputSchema` | `tool.input_schema` |
| Field: server info | `init_result.serverInfo` | `init_result.server_info` |

### Multi-version test results

| mcp version | Core (47 tests) | Status |
|---|---|---|
| v1.24.0 | 47 passed | :white_check_mark: |
| v1.26.0 | 47 passed | :white_check_mark: |
| v1.29.0 | 47 passed | :white_check_mark: |

### Review feedback addressed

- Sentinel pattern in `get_field()` for nullable fields (Elena, Clementine, Milo)
- `server_info` property using `get_field()` instead of manual dual-getattr (Milo)

Closes #231