### PR TITLE
refactor(executor): promote inline to thread on sync path — complete timeout matrix

### DIFF
--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -373,6 +373,7 @@ class ToolRegistry(
         tool: "Tool | None",
         execution_mode: str | None = None,
         default: str = "inline",
+        async_caller: bool = False,
     ) -> "ExecutionBackend":
         """Resolve the execution backend for a single tool.
 
@@ -383,11 +384,10 @@ class ToolRegistry(
         2. The tool's ``metadata.natural_backend`` hint.
         3. The *default* backend for the calling context.
 
-        The default differs by entry point: single-tool ``invoke`` passes
-        ``"inline"`` (zero overhead, no cross-thread hop), while
-        ``execute_tool_calls`` passes the registry's ``_execution_mode``
-        (``"process"`` by default) so plain Python tools still get CPU
-        isolation in a batch.
+        When ``async_caller`` is ``False`` (the sync path), an inline
+        resolution is promoted to **thread** so that
+        ``Future.result(timeout)`` gives a real deadline.  Async callers
+        keep inline because they need the coroutine on their own loop.
 
         Future isolation backends (e.g. a sandbox) plug in here without
         touching ``invoke``/``ainvoke``.
@@ -397,6 +397,8 @@ class ToolRegistry(
             execution_mode: Optional caller override.
             default: Backend name to use when neither an explicit mode nor
                 a ``natural_backend`` hint applies.
+            async_caller: ``True`` when called from an async entry point
+                (``ainvoke``/``aexecute_tool_calls``).
 
         Returns:
             An execution backend instance.
@@ -407,9 +409,15 @@ class ToolRegistry(
         metadata = getattr(tool, "metadata", None)
         natural = getattr(metadata, "natural_backend", None) if metadata else None
         if natural in ("inline", "thread", "process"):
-            return self._backend_for(natural)
+            resolved = self._backend_for(natural)
+        else:
+            resolved = self._backend_for(default)
 
-        return self._backend_for(default)
+        # Sync callers cannot interrupt a blocking inline callable, so
+        # promote to thread where Future.result(timeout) works.
+        if not async_caller and resolved is self._inline_backend:
+            return self._thread_backend
+        return resolved
 
     def _check_tool_access(
         self,
@@ -820,7 +828,7 @@ class ToolRegistry(
             )
 
         tool_obj = prepared
-        backend = self._resolve_backend(tool_obj, execution_mode)
+        backend = self._resolve_backend(tool_obj, execution_mode, async_caller=True)
         clean_kwargs = self._clean_kwargs(kwargs)
         per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
 
@@ -1157,30 +1165,10 @@ class ToolRegistry(
                 traceback_str=tb_module.format_exc(),
             )
 
-    @staticmethod
-    def _needs_async_timeout(handle: Any) -> bool:
-        """Whether *handle* must be driven asynchronously to honor a timeout.
-
-        Only inline handles need this: their synchronous ``result()``
-        blocks the calling thread with no way to interrupt it, so a
-        pending timeout would be silently ignored.  Thread and process
-        handles already enforce timeouts via ``Future.result(timeout)``.
-        """
-        from .executor._inline_backend import InlineExecutionHandle
-
-        return isinstance(handle, InlineExecutionHandle) and handle.timeout is not None
-
     def _collect_handle_result(
         self, handle: Any, tool_name: str
     ) -> str | list | _ToolError:
         """Wait for a handle and return the finalized result or a ``_ToolError``.
-
-        Inline handles carrying a timeout are driven through
-        :class:`AsyncRuntime` so the deadline is actually enforced —
-        ``InlineExecutionHandle.result()`` runs in the calling thread and
-        cannot be interrupted, while ``result_async()`` can be cancelled
-        by an event loop.  This keeps per-tool ``metadata.timeout``
-        meaningful for MCP/OpenAPI tools in a synchronous batch.
 
         Args:
             handle: An ExecutionHandle to collect.
@@ -1190,12 +1178,7 @@ class ToolRegistry(
             The finalized result string/list, or a ``_ToolError`` on failure.
         """
         try:
-            if self._needs_async_timeout(handle):
-                from ._async_runtime import AsyncRuntime
-
-                result = AsyncRuntime.run_sync(handle.result_async())
-            else:
-                result = handle.result()
+            result = handle.result()
             return self._finalize_result(result, tool_name)
         except TimeoutError:
             return _ToolError(
@@ -1288,49 +1271,24 @@ class ToolRegistry(
         execution_mode: str | None,
         call_arguments: dict[str, dict],
     ) -> dict[str, Any]:
-        """Run concurrency-safe calls with pool work overlapping inline work.
+        """Submit all calls concurrently, then collect results.
 
-        Submit pool-backed tools first so their handles run in the
-        background, then execute inline-backed tools, then collect the
-        pool handles — a slow inline tool never stalls submitted pool work.
+        On the sync path, ``_resolve_backend`` promotes inline to thread,
+        so every tool gets a pool handle — submit-all then collect-all.
         """
         from .executor import ExecutionHandle
 
         raw_results: dict[str, Any] = {}
-        pool_handles: list[tuple[Any, ExecutionHandle]] = []
-        inline_calls: list[Any] = []
+        handles: list[tuple[Any, ExecutionHandle]] = []
 
-        inline_backends: dict[str, Any] = {}
         for tc in enabled_calls:
-            tool_obj = self.get_tool(tc.name)
-            backend = self._resolve_backend(
-                tool_obj, execution_mode, default=self._execution_mode
-            )
-            if backend is self._inline_backend:
-                inline_calls.append(tc)
-                inline_backends[tc.id] = backend
-                continue
-            # Reuse the backend we just resolved instead of re-resolving.
-            handle_or_error = self._submit_tool_call(
-                tc, execution_mode, call_arguments, backend=backend
-            )
+            handle_or_error = self._submit_tool_call(tc, execution_mode, call_arguments)
             if isinstance(handle_or_error, _ToolError):
                 raw_results[tc.id] = handle_or_error
             else:
-                pool_handles.append((tc, handle_or_error))
+                handles.append((tc, handle_or_error))
 
-        for tc in inline_calls:
-            handle_or_error = self._submit_tool_call(
-                tc, execution_mode, call_arguments, backend=inline_backends[tc.id]
-            )
-            if isinstance(handle_or_error, _ToolError):
-                raw_results[tc.id] = handle_or_error
-            else:
-                raw_results[tc.id] = self._collect_handle_result(
-                    handle_or_error, tc.name
-                )
-
-        for tc, handle in pool_handles:
+        for tc, handle in handles:
             raw_results[tc.id] = self._collect_handle_result(handle, tc.name)
 
         return raw_results
@@ -1392,7 +1350,7 @@ class ToolRegistry(
         clean_kwargs = self._clean_kwargs(call_arguments.get(tc.id, {}))
         per_call_timeout = tool_obj.metadata.timeout if tool_obj.metadata else None
         backend = self._resolve_backend(
-            tool_obj, execution_mode, default=self._execution_mode
+            tool_obj, execution_mode, default=self._execution_mode, async_caller=True
         )
 
         try:

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1098,7 +1098,8 @@ class ToolRegistry(
 
         The backend is resolved per tool via :meth:`_resolve_backend`
         (caller ``execution_mode`` > ``natural_backend`` > registry
-        default), so MCP/OpenAPI tools run inline while plain Python
+        default), so MCP/OpenAPI tools resolve per the caller context
+        (thread for sync callers, inline for async) while plain Python
         tools use the batch default (process).
 
         Args:
@@ -1144,7 +1145,8 @@ class ToolRegistry(
             # Safety net for a plain Python tool that resolved to the
             # process backend but cannot be pickled (e.g. a closure over
             # unpicklable state).  MCP/OpenAPI tools never reach here —
-            # they resolve to inline via natural_backend.
+            # they resolve to thread (sync) or inline (async) via
+            # natural_backend + async_caller promotion.
             if backend is self._process_backend:
                 try:
                     return self._thread_backend.submit(

--- a/tests/test_aexecute_tool_calls.py
+++ b/tests/test_aexecute_tool_calls.py
@@ -167,7 +167,7 @@ class TestBatchBackendResolution:
         r = registry.execute_tool_calls(tcs, execution_mode="thread")
         assert r["c1"].result == "7"
 
-    def test_inline_natural_backend_resolves_inline(self, registry):
+    def test_sync_caller_inline_promotes_to_thread(self, registry):
         def ping(x: int) -> int:
             """Ping."""
             return x
@@ -176,9 +176,23 @@ class TestBatchBackendResolution:
             Tool.from_function(ping, metadata=ToolMetadata(natural_backend="inline"))
         )
         tool = registry.get_tool("ping")
-        # batch default is process, but natural_backend wins.
+        # Sync callers promote inline to thread for real timeout.
         backend = registry._resolve_backend(
             tool, None, default=registry._execution_mode
+        )
+        assert backend is registry._thread_backend
+
+    def test_async_caller_inline_stays_inline(self, registry):
+        def ping(x: int) -> int:
+            """Ping."""
+            return x
+
+        registry.register(
+            Tool.from_function(ping, metadata=ToolMetadata(natural_backend="inline"))
+        )
+        tool = registry.get_tool("ping")
+        backend = registry._resolve_backend(
+            tool, None, default=registry._execution_mode, async_caller=True
         )
         assert backend is registry._inline_backend
 
@@ -257,5 +271,5 @@ class TestInlineTimeoutInBatch:
 
         result = reg.invoke("plain", {"x": 21})
         assert result.result == "42"
-        # Executed in the calling thread — not dispatched to AsyncRuntime.
-        assert seen["thread"] == threading.get_ident()
+        # Sync path promotes inline to thread — runs in pool thread.
+        assert seen["thread"] != threading.get_ident()

--- a/tests/test_ainvoke.py
+++ b/tests/test_ainvoke.py
@@ -99,7 +99,7 @@ class TestAinvoke:
 
 
 class TestBackendResolution:
-    def test_inline_default_for_native(self):
+    def test_sync_caller_promotes_inline_to_thread(self):
         reg = ToolRegistry()
 
         def add(a: int, b: int) -> int:
@@ -107,7 +107,18 @@ class TestBackendResolution:
 
         reg.register(add)
         tool = reg.get_tool("add")
-        assert reg._resolve_backend(tool) is reg._inline_backend
+        # Sync callers get thread so Future.result(timeout) works.
+        assert reg._resolve_backend(tool) is reg._thread_backend
+
+    def test_async_caller_keeps_inline(self):
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        reg.register(add)
+        tool = reg.get_tool("add")
+        assert reg._resolve_backend(tool, async_caller=True) is reg._inline_backend
 
     def test_execution_mode_override(self):
         reg = ToolRegistry()

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -1,0 +1,232 @@
+"""End-to-end tests for the execution stack with real MCP tools.
+
+Verifies that sync/async registration, sync/async single-call, and
+sync/async batch execution all work with a live MCP stdio server —
+not just mock functions. Also tests that per-tool timeout is enforced
+on every path where it should be.
+"""
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from toolregistry import Tool, ToolRegistry
+from toolregistry.llm.tool_calls import ErrorResult, ToolCallResult
+from toolregistry.tool import ToolMetadata
+
+_SERVER_SCRIPT = str(Path(__file__).parent / "_mcp_test_server.py")
+
+
+def _stdio_config():
+    return {
+        "command": sys.executable,
+        "args": [_SERVER_SCRIPT, "--transport", "stdio"],
+    }
+
+
+def _tc(cid: str, name: str, args: str):
+    return {
+        "id": cid,
+        "type": "function",
+        "function": {"name": name, "arguments": args},
+    }
+
+
+# ── Sync registration + sync invoke ─────────────────────────────────
+
+
+class TestSyncMCPPaths:
+    def test_sync_register_and_invoke(self):
+        """register_from_mcp (sync) + invoke (sync) with a real MCP tool."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+            assert "add" in reg
+
+            r = reg.invoke("add", {"a": 10, "b": 20})
+            assert isinstance(r, ToolCallResult)
+            assert r.result == '{"result": 30}'
+
+    def test_sync_register_and_invoke_echo(self):
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+            r = reg.invoke("echo", {"message": "hello world"})
+            assert isinstance(r, ToolCallResult)
+            assert r.result == "hello world"
+
+    def test_sync_register_and_execute_batch(self):
+        """register_from_mcp (sync) + execute_tool_calls (sync batch)."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+
+            tcs = [
+                _tc("c1", "add", '{"a": 1, "b": 2}'),
+                _tc("c2", "echo", '{"message": "hi"}'),
+                _tc("c3", "greet", '{"name": "Alice"}'),
+            ]
+            results = reg.execute_tool_calls(tcs)
+            assert results["c1"].result == '{"result": 3}'
+            assert results["c2"].result == "hi"
+            assert "Alice" in results["c3"].result
+            assert [r.id for r in results] == ["c1", "c2", "c3"]
+
+
+# ── Async registration + async invoke ───────────────────────────────
+
+
+class TestAsyncMCPPaths:
+    @pytest.mark.asyncio
+    async def test_async_register_and_ainvoke(self):
+        """register_from_mcp_async + ainvoke with a real MCP tool."""
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+            assert "add" in reg
+
+            r = await reg.ainvoke("add", {"a": 5, "b": 7})
+            assert isinstance(r, ToolCallResult)
+            assert r.result == '{"result": 12}'
+
+    @pytest.mark.asyncio
+    async def test_async_register_and_aexecute_batch(self):
+        """register_from_mcp_async + aexecute_tool_calls."""
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+
+            tcs = [
+                _tc("c1", "add", '{"a": 3, "b": 4}'),
+                _tc("c2", "echo", '{"message": "async"}'),
+            ]
+            results = await reg.aexecute_tool_calls(tcs)
+            assert results["c1"].result == '{"result": 7}'
+            assert results["c2"].result == "async"
+
+
+# ── Mixed: sync register + async invoke ─────────────────────────────
+
+
+class TestMixedPaths:
+    @pytest.mark.asyncio
+    async def test_sync_register_async_invoke(self):
+        """register_from_mcp (sync) + ainvoke (async)."""
+        reg = ToolRegistry()
+        reg.register_from_mcp(_stdio_config(), persistent=True)
+        try:
+            r = await reg.ainvoke("add", {"a": 100, "b": 200})
+            assert isinstance(r, ToolCallResult)
+            assert r.result == '{"result": 300}'
+        finally:
+            await reg.close_async()
+
+    def test_sync_register_sync_invoke_multiple_sources(self):
+        """Two MCP sources registered sync, both callable via sync invoke."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), namespace="src1", persistent=True)
+            reg.register_from_mcp(_stdio_config(), namespace="src2", persistent=True)
+            assert "src1-add" in reg
+            assert "src2-add" in reg
+
+            r1 = reg.invoke("src1-add", {"a": 1, "b": 2})
+            r2 = reg.invoke("src2-echo", {"message": "test"})
+            assert isinstance(r1, ToolCallResult)
+            assert isinstance(r2, ToolCallResult)
+
+
+# ── Timeout enforcement ─────────────────────────────────────────────
+
+
+class TestTimeoutEnforcement:
+    def test_sync_invoke_native_tool_timeout(self):
+        """sync invoke + native async tool with tight timeout → ErrorResult."""
+        reg = ToolRegistry()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        reg.register(Tool.from_function(slow, metadata=ToolMetadata(timeout=0.3)))
+
+        start = time.perf_counter()
+        r = reg.invoke("slow", {"n": 1})
+        elapsed = time.perf_counter() - start
+
+        assert isinstance(r, ErrorResult)
+        assert "timed out" in r.message
+        assert elapsed < 2.0
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_native_tool_timeout(self):
+        """ainvoke + native async tool with tight timeout → ErrorResult."""
+        reg = ToolRegistry()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        reg.register(Tool.from_function(slow, metadata=ToolMetadata(timeout=0.3)))
+
+        start = time.perf_counter()
+        r = await reg.ainvoke("slow", {"n": 1})
+        elapsed = time.perf_counter() - start
+
+        assert isinstance(r, ErrorResult)
+        assert "timed out" in r.message
+        assert elapsed < 2.0
+
+    def test_sync_batch_native_tool_timeout(self):
+        """execute_tool_calls with a native tool that times out."""
+        reg = ToolRegistry()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        def fast(n: int) -> int:
+            return n * 2
+
+        reg.register(fast)
+        reg.register(Tool.from_function(slow, metadata=ToolMetadata(timeout=0.3)))
+
+        tcs = [
+            _tc("c1", "fast", '{"n": 5}'),
+            _tc("c2", "slow", '{"n": 1}'),
+        ]
+        start = time.perf_counter()
+        results = reg.execute_tool_calls(tcs)
+        elapsed = time.perf_counter() - start
+
+        assert isinstance(results["c1"], ToolCallResult)
+        assert results["c1"].result == "10"
+        assert isinstance(results["c2"], ErrorResult)
+        assert "timed out" in results["c2"].message
+        assert elapsed < 2.0
+
+    @pytest.mark.asyncio
+    async def test_async_batch_native_tool_timeout(self):
+        """aexecute_tool_calls with a native tool that times out."""
+        reg = ToolRegistry()
+
+        async def slow(n: int) -> int:
+            await asyncio.sleep(5)
+            return n
+
+        def fast(n: int) -> int:
+            return n * 2
+
+        reg.register(fast)
+        reg.register(Tool.from_function(slow, metadata=ToolMetadata(timeout=0.3)))
+
+        tcs = [
+            _tc("c1", "fast", '{"n": 5}'),
+            _tc("c2", "slow", '{"n": 1}'),
+        ]
+        start = time.perf_counter()
+        results = await reg.aexecute_tool_calls(tcs)
+        elapsed = time.perf_counter() - start
+
+        assert isinstance(results["c1"], ToolCallResult)
+        assert results["c1"].result == "10"
+        assert isinstance(results["c2"], ErrorResult)
+        assert "timed out" in results["c2"].message
+        assert elapsed < 2.0


### PR DESCRIPTION
## Summary

Sync entry points (`invoke`, `_invoke_raw`, `execute_tool_calls`) now resolve `natural_backend="inline"` tools to the **thread** backend, giving them real timeout via `Future.result(timeout)`. Async entry points (`ainvoke`, `aexecute_tool_calls`) keep inline so coroutines stay on the caller's loop.

This closes the last gap in the timeout matrix — `invoke()` with an inline tool now enforces `metadata.timeout` — and **deletes** the AsyncRuntime bridge workaround that was added to patch this gap.

## Why

Inline was introduced for MCP/OpenAPI tools that "can't be pickled and must stay on the current loop." But **only the second property matters for async callers.** Sync callers have no event loop to stay on. Thread backend satisfies "no pickle" equally well, and gives real timeout for free via `Future.result(timeout)`.

Verified that both blocking items are safe:
- **MCP from worker thread**: `AsyncRuntime.run_sync` uses `run_coroutine_threadsafe` — cross-thread by design. ThreadBackend's async tools already use this path.
- **PTC `IpcSubprocessRuntime`**: per-call `subprocess.Popen` — no shared pipes, no signal handlers, no thread affinity.

## What changed

`_resolve_backend` gains `async_caller: bool` (explicit, no auto-detection per Milo/Elena). When `False` (default, sync callers) and the resolved backend is inline, it's promoted to thread.

## What was deleted (net -17 lines)

- `_needs_async_timeout()` — sync path no longer has inline handles
- `AsyncRuntime` bridge in `_collect_handle_result` — thread handles enforce timeout natively
- `_execute_concurrent` three-phase logic (pool-first → inline → collect) — sync batch has no inline tools, collapses to submit-all → collect-all

## Timeout matrix (fully green)

| Entry point | inline | thread | process |
|---|---|---|---|
| `invoke()` | ✅ **fixed** | ✅ | ✅ |
| `execute_tool_calls()` | ✅ **simplified** | ✅ | ✅ |
| `ainvoke()` | ✅ | ✅ | ✅ |
| `aexecute_tool_calls()` | ✅ | ✅ | ✅ |

## Compatibility

InlineBackend is unreleased (post v0.14.0). Zero user impact.

## Test plan

- [x] sync invoke + inline tool → runs in pool thread (not calling thread)
- [x] sync invoke + timeout → enforced (was impossible)
- [x] ainvoke + inline → stays inline on caller loop
- [x] _resolve_backend: sync promotes inline→thread, async keeps inline, explicit mode overrides both
- [x] Existing timeout tests pass (sync batch, async batch, lambda patterns)
- [x] PTC tests pass (19/19)
- [x] Full suite: **1093 passed** (net +2 new resolution tests)
- [x] Pre-commit clean, **net -17 lines**