### PR TITLE
feat: emit additionalProperties for **kwargs functions

### DIFF
--- a/src/toolregistry/parameter_models.py
+++ b/src/toolregistry/parameter_models.py
@@ -231,16 +231,32 @@ def _simplify_nullable_schemas(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+class _ArgModelBaseExtra(ArgModelBase):
+    """ArgModelBase variant that accepts additional properties.
+
+    Used when the wrapped function has a ``**kwargs`` parameter so the
+    generated JSON Schema includes ``"additionalProperties": true``.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="allow",
+    )
+
+
 def _create_parameters_model(
     func: Callable,
     field_definitions: dict[str, Any],
+    *,
+    has_var_keyword: bool = False,
 ) -> type[ArgModelBase] | None:
     """Create and validate the final Pydantic parameter model."""
+    base = _ArgModelBaseExtra if has_var_keyword else ArgModelBase
     try:
         model = create_model(
             f"{getattr(func, '__name__', 'unknown')}Parameters",
             **field_definitions,
-            __base__=ArgModelBase,
+            __base__=base,
         )
         model.model_json_schema()
         return model
@@ -274,14 +290,15 @@ def _generate_parameters_model(func: Callable) -> type[ArgModelBase] | None:
         resolved_hints = {}
 
     field_definitions: dict[str, Any] = {}
+    has_var_keyword = False
     for param in signature.parameters.values():
         if param.name == "self":
             continue
-        if param.kind in (
-            inspect.Parameter.VAR_POSITIONAL,
-            inspect.Parameter.VAR_KEYWORD,
-        ):
+        if param.kind == inspect.Parameter.VAR_POSITIONAL:
             _warn_skipped_variadic_parameter(func, param)
+            continue
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            has_var_keyword = True
             continue
         field_definitions[param.name] = _field_def_for_parameter(
             func,
@@ -290,4 +307,6 @@ def _generate_parameters_model(func: Callable) -> type[ArgModelBase] | None:
             resolved_hints,
         )
 
-    return _create_parameters_model(func, field_definitions)
+    return _create_parameters_model(
+        func, field_definitions, has_var_keyword=has_var_keyword
+    )

--- a/src/toolregistry/parameter_models.py
+++ b/src/toolregistry/parameter_models.py
@@ -27,10 +27,16 @@ class ArgModelBase(BaseModel):
     def model_dump_one_level(self) -> dict[str, Any]:
         """Dump model fields one level deep, keeping sub-models as-is.
 
+        When the model allows extra fields (``extra="allow"``), any
+        additional keys accepted by Pydantic are included in the result.
+
         Returns:
             Dict[str, Any]: Dictionary of field names to values.
         """
-        return {field: getattr(self, field) for field in self.__pydantic_fields__}
+        result = {field: getattr(self, field) for field in self.__pydantic_fields__}
+        if self.model_extra:
+            result.update(self.model_extra)
+        return result
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -238,10 +244,7 @@ class _ArgModelBaseExtra(ArgModelBase):
     generated JSON Schema includes ``"additionalProperties": true``.
     """
 
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        extra="allow",
-    )
+    model_config = ConfigDict(extra="allow")
 
 
 def _create_parameters_model(

--- a/tests/test_param_warnings.py
+++ b/tests/test_param_warnings.py
@@ -59,69 +59,68 @@ class TestVarPositionalWarning:
             _generate_parameters_model(func_with_custom_args)
 
 
-class TestVarKeywordWarning:
-    """Test that **kwargs parameters emit a warning."""
+class TestVarKeywordHandling:
+    """Test that **kwargs enables additionalProperties instead of warning."""
 
-    def test_kwargs_emits_warning(self):
-        """Registering a function with **kwargs should warn about exclusion."""
+    def test_kwargs_no_warning(self):
+        """Registering a function with **kwargs should NOT warn."""
 
         def func_with_kwargs(x: int, **kwargs: str) -> str:
             return str(x)
 
-        with pytest.warns(
-            UserWarning,
-            match=r"Parameter '\*\*kwargs' \(\*\*kwargs\) in 'func_with_kwargs'.*excluded",
-        ):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             _generate_parameters_model(func_with_kwargs)
 
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 0
+
     def test_kwargs_via_tool_from_function(self):
-        """Tool.from_function with **kwargs should warn about exclusion."""
+        """Tool.from_function with **kwargs should set additionalProperties."""
 
         def func_with_kwargs(x: int, **kwargs: str) -> str:
             return str(x)
 
-        with pytest.warns(
-            UserWarning,
-            match=r"Parameter '\*\*kwargs' \(\*\*kwargs\) in 'func_with_kwargs'.*excluded",
-        ):
-            tool = Tool.from_function(func_with_kwargs)
+        tool = Tool.from_function(func_with_kwargs)
 
-        # The tool should still be created successfully, with only 'x' in schema
         assert tool is not None
         assert "x" in tool.parameters.get("properties", {})
+        assert tool.parameters.get("additionalProperties") is True
 
     def test_custom_kwargs_name(self):
-        """Custom **kwargs name should appear in the warning message."""
+        """Custom **kwargs name should also enable additionalProperties."""
 
         def func_with_custom_kwargs(x: int, **options: str) -> str:
             return str(x)
 
-        with pytest.warns(
-            UserWarning,
-            match=r"Parameter '\*\*options' \(\*\*kwargs\) in 'func_with_custom_kwargs'",
-        ):
-            _generate_parameters_model(func_with_custom_kwargs)
+        model = _generate_parameters_model(func_with_custom_kwargs)
+        assert model is not None
+        schema = model.model_json_schema()
+        assert schema.get("additionalProperties") is True
 
 
 class TestBothArgsAndKwargs:
-    """Test that functions with both *args and **kwargs emit two warnings."""
+    """Test that *args warns while **kwargs enables additionalProperties."""
 
-    def test_args_and_kwargs_both_warn(self):
-        """Both *args and **kwargs should each produce a warning."""
+    def test_args_warns_kwargs_does_not(self):
+        """Only *args should produce a warning; **kwargs enables additionalProperties."""
 
         def func_with_both(x: int, *args: str, **kwargs: str) -> str:
             return str(x)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            _generate_parameters_model(func_with_both)
+            model = _generate_parameters_model(func_with_both)
 
         user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
-        assert len(user_warnings) == 2
+        assert len(user_warnings) == 1
 
         messages = [str(w.message) for w in user_warnings]
         assert any("*args" in m and "'*args'" in m for m in messages)
-        assert any("**kwargs" in m and "'**kwargs'" in m for m in messages)
+
+        assert model is not None
+        schema = model.model_json_schema()
+        assert schema.get("additionalProperties") is True
 
 
 class TestParameterModelGenerationFailureWarning:

--- a/tests/test_parameter_models.py
+++ b/tests/test_parameter_models.py
@@ -687,6 +687,40 @@ class TestComplexTypeSchemaGeneration:
         assert "x" in schema["properties"]
         assert schema.get("additionalProperties") is True
 
+    def test_kwargs_only_function(self):
+        """Function with only **kwargs should produce additionalProperties schema."""
+
+        def f(**kwargs) -> None: ...
+
+        model = _generate_parameters_model(f)
+
+        assert model is not None
+        schema = model.model_json_schema()
+        assert schema.get("additionalProperties") is True
+        assert schema.get("properties", {}) == {}
+
+    def test_args_and_kwargs_combo(self):
+        """*args warns while **kwargs enables additionalProperties."""
+
+        def f(x: int, *args, **kwargs) -> None: ...
+
+        with pytest.warns(UserWarning, match=r"\*args"):
+            model = _generate_parameters_model(f)
+
+        assert model is not None
+        schema = model.model_json_schema()
+        assert "x" in schema["properties"]
+        assert "args" not in schema.get("properties", {})
+        assert schema.get("additionalProperties") is True
+
+    def test_normal_function_no_additional_properties(self):
+        """Normal functions should NOT have additionalProperties in schema."""
+
+        def f(name: str, age: int = 0) -> None: ...
+
+        schema = self._schema_for(f)
+        assert "additionalProperties" not in schema
+
     # --- Required fields tracking ---
 
     def test_required_fields_in_schema(self):

--- a/tests/test_parameter_models.py
+++ b/tests/test_parameter_models.py
@@ -674,17 +674,18 @@ class TestComplexTypeSchemaGeneration:
         assert "args" not in model.model_json_schema()["properties"]
         assert "x" in model.model_json_schema()["properties"]
 
-    def test_kwargs_emits_warning(self):
-        """**kwargs parameter should emit UserWarning and be excluded."""
+    def test_kwargs_enables_additional_properties(self):
+        """**kwargs parameter should set additionalProperties: true."""
 
         def f(x: int, **kwargs) -> None: ...
 
-        with pytest.warns(UserWarning, match=r"\*\*kwargs"):
-            model = _generate_parameters_model(f)
+        model = _generate_parameters_model(f)
 
         assert model is not None
-        assert "kwargs" not in model.model_json_schema()["properties"]
-        assert "x" in model.model_json_schema()["properties"]
+        schema = model.model_json_schema()
+        assert "kwargs" not in schema.get("properties", {})
+        assert "x" in schema["properties"]
+        assert schema.get("additionalProperties") is True
 
     # --- Required fields tracking ---
 


### PR DESCRIPTION
## Summary

- When a registered tool function has a `**kwargs` parameter, the generated JSON Schema now includes `"additionalProperties": true`
- Previously `**kwargs` was silently dropped with a warning, making it impossible to build proxy tools (like `call_deferred`) that forward arbitrary parameters
- `*args` still emits a warning and is excluded — positional parameters have no JSON Schema equivalent

## Motivation

This enables a `call_deferred(tool_name, **kwargs)` pattern where deferred tools can be invoked through a proxy without relying on `notifications/tools/list_changed` (which most MCP clients don't support — only Goose and Grok Build handle it; Codex logs but ignores it; OpenCode and Pi don't support it at all).

## Changes

- `parameter_models.py`: Added `_ArgModelBaseExtra` (Pydantic `extra="allow"`) and updated `_generate_parameters_model` to detect `VAR_KEYWORD` and pass `has_var_keyword` flag
- `test_parameter_models.py`: Updated test from expecting a warning to asserting `additionalProperties: true` in schema

## Test plan

- [x] `**kwargs` function generates schema with `additionalProperties: true`
- [x] Normal function schema unchanged (no `additionalProperties` key)
- [x] `*args` still warns and is excluded
- [x] `*args` + `**kwargs` combo: `additionalProperties: true` + `*args` warning
- [x] All 107 parameter_models + tool tests pass