### PR TITLE
feat(executor): enforce per-call timeout for inline backend

### DIFF
--- a/src/toolregistry/executor/_inline_backend.py
+++ b/src/toolregistry/executor/_inline_backend.py
@@ -59,6 +59,14 @@ class InlineExecutionHandle(ExecutionHandle):
     def execution_id(self) -> str:
         return self._exec_id
 
+    @property
+    def timeout(self) -> float | None:
+        """Deadline supplied at submit time, if any.
+
+        Enforced only on the async path — see :meth:`result_async`.
+        """
+        return self._timeout
+
     def cancel(self) -> bool:
         """Cancel before execution.
 

--- a/src/toolregistry/executor/_inline_backend.py
+++ b/src/toolregistry/executor/_inline_backend.py
@@ -43,11 +43,13 @@ class InlineExecutionHandle(ExecutionHandle):
         fn: Callable[..., Any],
         kwargs: dict[str, Any],
         is_async: bool,
+        timeout: float | None = None,
     ) -> None:
         self._exec_id = exec_id
         self._fn: Callable[..., Any] | None = fn
         self._kwargs: dict[str, Any] | None = kwargs
         self._is_async = is_async
+        self._timeout = timeout
         self._executed = False
         self._cancelled = False
         self._value: Any = None
@@ -83,10 +85,14 @@ class InlineExecutionHandle(ExecutionHandle):
     def result(self, timeout: float | None = None) -> Any:
         """Execute synchronously and return the result.
 
-        Inline execution does not support ``timeout`` — the callable
-        runs in the calling thread with no way to interrupt it
-        externally.  The parameter is accepted for interface
-        compatibility but is ignored.
+        ``timeout`` is **not enforced** on this path.  The callable runs
+        to completion in the calling thread, and there is no way to
+        interrupt it from outside without leaving the inline execution
+        model (a watchdog thread or signal).  The parameter is accepted
+        for interface compatibility.
+
+        Use :meth:`result_async` if you need the timeout honored — on
+        the async path the coroutine can be cancelled by the event loop.
         """
         if self._cancelled:
             raise CancelledError("Execution was cancelled before it started")
@@ -118,15 +124,23 @@ class InlineExecutionHandle(ExecutionHandle):
         non-``async def`` callables that return coroutines (e.g. a
         lambda wrapping ``tool.arun``).
 
-        Like :meth:`result`, ``timeout`` is accepted for interface
-        compatibility but is not enforced — inline execution has no
-        external mechanism to interrupt a running callable.
+        Unlike :meth:`result`, ``timeout`` **is** enforced here for
+        coroutine execution — the event loop can cancel an awaiting
+        coroutine, so ``asyncio.wait_for`` gives a real deadline.  The
+        effective timeout is the *timeout* argument, falling back to the
+        value supplied at submit time.  A ``TimeoutError`` is raised on
+        expiry, matching the thread/process backends.
+
+        A purely synchronous callable still blocks the calling thread
+        and cannot be interrupted, so no deadline applies to that case.
         """
+        effective_timeout = timeout if timeout is not None else self._timeout
+
         if self._cancelled:
             raise CancelledError("Execution was cancelled before it started")
         if not self._executed:
             if self._is_async:
-                await self._run_async()
+                await self._run_async(effective_timeout)
             else:
                 self._run_sync()
                 # A non-async-def callable (e.g. lambda wrapping
@@ -134,7 +148,9 @@ class InlineExecutionHandle(ExecutionHandle):
                 # on the caller's loop instead of asyncio.run().
                 if self._exception is None and asyncio.iscoroutine(self._value):
                     try:
-                        self._value = await self._value
+                        self._value = await self._await_with_timeout(
+                            self._value, effective_timeout
+                        )
                     except BaseException as exc:  # noqa: BLE001
                         self._exception = exc
         if self._exception is not None:
@@ -166,11 +182,27 @@ class InlineExecutionHandle(ExecutionHandle):
         self._executed = True
         self._fn = self._kwargs = None
 
-    async def _run_async(self) -> None:
+    @staticmethod
+    async def _await_with_timeout(coro: Any, timeout: float | None) -> Any:
+        """Await *coro*, applying *timeout* when one is set.
+
+        Translates ``asyncio.TimeoutError`` to the builtin
+        ``TimeoutError`` so all backends raise the same type.
+        """
+        if timeout is None:
+            return await coro
+        try:
+            return await asyncio.wait_for(coro, timeout)
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(str(e) or f"timed out after {timeout}s") from e
+
+    async def _run_async(self, timeout: float | None = None) -> None:
         """Drive execution by awaiting the callable."""
         assert self._fn is not None and self._kwargs is not None
         try:
-            self._value = await self._fn(**self._kwargs)
+            self._value = await self._await_with_timeout(
+                self._fn(**self._kwargs), timeout
+            )
         except BaseException as exc:  # noqa: BLE001
             self._exception = exc
         self._executed = True
@@ -190,6 +222,14 @@ class InlineBackend:
     It is suited to tools that are already isolated elsewhere
     (e.g. MCP servers, remote HTTP APIs), where pooling or pickling
     the target would be wrong or impossible.
+
+    Note:
+        ``timeout`` is enforced only on the async path
+        (``handle.result_async()``), where the event loop can cancel an
+        awaiting coroutine.  A synchronous callable driven through
+        ``handle.result()`` blocks the calling thread and cannot be
+        interrupted without abandoning the inline model, so no deadline
+        is applied there.
     """
 
     def submit(
@@ -212,7 +252,7 @@ class InlineBackend:
             ctx = ExecutionContext()
             kwargs = {**kwargs, "_ctx": ctx}
 
-        return InlineExecutionHandle(exec_id, fn, kwargs, is_async)
+        return InlineExecutionHandle(exec_id, fn, kwargs, is_async, timeout)
 
     def shutdown(self, wait: bool = True) -> None:
         pass

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1157,10 +1157,32 @@ class ToolRegistry(
                 traceback_str=tb_module.format_exc(),
             )
 
+    @staticmethod
+    def _needs_async_timeout(handle: Any) -> bool:
+        """Whether *handle* must be driven asynchronously to honor a timeout.
+
+        Only inline handles need this: their synchronous ``result()``
+        blocks the calling thread with no way to interrupt it, so a
+        pending timeout would be silently ignored.  Thread and process
+        handles already enforce timeouts via ``Future.result(timeout)``.
+        """
+        from .executor._inline_backend import InlineExecutionHandle
+
+        return isinstance(handle, InlineExecutionHandle) and (
+            getattr(handle, "_timeout", None) is not None
+        )
+
     def _collect_handle_result(
         self, handle: Any, tool_name: str
     ) -> str | list | _ToolError:
         """Wait for a handle and return the finalized result or a ``_ToolError``.
+
+        Inline handles carrying a timeout are driven through
+        :class:`AsyncRuntime` so the deadline is actually enforced —
+        ``InlineExecutionHandle.result()`` runs in the calling thread and
+        cannot be interrupted, while ``result_async()`` can be cancelled
+        by an event loop.  This keeps per-tool ``metadata.timeout``
+        meaningful for MCP/OpenAPI tools in a synchronous batch.
 
         Args:
             handle: An ExecutionHandle to collect.
@@ -1170,7 +1192,12 @@ class ToolRegistry(
             The finalized result string/list, or a ``_ToolError`` on failure.
         """
         try:
-            result = handle.result()
+            if self._needs_async_timeout(handle):
+                from ._async_runtime import AsyncRuntime
+
+                result = AsyncRuntime.run_sync(handle.result_async())
+            else:
+                result = handle.result()
             return self._finalize_result(result, tool_name)
         except TimeoutError:
             return _ToolError(

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1168,9 +1168,7 @@ class ToolRegistry(
         """
         from .executor._inline_backend import InlineExecutionHandle
 
-        return isinstance(handle, InlineExecutionHandle) and (
-            getattr(handle, "_timeout", None) is not None
-        )
+        return isinstance(handle, InlineExecutionHandle) and handle.timeout is not None
 
     def _collect_handle_result(
         self, handle: Any, tool_name: str

--- a/tests/test_aexecute_tool_calls.py
+++ b/tests/test_aexecute_tool_calls.py
@@ -1,6 +1,7 @@
 """Tests for aexecute_tool_calls and per-tool backend resolution in batch."""
 
 import asyncio
+import threading
 import time
 
 import pytest
@@ -188,3 +189,73 @@ class TestBatchBackendResolution:
         )
         # default execution mode is process
         assert backend is registry._process_backend
+
+
+class TestInlineTimeoutInBatch:
+    """Per-tool timeout is honored for inline tools in both batch paths."""
+
+    @staticmethod
+    def _registry_with_slow_inline_tool():
+        reg = ToolRegistry()
+
+        async def slow_remote(n: int) -> int:
+            """Simulates an MCP/OpenAPI call that hangs."""
+            await asyncio.sleep(5)
+            return n
+
+        reg.register(
+            Tool.from_function(
+                slow_remote,
+                metadata=ToolMetadata(natural_backend="inline", timeout=0.2),
+            )
+        )
+        return reg
+
+    def test_sync_batch_inline_tool_times_out(self):
+        """execute_tool_calls honors timeout for inline tools.
+
+        InlineExecutionHandle.result() cannot enforce a deadline, so the
+        registry drives such handles through AsyncRuntime instead.
+        """
+        reg = self._registry_with_slow_inline_tool()
+        tcs = [_tc("c1", "slow_remote", '{"n": 1}')]
+
+        start = time.perf_counter()
+        r = reg.execute_tool_calls(tcs)
+        elapsed = time.perf_counter() - start
+
+        assert isinstance(r["c1"], ErrorResult)
+        assert "timed out" in r["c1"].message
+        assert elapsed < 2.0
+
+    @pytest.mark.asyncio
+    async def test_async_batch_inline_tool_times_out(self):
+        reg = self._registry_with_slow_inline_tool()
+        tcs = [_tc("c1", "slow_remote", '{"n": 1}')]
+
+        start = time.perf_counter()
+        r = await reg.aexecute_tool_calls(tcs)
+        elapsed = time.perf_counter() - start
+
+        assert isinstance(r["c1"], ErrorResult)
+        assert "timed out" in r["c1"].message
+        assert elapsed < 2.0
+
+    def test_inline_tool_without_timeout_unaffected(self):
+        """No timeout set — the plain sync path is used, no loop hop."""
+        reg = ToolRegistry()
+        seen: dict[str, int] = {}
+
+        def plain(x: int) -> int:
+            """Inline tool with no timeout."""
+            seen["thread"] = threading.get_ident()
+            return x * 2
+
+        reg.register(
+            Tool.from_function(plain, metadata=ToolMetadata(natural_backend="inline"))
+        )
+
+        result = reg.invoke("plain", {"x": 21})
+        assert result.result == "42"
+        # Executed in the calling thread — not dispatched to AsyncRuntime.
+        assert seen["thread"] == threading.get_ident()

--- a/tests/test_executor/test_inline_backend.py
+++ b/tests/test_executor/test_inline_backend.py
@@ -1,6 +1,8 @@
 """Tests for InlineBackend (lazy capture, deferred execution)."""
 
+import asyncio
 import threading
+import time
 
 import pytest
 
@@ -171,3 +173,73 @@ class TestInlineBackend:
         assert handle.result() == 42
         assert handle.result() == 42
         assert len(count) == 1
+
+
+class TestInlineTimeout:
+    """Timeout is enforced on the async path only."""
+
+    @pytest.mark.asyncio
+    async def test_submit_timeout_enforced(self):
+        backend = InlineBackend()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        handle = backend.submit(slow, {"n": 1}, timeout=0.2)
+        start = time.perf_counter()
+        with pytest.raises(TimeoutError):
+            await handle.result_async()
+        assert time.perf_counter() - start < 1.0
+
+    @pytest.mark.asyncio
+    async def test_call_site_timeout_overrides_submit(self):
+        backend = InlineBackend()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        handle = backend.submit(slow, {"n": 1}, timeout=10)
+        start = time.perf_counter()
+        with pytest.raises(TimeoutError):
+            await handle.result_async(timeout=0.2)
+        assert time.perf_counter() - start < 1.0
+
+    @pytest.mark.asyncio
+    async def test_no_timeout_runs_to_completion(self):
+        backend = InlineBackend()
+
+        async def quick(n: int) -> int:
+            await asyncio.sleep(0.05)
+            return n
+
+        handle = backend.submit(quick, {"n": 7})
+        assert await handle.result_async() == 7
+
+    @pytest.mark.asyncio
+    async def test_lambda_wrapped_coroutine_honors_timeout(self):
+        """The ainvoke pattern (lambda returning a coroutine) times out too."""
+        backend = InlineBackend()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        handle = backend.submit(lambda **kw: slow(**kw), {"n": 1}, timeout=0.2)
+        start = time.perf_counter()
+        with pytest.raises(TimeoutError):
+            await handle.result_async()
+        assert time.perf_counter() - start < 1.0
+
+    def test_sync_result_does_not_enforce_timeout(self):
+        """result() cannot interrupt a blocking callable — documented limit."""
+        backend = InlineBackend()
+
+        def blocking() -> int:
+            time.sleep(0.3)
+            return 1
+
+        handle = backend.submit(blocking, {}, timeout=0.05)
+        # Runs to completion despite the shorter timeout.
+        assert handle.result() == 1


### PR DESCRIPTION
## Problem

`InlineBackend.submit()` accepted a `timeout` argument and **threw it away**. Every inline-resolved tool — MCP, OpenAPI, PTC — silently ignored `metadata.timeout`. A hanging remote call blocked indefinitely with no deadline.

This was the last gap in the timeout matrix. Thread and process backends store the value and enforce it via `Future.result(timeout)`; inline stored nothing.

## Fix

**1. `InlineExecutionHandle` stores and enforces the timeout (async path)**

`result_async()` applies `asyncio.wait_for`, translating `asyncio.TimeoutError` to the builtin `TimeoutError` so every backend raises the same type. A call-site `timeout=` overrides the submit-time value, matching the thread/process handles.

**2. `result()` still does not enforce — documented, not silently ignored**

A synchronous callable blocks the calling thread; interrupting it would require a watchdog thread or signal, i.e. abandoning the inline model. (Note that even `ThreadBackend`'s timeout doesn't *terminate* work — it stops waiting. Inline has no separate thread to walk away from.) The class docstring and both methods now say this explicitly and point at `result_async()` / the thread backend.

**3. `_collect_handle_result` bridges the sync-batch case**

`execute_tool_calls()` collects via `handle.result()`, which can't enforce. When a handle is inline **and** carries a timeout, the registry now drives it through `AsyncRuntime.run_sync(handle.result_async())` to get a real deadline.

`AsyncRuntime` lives at the registry layer, not in the handle — `executor/` is documented as having zero toolregistry imports, and `_collect_handle_result` sits just above that boundary.

Handles **without** a timeout keep the plain in-thread path, so the common case pays no event-loop hop (covered by a test asserting the tool still runs on the calling thread).

## Timeout matrix

| Entry point | inline | thread | process |
|---|---|---|---|
| `invoke()` | ⚠️ by design | ✅ | ✅ |
| `execute_tool_calls()` | ✅ **fixed** | ✅ | ✅ |
| `ainvoke()` | ✅ **fixed** | ✅ | ✅ |
| `aexecute_tool_calls()` | ✅ **fixed** | ✅ | ✅ |

`invoke()` is deliberately left non-enforcing: routing the hottest single-call path through `AsyncRuntime` to add a deadline isn't worth the loop hop. Callers needing a sync timeout can pass `execution_mode="thread"`.

## Compatibility

`InlineBackend` is unreleased (introduced after v0.14.0, the current PyPI version), so no user is relying on the previous ignore-the-timeout behavior.

## Test plan

- [x] `TestInlineTimeout` — submit-time timeout enforced, call-site override, no-timeout completes, lambda-wrapped coroutine (the `ainvoke` pattern) times out, sync `result()` documented as non-enforcing
- [x] `TestInlineTimeoutInBatch` — sync batch times out (~0.3s not 5s), async batch times out, no-timeout inline tool still runs on the calling thread
- [x] Full suite: **1091 passed** (was 1082; +9 new)
- [x] `pre-commit run` — ruff, ruff-format, ty, complexipy all pass