### PR TITLE
feat: expand _CONTENT_BLOCK_TYPES for MCP 2026-07-28 content types

### DIFF
--- a/src/toolregistry/llm/content_blocks.py
+++ b/src/toolregistry/llm/content_blocks.py
@@ -42,7 +42,7 @@ class ImageBlock(TypedDict):
 ContentBlock = Union[TextBlock, ImageBlock]
 """Union type for all supported content block kinds."""
 
-_CONTENT_BLOCK_TYPES = {"text", "image"}
+_CONTENT_BLOCK_TYPES = {"text", "image", "audio", "resource_link", "resource"}
 
 
 def is_content_block_list(value: Any) -> bool:
@@ -50,7 +50,8 @@ def is_content_block_list(value: Any) -> bool:
 
     A valid content block list is a non-empty ``list`` where every
     element is a ``dict`` with a ``"type"`` key whose value is one of
-    the recognized content block types (``"text"`` or ``"image"``).
+    the recognized content block types (``"text"``, ``"image"``,
+    ``"audio"``, ``"resource_link"``, or ``"resource"``).
 
     Args:
         value: The value to check.

--- a/tests/test_content_blocks.py
+++ b/tests/test_content_blocks.py
@@ -81,7 +81,7 @@ class TestIsContentBlockList:
 
     def test_rejects_mixed_valid_and_invalid(self):
         assert not is_content_block_list(
-            [_make_text_block("ok"), {"type": "audio", "data": "x"}]
+            [_make_text_block("ok"), {"type": "video", "url": "x"}]
         )
 
 


### PR DESCRIPTION
## Summary

One-line change: expand `_CONTENT_BLOCK_TYPES` from `{"text", "image"}` to `{"text", "image", "audio", "resource_link", "resource"}`.

Without this, `is_content_block_list()` rejects tool results containing these MCP 2026-07-28 content types, causing the MCP adapter in toolregistry-server to JSON-dump them into text instead of converting to native MCP content blocks.

Closes #239

## Test plan

- [x] All 43 content block tests pass
- [x] Full test suite passes