### PR TITLE
fix(executor): block process for inline tools + e2e test coverage

### DIFF
--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -403,11 +403,19 @@ class ToolRegistry(
         Returns:
             An execution backend instance.
         """
+        metadata = getattr(tool, "metadata", None)
+        natural = getattr(metadata, "natural_backend", None) if metadata else None
+
+        # Inline tools (MCP, OpenAPI) cannot run in a process pool — the
+        # live connection state serializes via cloudpickle but the worker
+        # process has no connection, causing a hang.  Block process even
+        # if the caller explicitly requested it.
+        if natural == "inline" and execution_mode == "process":
+            execution_mode = "thread"
+
         if execution_mode in ("thread", "process"):
             return self._backend_for(execution_mode)
 
-        metadata = getattr(tool, "metadata", None)
-        natural = getattr(metadata, "natural_backend", None) if metadata else None
         if natural in ("inline", "thread", "process"):
             resolved = self._backend_for(natural)
         else:

--- a/tests/_mcp_test_server.py
+++ b/tests/_mcp_test_server.py
@@ -53,6 +53,14 @@ def create_server(host: str = "127.0.0.1", port: int = 8000):
         """Return a greeting message."""
         return f"Hello, {name}!"
 
+    @mcp.tool()
+    def slow_tool(seconds: float = 5.0) -> str:
+        """Sleep for the given duration, then return. Used to test timeout."""
+        import time
+
+        time.sleep(seconds)
+        return f"slept {seconds}s"
+
     return mcp
 
 

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -323,3 +323,179 @@ class TestMCPToolTimeout:
             assert isinstance(results["c1"], ErrorResult)
             assert "timed out" in results["c1"].message
             assert elapsed < 2.0
+
+
+# ── OpenAPI through the execution stack ────────────────────────────
+
+
+class TestOpenAPIExecutionStack:
+    """OpenAPI tools through invoke/execute with the full backend seam.
+
+    Uses mock httpx clients (no live server) but goes through the real
+    ToolRegistry.register_from_openapi → invoke/execute_tool_calls
+    pipeline, verifying that natural_backend="inline" resolves
+    correctly on sync/async paths.
+    """
+
+    @staticmethod
+    def _openapi_registry():
+        import json as _json
+        from toolregistry.integrations.openapi.integration import OpenAPIIntegration
+
+        from tests.test_openapi_integration import (
+            PETSTORE_SPEC,
+            _make_config_with_mock,
+            _mock_response,
+        )
+
+        def handler(request):
+            if request.url.path == "/pets" and request.method == "GET":
+                return _mock_response(200, [{"id": 1, "name": "Fido"}])
+            if request.url.path == "/pets" and request.method == "POST":
+                body = _json.loads(request.content)
+                return _mock_response(201, {"id": 2, "name": body["name"]})
+            return _mock_response(404)
+
+        reg = ToolRegistry()
+        config = _make_config_with_mock(handler)
+        integration = OpenAPIIntegration(reg)
+        integration.register_openapi_tools(config, PETSTORE_SPEC)
+        return reg
+
+    def test_sync_invoke_openapi_tool(self):
+        reg = self._openapi_registry()
+        r = reg.invoke("list_pets", {"limit": 10})
+        assert isinstance(r, ToolCallResult)
+        assert "Fido" in r.result
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_openapi_tool(self):
+        reg = self._openapi_registry()
+        r = await reg.ainvoke("list_pets", {"limit": 5})
+        assert isinstance(r, ToolCallResult)
+        assert "Fido" in r.result
+
+    def test_sync_batch_openapi_tools(self):
+        reg = self._openapi_registry()
+        tcs = [
+            _tc("c1", "list_pets", '{"limit": 10}'),
+            _tc("c2", "create_pet", '{"name": "Rex"}'),
+        ]
+        results = reg.execute_tool_calls(tcs)
+        assert isinstance(results["c1"], ToolCallResult)
+        assert isinstance(results["c2"], ToolCallResult)
+        assert "Fido" in results["c1"].result
+        assert "Rex" in results["c2"].result
+
+
+# ── Mixed batch: MCP + native Python in one batch ──────────────────
+
+
+class TestMixedBatch:
+    """MCP (→thread on sync) + native Python (→process) in the same batch."""
+
+    def test_sync_mixed_mcp_and_native(self):
+        """MCP tools resolve to thread, native tools to process, same batch."""
+        reg = ToolRegistry()
+
+        def double(n: int) -> int:
+            """Native Python tool."""
+            return n * 2
+
+        reg.register(double)
+        reg.register_from_mcp(_stdio_config(), persistent=True)
+
+        tcs = [
+            _tc("c1", "double", '{"n": 7}'),
+            _tc("c2", "add", '{"a": 10, "b": 20}'),
+            _tc("c3", "echo", '{"message": "mixed"}'),
+        ]
+        results = reg.execute_tool_calls(tcs)
+
+        assert results["c1"].result == "14"
+        assert results["c2"].result == '{"result": 30}'
+        assert results["c3"].result == "mixed"
+        assert [r.id for r in results] == ["c1", "c2", "c3"]
+        reg.close()
+
+    @pytest.mark.asyncio
+    async def test_async_mixed_mcp_and_native(self):
+        """Async batch: MCP (inline) + native overlap under gather."""
+        reg = ToolRegistry()
+
+        async def double(n: int) -> int:
+            """Native async tool."""
+            return n * 2
+
+        reg.register(double)
+        await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+
+        tcs = [
+            _tc("c1", "double", '{"n": 5}'),
+            _tc("c2", "add", '{"a": 3, "b": 4}'),
+        ]
+        results = await reg.aexecute_tool_calls(tcs)
+
+        assert results["c1"].result == "10"
+        assert results["c2"].result == '{"result": 7}'
+        await reg.close_async()
+
+
+# ── MCP concurrent ainvoke (same connection) ───────────────────────
+
+
+class TestMCPConcurrentAinvoke:
+    """Multiple ainvoke on the same MCP connection overlap correctly."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_ainvoke_same_connection(self):
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+
+            r1, r2 = await asyncio.gather(
+                reg.ainvoke("add", {"a": 1, "b": 2}),
+                reg.ainvoke("add", {"a": 10, "b": 20}),
+            )
+            assert isinstance(r1, ToolCallResult)
+            assert isinstance(r2, ToolCallResult)
+            assert r1.result == '{"result": 3}'
+            assert r2.result == '{"result": 30}'
+
+
+# ── PTC in batch execution ─────────────────────────────────────────
+
+
+class TestPTCInBatch:
+    """PTC tool through execute_tool_calls (natural_backend=inline
+    promoted to thread on sync path)."""
+
+    def test_ptc_in_sync_batch(self):
+        from toolregistry.runtimes import PTC_TOOL_NAME
+
+        reg = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add."""
+            return a + b
+
+        reg.register(add)
+        reg.ptc.enable()
+
+        tcs = [
+            _tc("c1", "add", '{"a": 3, "b": 4}'),
+            _tc("c2", PTC_TOOL_NAME, '{"code": "print(add(a=10, b=20))"}'),
+        ]
+        results = reg.execute_tool_calls(tcs)
+
+        assert isinstance(results["c1"], ToolCallResult)
+        assert results["c1"].result == "7"
+        assert isinstance(results["c2"], ToolCallResult)
+        assert "30" in results["c2"].result
+        reg.close()
+
+
+# Note: forcing execution_mode="process" on MCP/OpenAPI tools is a usage
+# error — cloudpickle serializes the wrapper successfully, but the worker
+# process has no live MCP connection, so the deserialized call hangs.
+# The seam's natural_backend="inline" → thread promotion exists precisely
+# to prevent this.  No test for this path: it deadlocks by design.

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -494,8 +494,59 @@ class TestPTCInBatch:
         reg.close()
 
 
-# Note: forcing execution_mode="process" on MCP/OpenAPI tools is a usage
-# error — cloudpickle serializes the wrapper successfully, but the worker
-# process has no live MCP connection, so the deserialized call hangs.
-# The seam's natural_backend="inline" → thread promotion exists precisely
-# to prevent this.  No test for this path: it deadlocks by design.
+# ── Process blocked for inline tools ───────────────────────────────
+
+
+class TestProcessBlockedForInlineTools:
+    """execution_mode='process' is silently blocked for inline-natural
+    tools (MCP, OpenAPI) — downgraded to thread to prevent deadlock.
+
+    The live connection state serializes via cloudpickle but the worker
+    process has no connection, so it would hang.  _resolve_backend
+    intercepts this and routes to thread instead.
+    """
+
+    def test_invoke_force_process_mcp_goes_thread(self):
+        """invoke(execution_mode='process') on MCP tool succeeds (→thread)."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+            r = reg.invoke("echo", {"message": "safe"}, execution_mode="process")
+            assert isinstance(r, ToolCallResult)
+            assert r.result == "safe"
+
+    def test_batch_force_process_mcp_goes_thread(self):
+        """execute_tool_calls(execution_mode='process') on MCP tool succeeds."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+            tcs = [_tc("c1", "echo", '{"message": "batch safe"}')]
+            results = reg.execute_tool_calls(tcs, execution_mode="process")
+            assert isinstance(results["c1"], ToolCallResult)
+            assert results["c1"].result == "batch safe"
+
+    def test_resolve_backend_blocks_process_for_inline(self):
+        """_resolve_backend downgrades process→thread for inline tools."""
+        reg = ToolRegistry()
+
+        def ping(x: int) -> int:
+            return x
+
+        reg.register(
+            Tool.from_function(ping, metadata=ToolMetadata(natural_backend="inline"))
+        )
+        tool = reg.get_tool("ping")
+        backend = reg._resolve_backend(tool, execution_mode="process")
+        assert backend is reg._thread_backend
+
+    def test_resolve_backend_allows_thread_for_inline(self):
+        """execution_mode='thread' on inline tools is fine (no downgrade)."""
+        reg = ToolRegistry()
+
+        def ping(x: int) -> int:
+            return x
+
+        reg.register(
+            Tool.from_function(ping, metadata=ToolMetadata(natural_backend="inline"))
+        )
+        tool = reg.get_tool("ping")
+        backend = reg._resolve_backend(tool, execution_mode="thread")
+        assert backend is reg._thread_backend

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -230,3 +230,96 @@ class TestTimeoutEnforcement:
         assert isinstance(results["c2"], ErrorResult)
         assert "timed out" in results["c2"].message
         assert elapsed < 2.0
+
+
+# ── Real MCP tool timeout ──────────────────────────────────────────
+
+
+class TestMCPToolTimeout:
+    """Timeout with a real MCP server tool (not a mock async function).
+
+    Uses ``slow_tool`` from the test MCP server which does a real
+    ``time.sleep`` in the subprocess, exercising the full MCP transport
+    path (stdio pipes, MCP SDK request/response, connection manager).
+    """
+
+    def test_sync_invoke_mcp_timeout(self):
+        """sync invoke + real MCP tool + timeout → ErrorResult."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+            tool = reg.get_tool("slow_tool")
+            tool.metadata.timeout = 0.5
+
+            start = time.perf_counter()
+            r = reg.invoke("slow_tool", {"seconds": 5.0})
+            elapsed = time.perf_counter() - start
+
+            assert isinstance(r, ErrorResult)
+            assert "timed out" in r.message
+            assert elapsed < 2.0
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_mcp_timeout(self):
+        """ainvoke + real MCP tool + timeout → ErrorResult."""
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+            tool = reg.get_tool("slow_tool")
+            tool.metadata.timeout = 0.5
+
+            start = time.perf_counter()
+            r = await reg.ainvoke("slow_tool", {"seconds": 5.0})
+            elapsed = time.perf_counter() - start
+
+            assert isinstance(r, ErrorResult)
+            assert "timed out" in r.message
+            assert elapsed < 2.0
+
+    def test_sync_invoke_mcp_no_timeout_completes(self):
+        """MCP tool without timeout runs to completion normally."""
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+
+            r = reg.invoke("slow_tool", {"seconds": 0.3})
+            assert isinstance(r, ToolCallResult)
+            assert "slept" in r.result
+
+    def test_sync_batch_mcp_timeout(self):
+        """sync batch: single slow MCP tool times out.
+
+        Uses a single-tool batch because our test MCP server uses
+        blocking ``time.sleep`` in ``slow_tool``, which serializes all
+        requests at the server process level.  This is a test-server
+        limitation, not an MCP protocol constraint — the protocol
+        multiplexes by request-id and our client-side connection
+        manager does not serialize calls.
+        """
+        with ToolRegistry() as reg:
+            reg.register_from_mcp(_stdio_config(), persistent=True)
+            tool = reg.get_tool("slow_tool")
+            tool.metadata.timeout = 0.5
+
+            tcs = [_tc("c1", "slow_tool", '{"seconds": 5.0}')]
+            start = time.perf_counter()
+            results = reg.execute_tool_calls(tcs)
+            elapsed = time.perf_counter() - start
+
+            assert isinstance(results["c1"], ErrorResult)
+            assert "timed out" in results["c1"].message
+            assert elapsed < 2.0
+
+    @pytest.mark.asyncio
+    async def test_async_batch_mcp_timeout(self):
+        """async batch: single slow MCP tool times out."""
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+            tool = reg.get_tool("slow_tool")
+            tool.metadata.timeout = 0.5
+
+            tcs = [_tc("c1", "slow_tool", '{"seconds": 5.0}')]
+            start = time.perf_counter()
+            results = await reg.aexecute_tool_calls(tcs)
+            elapsed = time.perf_counter() - start
+
+            assert isinstance(results["c1"], ErrorResult)
+            assert "timed out" in results["c1"].message
+            assert elapsed < 2.0

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -163,7 +163,7 @@ class TestStdioTransport:
         """MCPClient should accept a .py path directly for stdio."""
         async with MCPClient(_SERVER_SCRIPT) as client:
             tools = await client.list_tools()
-            assert len(tools) == 3
+            assert len(tools) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -236,7 +236,7 @@ class TestStreamableHttpTransport:
         headers = {"X-Custom-Header": "test-value"}
         async with MCPClient(f"http://127.0.0.1:{port}/mcp", headers=headers) as client:
             tools = await client.list_tools()
-            assert len(tools) == 3
+            assert len(tools) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +309,7 @@ class TestSseTransport:
         headers = {"Authorization": "Bearer test-token"}
         async with MCPClient(f"http://127.0.0.1:{port}/sse", headers=headers) as client:
             tools = await client.list_tools()
-            assert len(tools) == 3
+            assert len(tools) == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three changes that were incorrectly pushed directly to master, now going through proper PR flow.

### 1. Block process backend for inline-natural tools (fix)
`_resolve_backend` now downgrades `execution_mode="process"` to `"thread"` when the tool has `natural_backend="inline"` (MCP, OpenAPI). Previously this caused a silent deadlock: cloudpickle serialized the wrapper but the worker process had no live connection.

### 2. E2e test coverage gaps (test)
7 new test classes covering:
- OpenAPI tools through invoke/ainvoke/batch (mock transport, full pipeline)
- Mixed batch: MCP (→thread) + native Python (→process) in same batch
- MCP concurrent ainvoke on same connection via gather
- PTC in sync batch (natural_backend=inline promoted to thread)
- Process-blocked tests: force-process on MCP safely → thread

### 3. Real MCP timeout tests (test)
`slow_tool` added to the MCP test server (blocking `time.sleep` in subprocess). 5 tests exercising real MCP timeout on sync invoke, ainvoke, no-timeout, sync batch, and async batch.

## Test plan

- [x] 27 e2e tests pass (no hangs, 56s)
- [x] Pre-commit clean

## Context

Gaps identified during post-refactor testing review. The process-block fix was discovered via a hanging test — forcing `execution_mode="process"` on MCP tools deadlocked because the worker process had no connection.