### PR TITLE
refactor: replace Pydantic with dataclasses + zerodep validate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "pydantic>=2.7.2,<3.0.0",
     "cloudpickle>=3.0.0",
     "llm-rosetta>=0.7.1,<0.10.0",
 ]

--- a/src/toolregistry/_vendor/validate.py
+++ b/src/toolregistry/_vendor/validate.py
@@ -1,0 +1,1382 @@
+# /// zerodep
+# version = "0.7.0"
+# deps = []
+# tier = "medium"
+# category = "validation"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+
+"""Zero-dependency runtime validator for TypedDict and dataclass types.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Validate arbitrary data against stdlib type annotations (TypedDict,
+dataclass, Annotated constraints) and generate JSON Schema from the
+same type definitions.
+
+Basic usage::
+
+    from validate import validate, json_schema, ValidationError
+
+    class User(TypedDict):
+        name: str
+        age: int
+
+    validate({"name": "Alice", "age": 30}, User)   # ok
+    validate({"name": "Alice", "age": "x"}, User)   # raises ValidationError
+
+    schema = json_schema(User)  # {"type": "object", "properties": ...}
+
+Annotated constraints::
+
+    from validate import Gt, MinLen
+    from typing import Annotated
+
+    class Item(TypedDict):
+        name: Annotated[str, MinLen(1)]
+        price: Annotated[float, Gt(0)]
+
+Field validators (transform + validate)::
+
+    from validate import FieldValidator
+
+    def strip_lower(v: str) -> str:
+        v = v.strip().lower()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    class User(TypedDict):
+        name: Annotated[str, FieldValidator(strip_lower)]
+
+Model validators (cross-field validation)::
+
+    from validate import model_validator
+
+    class RegisterForm(TypedDict):
+        password: str
+        confirm: str
+
+    @model_validator(RegisterForm)
+    def passwords_match(data: dict) -> dict:
+        if data["password"] != data["confirm"]:
+            raise ValueError("passwords do not match")
+        return data
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import re
+import types
+import typing
+from collections.abc import Callable
+from typing import Any, Union, get_type_hints
+
+_UNION_ORIGINS = (Union, types.UnionType)
+
+__all__ = [
+    # Constraint annotations
+    "Gt",
+    "Ge",
+    "Lt",
+    "Le",
+    "MinLen",
+    "MaxLen",
+    "Match",
+    "Predicate",
+    "FieldValidator",
+    "Doc",
+    # Error types
+    "ErrorDetail",
+    "ValidationError",
+    # Public API
+    "validate",
+    "json_schema",
+    "model_validator",
+    "create_struct",
+]
+
+# ── Constraint Annotations ──
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Gt:
+    """Value must be strictly greater than *val*."""
+
+    val: float
+
+    def check(self, value: Any) -> bool:
+        return value > self.val
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"exclusiveMinimum": self.val}
+
+    def __str__(self) -> str:
+        return f"> {self.val}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Ge:
+    """Value must be greater than or equal to *val*."""
+
+    val: float
+
+    def check(self, value: Any) -> bool:
+        return value >= self.val
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"minimum": self.val}
+
+    def __str__(self) -> str:
+        return f">= {self.val}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Lt:
+    """Value must be strictly less than *val*."""
+
+    val: float
+
+    def check(self, value: Any) -> bool:
+        return value < self.val
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"exclusiveMaximum": self.val}
+
+    def __str__(self) -> str:
+        return f"< {self.val}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Le:
+    """Value must be less than or equal to *val*."""
+
+    val: float
+
+    def check(self, value: Any) -> bool:
+        return value <= self.val
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"maximum": self.val}
+
+    def __str__(self) -> str:
+        return f"<= {self.val}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MinLen:
+    """Length must be at least *val*."""
+
+    val: int
+
+    def check(self, value: Any) -> bool:
+        return len(value) >= self.val
+
+    def schema_kw(self) -> dict[str, Any]:
+        if isinstance(self.val, int):
+            return {"minLength": self.val}
+        return {"minLength": self.val}
+
+    def schema_kw_array(self) -> dict[str, Any]:
+        return {"minItems": self.val}
+
+    def __str__(self) -> str:
+        return f"len >= {self.val}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MaxLen:
+    """Length must be at most *val*."""
+
+    val: int
+
+    def check(self, value: Any) -> bool:
+        return len(value) <= self.val
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"maxLength": self.val}
+
+    def schema_kw_array(self) -> dict[str, Any]:
+        return {"maxItems": self.val}
+
+    def __str__(self) -> str:
+        return f"len <= {self.val}"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Match:
+    """Value must match *pattern* (via ``re.fullmatch``)."""
+
+    pattern: str
+
+    def check(self, value: Any) -> bool:
+        return re.fullmatch(self.pattern, value) is not None
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"pattern": self.pattern}
+
+    def __str__(self) -> str:
+        return f"match({self.pattern!r})"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Predicate:
+    """Value must satisfy a custom predicate function.
+
+    Args:
+        fn: A callable ``(value) -> bool``.
+        description: Human-readable description for error messages.
+    """
+
+    fn: Callable[[Any], bool]
+    description: str = "custom predicate"
+
+    def check(self, value: Any) -> bool:
+        return self.fn(value)
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {}
+
+    def __str__(self) -> str:
+        return self.description
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FieldValidator:
+    """Custom validator that can transform the field value.
+
+    Unlike ``Predicate`` (which returns bool), the function receives the
+    validated value and returns a (possibly transformed) value.  Raise
+    ``ValueError`` or ``AssertionError`` to signal failure.
+
+    Args:
+        fn: A callable ``(value) -> value``.  Raise on failure.
+        description: Human-readable description for error messages.
+    """
+
+    fn: Callable[[Any], Any]
+    description: str = "custom validator"
+
+    def validate(self, value: Any) -> Any:
+        return self.fn(value)
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {}
+
+    def __str__(self) -> str:
+        return self.description
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Doc:
+    """Field description marker for ``Annotated`` types.
+
+    Attaches a human-readable description to a type annotation.  The
+    description is emitted as ``{"description": ...}`` in JSON Schema
+    and has no effect on validation.
+
+    Example::
+
+        Annotated[str, Doc("The user's full name")]
+    """
+
+    description: str
+
+    def check(self, value: Any) -> bool:
+        return True
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {"description": self.description}
+
+    def __str__(self) -> str:
+        return self.description
+
+
+# Constraint base types for isinstance checks
+_CONSTRAINT_TYPES = (
+    Gt,
+    Ge,
+    Lt,
+    Le,
+    MinLen,
+    MaxLen,
+    Match,
+    Predicate,
+    FieldValidator,
+    Doc,
+)
+
+
+# ── Model Validator Registry ──
+
+_MODEL_VALIDATORS: dict[type, list[Callable]] = {}
+
+
+def model_validator(tp: type) -> Callable[[Callable], Callable]:
+    """Register a model-level validator for a TypedDict or dataclass type.
+
+    The validator receives the full data dict after all field validation
+    passes.  It should return the (possibly modified) dict, or raise
+    ``ValueError`` / ``AssertionError`` on failure.
+
+    Args:
+        tp: The TypedDict or dataclass type to attach the validator to.
+
+    Returns:
+        A decorator that registers the function and returns it unchanged.
+
+    Example::
+
+        class RegisterForm(TypedDict):
+            password: str
+            confirm: str
+
+        @model_validator(RegisterForm)
+        def passwords_match(data: dict) -> dict:
+            if data["password"] != data["confirm"]:
+                raise ValueError("passwords do not match")
+            return data
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        _MODEL_VALIDATORS.setdefault(tp, []).append(fn)
+        return fn
+
+    return decorator
+
+
+# ── Error Types ──
+
+
+@dataclasses.dataclass
+class ErrorDetail:
+    """A single validation error.
+
+    Attributes:
+        path: Dotted/bracketed path to the failing field (e.g. ``"items[2].name"``).
+        expected: Expected type or constraint description.
+        actual: Actual type or value description.
+        message: Human-readable error message.
+    """
+
+    path: str
+    expected: str
+    actual: str
+    message: str
+
+
+class ValidationError(Exception):
+    """Raised when validation fails.
+
+    Attributes:
+        errors: List of all validation errors found.
+    """
+
+    def __init__(self, errors: list[ErrorDetail]) -> None:
+        self.errors = errors
+        msgs = "; ".join(e.message for e in errors[:5])
+        if len(errors) > 5:
+            msgs += f" ... and {len(errors) - 5} more"
+        super().__init__(f"{len(errors)} validation error(s): {msgs}")
+
+
+# ── Internal Helpers ──
+
+
+@functools.cache
+def _unwrap_annotated(tp: Any) -> tuple[Any, tuple[Any, ...]]:
+    """Extract the base type and constraint metadata from an Annotated type.
+
+    Results are cached because Annotated type structures are static at
+    runtime.
+
+    Returns:
+        ``(base_type, (constraint1, constraint2, ...))`` if Annotated,
+        otherwise ``(tp, ())``.
+    """
+    origin = typing.get_origin(tp)
+    if origin is typing.Annotated:
+        args = typing.get_args(tp)
+        base = args[0]
+        constraints = tuple(a for a in args[1:] if isinstance(a, _CONSTRAINT_TYPES))
+        return base, constraints
+    return tp, ()
+
+
+@functools.cache
+def _is_typeddict(tp: Any) -> bool:
+    """Check if *tp* is a TypedDict class.
+
+    Uses ``__required_keys__`` attribute detection to support TypedDicts
+    created with both ``typing.TypedDict`` and ``typing_extensions.TypedDict``.
+
+    Results are cached because type identity is stable at runtime.
+    """
+    return isinstance(tp, type) and hasattr(tp, "__required_keys__")
+
+
+@functools.cache
+def _is_dataclass_type(tp: Any) -> bool:
+    """Check if *tp* is a dataclass class (not an instance).
+
+    Results are cached because type identity is stable at runtime.
+    """
+    return isinstance(tp, type) and dataclasses.is_dataclass(tp)
+
+
+def _resolve_required(tp: Any) -> tuple[Any, bool | None]:
+    """Unwrap ``Required``/``NotRequired`` and report the wrapper kind.
+
+    Returns:
+        ``(inner_type, is_required)`` where *is_required* is ``True`` for
+        ``Required``, ``False`` for ``NotRequired``, or ``None`` when the
+        type has no such wrapper.
+
+    Detection uses the origin's ``_name`` attribute, which both
+    ``typing`` (3.11+) and ``typing_extensions`` set to ``"Required"``
+    or ``"NotRequired"``.  This avoids version-gated imports.
+    """
+    origin = typing.get_origin(tp)
+    # _name is a CPython implementation detail, stable across 3.10-3.14+
+    # and explicitly maintained by typing_extensions.
+    name = getattr(origin, "_name", None)
+    if name in ("Required", "NotRequired"):
+        args = typing.get_args(tp)
+        return (args[0] if args else tp), (name == "Required")
+    return tp, None
+
+
+def _strip_required(tp: Any) -> Any:
+    """Strip ``Required`` / ``NotRequired`` wrappers, returning the inner type."""
+    inner, _ = _resolve_required(tp)
+    return inner
+
+
+@functools.cache
+def _typeddict_fields(td: type) -> dict[str, tuple[Any, bool]]:
+    """Get fields of a TypedDict with their types and required status.
+
+    Results are cached because TypedDict type structures are static at
+    runtime, and ``get_type_hints()`` is expensive on Python 3.10-3.12.
+
+    Strips ``Required``/``NotRequired`` wrappers so downstream sees the
+    actual type (e.g. ``Literal["response"]``, not ``Required[Literal["response"]]``).
+
+    Returns:
+        Dict mapping field name to ``(type_hint, is_required)``.
+    """
+    hints = get_type_hints(td, include_extras=True)
+    required = getattr(td, "__required_keys__", set())
+    optional = getattr(td, "__optional_keys__", set())
+    result: dict[str, tuple[Any, bool]] = {}
+    for name, tp in hints.items():
+        inner, explicit = _resolve_required(tp)
+        if explicit is not None:
+            # Annotation-level Required/NotRequired is authoritative.
+            # On Python 3.10, typing.TypedDict ignores these wrappers
+            # when populating __required_keys__ / __optional_keys__,
+            # so the annotation is the only reliable source.
+            result[name] = (inner, explicit)
+        elif name in required:
+            result[name] = (inner, True)
+        elif name in optional:
+            result[name] = (inner, False)
+        else:
+            result[name] = (inner, True)
+    return result
+
+
+@functools.cache
+def _dataclass_fields(dc: type) -> dict[str, tuple[Any, bool]]:
+    """Get fields of a dataclass with their types and required status.
+
+    Results are cached because dataclass type structures are static at
+    runtime, and ``get_type_hints()`` is expensive on Python 3.10-3.12.
+
+    Returns:
+        Dict mapping field name to ``(type_hint, is_required)``.
+    """
+    hints = get_type_hints(dc, include_extras=True)
+    result: dict[str, tuple[Any, bool]] = {}
+    for f in dataclasses.fields(dc):
+        tp = hints.get(f.name, f.type)
+        has_default = (
+            f.default is not dataclasses.MISSING
+            or f.default_factory is not dataclasses.MISSING
+        )
+        result[f.name] = (tp, not has_default)
+    return result
+
+
+def _dataclass_defaults(dc: type) -> dict[str, Any] | None:
+    """Extract static default values from a dataclass type.
+
+    Fields using ``default_factory`` are intentionally excluded — factory
+    return values are not statically known and calling them would risk
+    side effects.
+    """
+    result: dict[str, Any] = {}
+    for f in dataclasses.fields(dc):
+        if f.default is not dataclasses.MISSING:
+            result[f.name] = f.default
+    return result or None
+
+
+def _join_path(base: str, key: str | int) -> str:
+    """Join a path segment."""
+    if isinstance(key, int):
+        return f"{base}[{key}]" if base else f"[{key}]"
+    return f"{base}.{key}" if base else key
+
+
+def _type_name(tp: Any) -> str:
+    """Human-readable name for a type."""
+    origin = typing.get_origin(tp)
+    if origin is typing.Annotated:
+        base = typing.get_args(tp)[0]
+        return _type_name(base)
+    if origin in _UNION_ORIGINS:
+        args = typing.get_args(tp)
+        return " | ".join(_type_name(a) for a in args)
+    if origin is typing.Literal:
+        args = typing.get_args(tp)
+        return f"Literal[{', '.join(repr(a) for a in args)}]"
+    if origin is not None:
+        base_name = getattr(origin, "__name__", str(origin))
+        args = typing.get_args(tp)
+        if args:
+            args_str = ", ".join(_type_name(a) for a in args)
+            return f"{base_name}[{args_str}]"
+        return base_name
+    if isinstance(tp, type):
+        return tp.__name__
+    if tp is type(None):
+        return "None"
+    return str(tp)
+
+
+@functools.cache
+def _find_discriminator(union_args: tuple[Any, ...]) -> str | None:
+    """Find a shared Literal field that can discriminate union members.
+
+    Checks all TypedDict members for a common field whose type is
+    ``Literal[...]``.  Returns the field name if found, else None.
+
+    Results are cached because union type structures are static.
+    """
+    td_args = [a for a in union_args if _is_typeddict(a)]
+    if len(td_args) < 2:
+        return None
+
+    # Get all Literal field names from first TypedDict
+    first_fields = _typeddict_fields(td_args[0])
+    candidates: list[str] = []
+    for name, (hint, _req) in first_fields.items():
+        base, _ = _unwrap_annotated(hint)
+        if typing.get_origin(base) is typing.Literal:
+            candidates.append(name)
+
+    for name in candidates:
+        # Check that all other TypedDicts also have this field as Literal
+        all_have = True
+        for td in td_args[1:]:
+            fields = _typeddict_fields(td)
+            if name not in fields:
+                all_have = False
+                break
+            base, _ = _unwrap_annotated(fields[name][0])
+            if typing.get_origin(base) is not typing.Literal:
+                all_have = False
+                break
+        if all_have:
+            return name
+
+    return None
+
+
+# ── Coercion ──
+
+_COERCIONS: dict[tuple[type, type], Callable[[Any], Any]] = {
+    (str, int): int,
+    (str, float): float,
+    (int, float): float,
+    (list, tuple): tuple,
+    (tuple, list): list,
+}
+
+
+def _try_coerce(value: Any, target_type: type, coerce: bool) -> tuple[Any, bool]:
+    """Attempt to coerce *value* to *target_type*.
+
+    Returns:
+        ``(coerced_value, True)`` on success, ``(value, False)`` on failure.
+    """
+    if not coerce:
+        return value, False
+    actual = type(value)
+    converter = _COERCIONS.get((actual, target_type))
+    if converter is None:
+        return value, False
+    try:
+        return converter(value), True
+    except (ValueError, TypeError):
+        return value, False
+
+
+# ── Core Validation Walker ──
+
+# Mapping from Python type to expected isinstance types
+_SIMPLE_TYPES: dict[type, type | tuple[type, ...]] = {
+    str: str,
+    int: int,
+    float: (int, float),  # int is valid for float
+    bool: bool,
+    bytes: bytes,
+}
+
+
+def _validate_annotated(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+) -> Any:
+    """Validate an ``Annotated[base, ...]`` type: check base then constraints."""
+    base, constraints = _unwrap_annotated(tp)
+    err_count_before = len(errors)
+    value = _validate(value, base, path, errors, coerce)
+    if len(errors) == err_count_before:
+        for c in constraints:
+            if isinstance(c, FieldValidator):
+                try:
+                    value = c.validate(value)
+                except (ValueError, AssertionError) as e:
+                    errors.append(
+                        ErrorDetail(
+                            path=path or "$",
+                            expected=str(c),
+                            actual=repr(value),
+                            message=f"Validator '{c}' failed for value {value!r} at '{path or '$'}': {e}",
+                        )
+                    )
+            elif not c.check(value):
+                errors.append(
+                    ErrorDetail(
+                        path=path or "$",
+                        expected=str(c),
+                        actual=repr(value),
+                        message=f"Constraint {c} failed for value {value!r} at '{path or '$'}'",
+                    )
+                )
+    return value
+
+
+def _validate_literal(
+    value: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    args: tuple[Any, ...],
+) -> Any:
+    """Validate a ``Literal[...]`` type."""
+    if value not in args:
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected=f"Literal[{', '.join(repr(a) for a in args)}]",
+                actual=repr(value),
+                message=f"Expected one of {args!r} at '{path or '$'}', got {value!r}",
+            )
+        )
+    return value
+
+
+@functools.cache
+def _build_dispatch_table(
+    disc_field: str, union_args: tuple[Any, ...]
+) -> dict[object, type]:
+    """Build a ``{literal_value: TypedDict}`` dispatch table for a union.
+
+    Called once per unique (discriminator field, union args) combination
+    and cached forever — type structures are static at runtime.
+
+    Args:
+        disc_field: The discriminator field name (e.g. ``"type"``).
+        union_args: The non-None union member types (must be a tuple
+            for hashability).
+
+    Returns:
+        Mapping from each Literal value to its corresponding TypedDict
+        type.  Non-TypedDict variants are silently skipped.
+    """
+    table: dict[object, type] = {}
+    for candidate in union_args:
+        if not _is_typeddict(candidate):
+            continue
+        fields = _typeddict_fields(candidate)
+        if disc_field not in fields:
+            continue
+        base, _ = _unwrap_annotated(fields[disc_field][0])
+        if typing.get_origin(base) is typing.Literal:
+            for lit_val in typing.get_args(base):
+                table[lit_val] = candidate
+    return table
+
+
+def _try_discriminated(
+    value: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    non_none_args: list[Any],
+) -> tuple[Any, bool]:
+    """Try to resolve a discriminated union via a shared Literal field.
+
+    Uses a cached dispatch table for O(1) lookup instead of scanning
+    all variants on every call.
+
+    Returns:
+        ``(result, True)`` if a discriminator matched, ``(value, False)`` otherwise.
+    """
+    args_key = tuple(non_none_args)
+    disc_field = _find_discriminator(args_key)
+    if disc_field is None or not isinstance(value, dict) or disc_field not in value:
+        return value, False
+    table = _build_dispatch_table(disc_field, args_key)
+    try:
+        candidate = table.get(value[disc_field])
+    except TypeError:
+        # Unhashable discriminator value (e.g. list or dict) — fall back
+        return value, False
+    if candidate is not None:
+        return _validate(value, candidate, path, errors, coerce), True
+    return value, False
+
+
+def _validate_union(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    args: tuple[Any, ...],
+) -> Any:
+    """Validate a ``Union`` / ``Optional`` type."""
+    none_args = [a for a in args if a is type(None)]
+    non_none_args = [a for a in args if a is not type(None)]
+
+    if value is None:
+        if none_args:
+            return value
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected=_type_name(tp),
+                actual="None",
+                message=f"Expected {_type_name(tp)} at '{path or '$'}', got None",
+            )
+        )
+        return value
+
+    # Try discriminated union for TypedDicts
+    result, matched = _try_discriminated(value, path, errors, coerce, non_none_args)
+    if matched:
+        return result
+
+    # Try each variant, pick the one with no errors
+    for variant in non_none_args:
+        test_errors: list[ErrorDetail] = []
+        result = _validate(value, variant, path, test_errors, coerce)
+        if not test_errors:
+            return result
+
+    errors.append(
+        ErrorDetail(
+            path=path or "$",
+            expected=_type_name(tp),
+            actual=type(value).__name__,
+            message=f"Value at '{path or '$'}' does not match any variant of {_type_name(tp)}",
+        )
+    )
+    return value
+
+
+def _validate_struct_fields(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    fields: dict[str, tuple[Any, bool]],
+) -> Any:
+    """Validate a struct-like type (TypedDict or dataclass) against its fields."""
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        value = {f.name: getattr(value, f.name) for f in dataclasses.fields(value)}
+    if not isinstance(value, dict):
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected=tp.__name__,
+                actual=type(value).__name__,
+                message=f"Expected dict for {tp.__name__} at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+        return value
+
+    err_before = len(errors)
+
+    for name, (field_tp, required) in fields.items():
+        if required and name not in value:
+            errors.append(
+                ErrorDetail(
+                    path=_join_path(path, name),
+                    expected=_type_name(field_tp),
+                    actual="MISSING",
+                    message=f"Missing required field '{name}' at '{path or '$'}'",
+                )
+            )
+
+    for name, val in value.items():
+        if name in fields:
+            field_tp, _ = fields[name]
+            value[name] = _validate(val, field_tp, _join_path(path, name), errors, coerce)
+
+    # Run model validators only if no field-level errors were added
+    validators = _MODEL_VALIDATORS.get(tp)
+    if validators and len(errors) == err_before:
+        for validator in validators:
+            try:
+                result = validator(value)
+                if result is not None:
+                    value = result
+            except (ValueError, AssertionError) as e:
+                errors.append(
+                    ErrorDetail(
+                        path=path or "$",
+                        expected=f"{tp.__name__} model validation",
+                        actual=str(e),
+                        message=f"Model validator failed for {tp.__name__} at '{path or '$'}': {e}",
+                    )
+                )
+
+    return value
+
+
+def _validate_list(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    args: tuple[Any, ...],
+) -> Any:
+    """Validate a ``list[X]`` type."""
+    if not isinstance(value, list):
+        coerced, ok = _try_coerce(value, list, coerce)
+        if ok:
+            value = coerced
+        else:
+            errors.append(
+                ErrorDetail(
+                    path=path or "$",
+                    expected=_type_name(tp),
+                    actual=type(value).__name__,
+                    message=f"Expected list at '{path or '$'}', got {type(value).__name__}",
+                )
+            )
+            return value
+    if args:
+        item_tp = args[0]
+        for i, item in enumerate(value):
+            _validate(item, item_tp, _join_path(path, i), errors, coerce)
+    return value
+
+
+def _validate_dict(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    args: tuple[Any, ...],
+) -> Any:
+    """Validate a ``dict[K, V]`` type."""
+    if not isinstance(value, dict):
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected=_type_name(tp),
+                actual=type(value).__name__,
+                message=f"Expected dict at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+        return value
+    if args and len(args) == 2:
+        key_tp, val_tp = args
+        for k, v in value.items():
+            _validate(k, key_tp, _join_path(path, f"<key:{k!r}>"), errors, coerce)
+            _validate(v, val_tp, _join_path(path, str(k)), errors, coerce)
+    return value
+
+
+def _validate_tuple(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    args: tuple[Any, ...],
+) -> Any:
+    """Validate a ``tuple[X, ...]`` or ``tuple[X, Y, Z]`` type."""
+    if not isinstance(value, (tuple, list)):
+        coerced, ok = _try_coerce(value, tuple, coerce)
+        if ok:
+            value = coerced
+        else:
+            errors.append(
+                ErrorDetail(
+                    path=path or "$",
+                    expected=_type_name(tp),
+                    actual=type(value).__name__,
+                    message=f"Expected tuple at '{path or '$'}', got {type(value).__name__}",
+                )
+            )
+            return value
+    if args:
+        if len(args) == 2 and args[1] is Ellipsis:
+            item_tp = args[0]
+            for i, item in enumerate(value):
+                _validate(item, item_tp, _join_path(path, i), errors, coerce)
+        elif len(value) != len(args):
+            errors.append(
+                ErrorDetail(
+                    path=path or "$",
+                    expected=f"tuple of length {len(args)}",
+                    actual=f"length {len(value)}",
+                    message=f"Expected tuple of {len(args)} elements at '{path or '$'}', got {len(value)}",
+                )
+            )
+        else:
+            for i, (item, item_tp) in enumerate(zip(value, args)):
+                _validate(item, item_tp, _join_path(path, i), errors, coerce)
+    return value
+
+
+def _validate_set(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+    args: tuple[Any, ...],
+) -> Any:
+    """Validate a ``set[X]`` or ``frozenset[X]`` type."""
+    if not isinstance(value, (set, frozenset, list)):
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected=_type_name(tp),
+                actual=type(value).__name__,
+                message=f"Expected set at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+        return value
+    items = value if isinstance(value, (set, frozenset)) else value
+    if args:
+        item_tp = args[0]
+        for i, item in enumerate(items):
+            _validate(item, item_tp, _join_path(path, i), errors, coerce)
+    return value
+
+
+def _validate_bool(value: Any, path: str, errors: list[ErrorDetail]) -> Any:
+    """Validate a ``bool`` type."""
+    if not isinstance(value, bool):
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected="bool",
+                actual=type(value).__name__,
+                message=f"Expected bool at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+    return value
+
+
+def _validate_int(
+    value: Any, path: str, errors: list[ErrorDetail], coerce: bool
+) -> Any:
+    """Validate an ``int`` type (rejects bools)."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        coerced, ok = _try_coerce(value, int, coerce)
+        if ok:
+            return coerced
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected="int",
+                actual=type(value).__name__,
+                message=f"Expected int at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+    return value
+
+
+def _validate_float(
+    value: Any, path: str, errors: list[ErrorDetail], coerce: bool
+) -> Any:
+    """Validate a ``float`` type (rejects bools, accepts ints)."""
+    if isinstance(value, bool):
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected="float",
+                actual="bool",
+                message=f"Expected float at '{path or '$'}', got bool",
+            )
+        )
+        return value
+    if not isinstance(value, (int, float)):
+        coerced, ok = _try_coerce(value, float, coerce)
+        if ok:
+            return coerced
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected="float",
+                actual=type(value).__name__,
+                message=f"Expected float at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+    return value
+
+
+def _validate_simple(
+    value: Any,
+    tp: type,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+) -> Any:
+    """Validate a simple type (bool, int, float, str, bytes, etc.)."""
+    if tp is bool:
+        return _validate_bool(value, path, errors)
+    if tp is int:
+        return _validate_int(value, path, errors, coerce)
+    if tp is float:
+        return _validate_float(value, path, errors, coerce)
+
+    # General isinstance check for str, bytes, etc.
+    if not isinstance(value, tp):
+        coerced, ok = _try_coerce(value, tp, coerce)
+        if ok:
+            return coerced
+        errors.append(
+            ErrorDetail(
+                path=path or "$",
+                expected=tp.__name__,
+                actual=type(value).__name__,
+                message=f"Expected {tp.__name__} at '{path or '$'}', got {type(value).__name__}",
+            )
+        )
+    return value
+
+
+def _validate(
+    value: Any,
+    tp: Any,
+    path: str,
+    errors: list[ErrorDetail],
+    coerce: bool,
+) -> Any:
+    """Recursively validate *value* against type *tp*.
+
+    Mutates *errors* in place.  Returns the (possibly coerced) value.
+    Dispatches to per-type helpers for each supported annotation kind.
+    """
+    if tp is Any:
+        return value
+
+    if tp is None or tp is type(None):
+        if value is not None:
+            errors.append(
+                ErrorDetail(
+                    path=path or "$",
+                    expected="None",
+                    actual=type(value).__name__,
+                    message=f"Expected None at '{path or '$'}', got {type(value).__name__}",
+                )
+            )
+        return value
+
+    origin = typing.get_origin(tp)
+    args = typing.get_args(tp)
+
+    if origin is typing.Annotated:
+        return _validate_annotated(value, tp, path, errors, coerce)
+    if origin is typing.Literal:
+        return _validate_literal(value, path, errors, args)
+    if origin in _UNION_ORIGINS:
+        return _validate_union(value, tp, path, errors, coerce, args)
+    if origin is list:
+        return _validate_list(value, tp, path, errors, coerce, args)
+    if origin is dict:
+        return _validate_dict(value, tp, path, errors, coerce, args)
+    if origin is tuple:
+        return _validate_tuple(value, tp, path, errors, coerce, args)
+    if origin in (set, frozenset):
+        return _validate_set(value, tp, path, errors, coerce, args)
+
+    if _is_typeddict(tp):
+        return _validate_struct_fields(
+            value, tp, path, errors, coerce, _typeddict_fields(tp)
+        )
+    if _is_dataclass_type(tp):
+        return _validate_struct_fields(
+            value, tp, path, errors, coerce, _dataclass_fields(tp)
+        )
+
+    if isinstance(tp, type):
+        return _validate_simple(value, tp, path, errors, coerce)
+
+    # Fallback — unknown type, skip validation
+    return value
+
+
+# ── JSON Schema Walker ──
+
+_PY_TO_JSON_TYPE: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    bytes: "string",
+}
+
+
+def _schema_annotated(tp: Any) -> dict[str, Any]:
+    """Generate JSON Schema for an ``Annotated[base, ...]`` type."""
+    base, constraints = _unwrap_annotated(tp)
+    schema = _type_to_schema(base)
+    for c in constraints:
+        kw = c.schema_kw()
+        if schema.get("type") == "array" and hasattr(c, "schema_kw_array"):
+            kw = c.schema_kw_array()
+        schema.update(kw)
+    return schema
+
+
+def _schema_union(args: tuple[Any, ...]) -> dict[str, Any]:
+    """Generate JSON Schema for a ``Union`` type."""
+    none_args = [a for a in args if a is type(None)]
+    non_none = [a for a in args if a is not type(None)]
+
+    if len(non_none) == 1 and none_args:
+        schema = _type_to_schema(non_none[0])
+        if "type" in schema:
+            current = schema["type"]
+            if isinstance(current, list):
+                if "null" not in current:
+                    schema["type"] = [*current, "null"]
+            else:
+                schema["type"] = [current, "null"]
+        else:
+            schema = {"oneOf": [schema, {"type": "null"}]}
+        return schema
+
+    return {"oneOf": [_type_to_schema(a) for a in args]}
+
+
+def _schema_struct(
+    fields: dict[str, tuple[Any, bool]],
+    defaults: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Generate JSON Schema for a struct-like type (TypedDict or dataclass)."""
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, (field_tp, is_required) in fields.items():
+        properties[name] = _type_to_schema(field_tp)
+        if is_required:
+            required.append(name)
+        if defaults and name in defaults:
+            default_val = defaults[name]
+            # Shallow check — list/dict contents are not inspected.
+            if isinstance(default_val, (str, int, float, bool, type(None), list, dict)):
+                properties[name]["default"] = default_val
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+    }
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _schema_tuple(args: tuple[Any, ...]) -> dict[str, Any]:
+    """Generate JSON Schema for a ``tuple`` type."""
+    if args:
+        if len(args) == 2 and args[1] is Ellipsis:
+            return {"type": "array", "items": _type_to_schema(args[0])}
+        return {
+            "type": "array",
+            "prefixItems": [_type_to_schema(a) for a in args],
+            "minItems": len(args),
+            "maxItems": len(args),
+        }
+    return {"type": "array"}
+
+
+def _schema_list(args: tuple[Any, ...]) -> dict[str, Any]:
+    """Generate JSON Schema for a ``list[X]`` type."""
+    schema: dict[str, Any] = {"type": "array"}
+    if args:
+        schema["items"] = _type_to_schema(args[0])
+    return schema
+
+
+def _schema_dict(args: tuple[Any, ...]) -> dict[str, Any]:
+    """Generate JSON Schema for a ``dict[K, V]`` type."""
+    schema: dict[str, Any] = {"type": "object"}
+    if args and len(args) == 2:
+        schema["additionalProperties"] = _type_to_schema(args[1])
+    return schema
+
+
+def _schema_set(args: tuple[Any, ...]) -> dict[str, Any]:
+    """Generate JSON Schema for a ``set`` or ``frozenset`` type."""
+    schema: dict[str, Any] = {"type": "array", "uniqueItems": True}
+    if args:
+        schema["items"] = _type_to_schema(args[0])
+    return schema
+
+
+def _type_to_schema(tp: Any) -> dict[str, Any]:
+    """Convert a Python type annotation to a JSON Schema dict.
+
+    Dispatches to per-type schema helpers for each supported annotation kind.
+    """
+    if tp is Any:
+        return {}
+    if tp is None or tp is type(None):
+        return {"type": "null"}
+
+    origin = typing.get_origin(tp)
+    args = typing.get_args(tp)
+
+    if origin is typing.Annotated:
+        return _schema_annotated(tp)
+    if origin is typing.Literal:
+        return {"enum": list(args)}
+    if origin in _UNION_ORIGINS:
+        return _schema_union(args)
+    if origin is list:
+        return _schema_list(args)
+    if origin is dict:
+        return _schema_dict(args)
+    if origin is tuple:
+        return _schema_tuple(args)
+    if origin in (set, frozenset):
+        return _schema_set(args)
+    if _is_typeddict(tp):
+        return _schema_struct(
+            _typeddict_fields(tp), getattr(tp, "__field_defaults__", None)
+        )
+    if _is_dataclass_type(tp):
+        return _schema_struct(_dataclass_fields(tp), _dataclass_defaults(tp))
+    if isinstance(tp, type) and tp in _PY_TO_JSON_TYPE:
+        return {"type": _PY_TO_JSON_TYPE[tp]}
+    return {}
+
+
+# ── Public API ──
+
+
+def validate(data: Any, tp: Any, *, coerce: bool = False) -> Any:
+    """Validate *data* against type annotation *tp*.
+
+    Args:
+        data: The data to validate.
+        tp: A TypedDict class, dataclass class, or any type annotation.
+        coerce: If True, attempt type coercion (e.g. str to int).
+
+    Returns:
+        The validated (and possibly coerced) data.
+
+    Raises:
+        ValidationError: If validation fails, with all errors collected.
+    """
+    errors: list[ErrorDetail] = []
+    result = _validate(data, tp, "", errors, coerce)
+    if errors:
+        raise ValidationError(errors)
+    return result
+
+
+def json_schema(tp: Any, *, title: str | None = None) -> dict[str, Any]:
+    """Generate a JSON Schema dict from a type annotation.
+
+    Args:
+        tp: A TypedDict class, dataclass class, or any type annotation.
+        title: Optional title for the schema root.
+
+    Returns:
+        A JSON Schema dict (draft 2020-12 compatible subset).
+    """
+    schema = _type_to_schema(tp)
+    if title is not None:
+        schema["title"] = title
+    elif isinstance(tp, type) and hasattr(tp, "__name__"):
+        schema["title"] = tp.__name__
+    return schema
+
+
+def create_struct(name: str, fields: dict[str, tuple[Any, ...]]) -> type:
+    """Dynamically create a TypedDict type from a field specification.
+
+    Each field is specified as ``(type, default)`` where ``...`` (Ellipsis)
+    marks the field as required.  Fields with any other default value are
+    optional (``NotRequired``).
+
+    The returned type works with :func:`validate` and :func:`json_schema`
+    just like a hand-written ``TypedDict``.  Default values are stored in
+    a ``__field_defaults__`` class attribute and emitted by
+    :func:`json_schema`.
+
+    Args:
+        name: The name of the new type.
+        fields: Mapping of field names to ``(type, default)`` tuples.
+
+    Returns:
+        A new TypedDict class.
+
+    Example::
+
+        Params = create_struct("Params", {
+            "query": (str, ...),            # required
+            "limit": (int, 10),             # optional, default 10
+            "tag": (str | None, None),      # optional, default None
+        })
+    """
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from typing import NotRequired, TypedDict
+    else:
+        from typing_extensions import NotRequired, TypedDict
+
+    annotations: dict[str, Any] = {}
+    defaults: dict[str, Any] = {}
+    for field_name, spec in fields.items():
+        field_type, default = spec
+        if default is ...:
+            annotations[field_name] = field_type
+        else:
+            annotations[field_name] = NotRequired[field_type]
+            defaults[field_name] = default
+
+    td = TypedDict(name, annotations)  # type: ignore[operator]  # ty: ignore[invalid-argument-type, mismatched-type-name]
+    td.__field_defaults__ = defaults  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    return td

--- a/src/toolregistry/_vendor/validate.py
+++ b/src/toolregistry/_vendor/validate.py
@@ -891,7 +891,7 @@ def _validate_list(
     if args:
         item_tp = args[0]
         for i, item in enumerate(value):
-            _validate(item, item_tp, _join_path(path, i), errors, coerce)
+            value[i] = _validate(item, item_tp, _join_path(path, i), errors, coerce)
     return value
 
 
@@ -916,9 +916,9 @@ def _validate_dict(
         return value
     if args and len(args) == 2:
         key_tp, val_tp = args
-        for k, v in value.items():
+        for k, v in list(value.items()):
             _validate(k, key_tp, _join_path(path, f"<key:{k!r}>"), errors, coerce)
-            _validate(v, val_tp, _join_path(path, str(k)), errors, coerce)
+            value[k] = _validate(v, val_tp, _join_path(path, str(k)), errors, coerce)
     return value
 
 

--- a/src/toolregistry/_vendor/validate.py
+++ b/src/toolregistry/_vendor/validate.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.7.0"
+# version = "0.7.1"
 # deps = []
 # tier = "medium"
 # category = "validation"
@@ -826,6 +826,7 @@ def _validate_struct_fields(
         )
         return value
 
+    value = dict(value)
     err_before = len(errors)
 
     for name, (field_tp, required) in fields.items():
@@ -842,7 +843,9 @@ def _validate_struct_fields(
     for name, val in value.items():
         if name in fields:
             field_tp, _ = fields[name]
-            value[name] = _validate(val, field_tp, _join_path(path, name), errors, coerce)
+            value[name] = _validate(
+                val, field_tp, _join_path(path, name), errors, coerce
+            )
 
     # Run model validators only if no field-level errors were added
     validators = _MODEL_VALIDATORS.get(tp)
@@ -888,6 +891,7 @@ def _validate_list(
                 )
             )
             return value
+    value = list(value)
     if args:
         item_tp = args[0]
         for i, item in enumerate(value):
@@ -916,9 +920,14 @@ def _validate_dict(
         return value
     if args and len(args) == 2:
         key_tp, val_tp = args
-        for k, v in list(value.items()):
-            _validate(k, key_tp, _join_path(path, f"<key:{k!r}>"), errors, coerce)
-            value[k] = _validate(v, val_tp, _join_path(path, str(k)), errors, coerce)
+        new_value = {}
+        for k, v in value.items():
+            new_k = _validate(
+                k, key_tp, _join_path(path, f"<key:{k!r}>"), errors, coerce
+            )
+            new_v = _validate(v, val_tp, _join_path(path, str(k)), errors, coerce)
+            new_value[new_k] = new_v
+        value = new_value
     return value
 
 
@@ -948,8 +957,12 @@ def _validate_tuple(
     if args:
         if len(args) == 2 and args[1] is Ellipsis:
             item_tp = args[0]
+            coerced_items = []
             for i, item in enumerate(value):
-                _validate(item, item_tp, _join_path(path, i), errors, coerce)
+                coerced_items.append(
+                    _validate(item, item_tp, _join_path(path, i), errors, coerce)
+                )
+            value = tuple(coerced_items)
         elif len(value) != len(args):
             errors.append(
                 ErrorDetail(
@@ -960,8 +973,12 @@ def _validate_tuple(
                 )
             )
         else:
+            coerced_items = []
             for i, (item, item_tp) in enumerate(zip(value, args)):
-                _validate(item, item_tp, _join_path(path, i), errors, coerce)
+                coerced_items.append(
+                    _validate(item, item_tp, _join_path(path, i), errors, coerce)
+                )
+            value = tuple(coerced_items)
     return value
 
 
@@ -984,12 +1001,15 @@ def _validate_set(
             )
         )
         return value
-    items = value if isinstance(value, (set, frozenset)) else value
+    target_type = frozenset if isinstance(value, frozenset) else set
+    items = list(value)
     if args:
         item_tp = args[0]
-        for i, item in enumerate(items):
+        items = [
             _validate(item, item_tp, _join_path(path, i), errors, coerce)
-    return value
+            for i, item in enumerate(items)
+        ]
+    return target_type(items)
 
 
 def _validate_bool(value: Any, path: str, errors: list[ErrorDetail]) -> Any:

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -5,6 +5,7 @@ as toolregistry's internal representations, plus thin wrappers around
 llm-rosetta for converting between provider-specific API formats.
 """
 
+import dataclasses
 import json
 import warnings
 from dataclasses import dataclass
@@ -111,6 +112,10 @@ class ToolCall:
     """The arguments in JSON string format."""
     type: Literal["function", "custom"] = "function"
     """The type of the tool call."""
+
+    def model_dump(self) -> dict[str, Any]:
+        """Backward-compatible serialization."""
+        return dataclasses.asdict(self)
 
     def to_ir(self) -> dict[str, Any]:
         """Convert to a rosetta IR ``ToolCallPart`` dict."""

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -10,8 +10,6 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from pydantic import BaseModel
-
 # ── Format registry ────────────────────────────────────────────────
 
 API_FORMATS = Literal[
@@ -97,7 +95,8 @@ def _get_tool_ops(api_format: API_FORMATS) -> Any:
 # ── Internal types ─────────────────────────────────────────────────
 
 
-class ToolCall(BaseModel):
+@dataclass
+class ToolCall:
     """Toolregistry's normalized tool call representation.
 
     All provider formats are converted to/from this type via the

--- a/src/toolregistry/parameter_models.py
+++ b/src/toolregistry/parameter_models.py
@@ -1,52 +1,36 @@
 import inspect
+import typing
 import warnings
-from typing import Any, get_type_hints
+from enum import Enum
+from typing import Any, Literal, get_type_hints
 from collections.abc import Callable
 
-from pydantic import BaseModel, ConfigDict, Field, create_model
-from pydantic.fields import FieldInfo
+from ._vendor.validate import (
+    Doc,
+    Ge,
+    Gt,
+    Le,
+    Lt,
+    MaxLen,
+    MinLen,
+    create_struct,
+    json_schema as _json_schema,
+)
 
 
 class InvalidSignature(Exception):
-    """Exception raised when a function signature cannot be processed for FastMCP.
+    """Exception raised when a function signature cannot be processed.
 
     Attributes:
         message (str): Explanation of the error.
     """
 
 
-class ArgModelBase(BaseModel):
-    """Base model for function argument validation with Pydantic.
-
-    Features:
-        - Supports arbitrary types in fields
-        - Provides method to dump fields one level deep
-        - Configures Pydantic model behavior
-    """
-
-    def model_dump_one_level(self) -> dict[str, Any]:
-        """Dump model fields one level deep, keeping sub-models as-is.
-
-        When the model allows extra fields (``extra="allow"``), any
-        additional keys accepted by Pydantic are included in the result.
-
-        Returns:
-            Dict[str, Any]: Dictionary of field names to values.
-        """
-        result = {field: getattr(self, field) for field in self.__pydantic_fields__}
-        if self.model_extra:
-            result.update(self.model_extra)
-        return result
-
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-    )
-
-
 def _get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
     """Evaluate type annotation, handling forward references.
 
-    Uses Python's public get_type_hints function rather than relying on a pydantic internal function.
+    Uses Python's public get_type_hints function rather than relying on
+    a framework-specific internal function.
 
     Args:
         annotation (Any): The annotation to evaluate (can be string forward reference).
@@ -60,11 +44,10 @@ def _get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
     """
 
     if isinstance(annotation, str):
-        # Create a dummy function with a parameter annotated by the string.
+
         def dummy(a: Any):
             pass
 
-        # Manually set the annotation on the dummy function.
         dummy.__annotations__ = {"a": annotation}
         try:
             hints = get_type_hints(dummy, globalns, include_extras=True)
@@ -77,37 +60,20 @@ def _get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
     return annotation
 
 
-def _create_field(
-    param: inspect.Parameter, annotation_type: Any
-) -> tuple[Any, FieldInfo]:
-    """Create a Pydantic field for a function parameter.
-
-    Handles both annotated and unannotated parameters, with and without defaults.
-
-    Args:
-        param (inspect.Parameter): The parameter to create a field for.
-        annotation_type (Any): The type annotation for the parameter.
+def _create_field(param: inspect.Parameter, annotation_type: Any) -> tuple[Any, Any]:
+    """Create a field definition for a function parameter.
 
     Returns:
-        Tuple[Any, FieldInfo]: A tuple of (annotated_type, field_info).
+        Tuple of (type, default) where default is ``...`` for required fields.
     """
     if param.default is inspect.Parameter.empty:
-        if param.annotation is inspect.Parameter.empty:
-            field_info = Field(title=param.name)
-        else:
-            field_info = Field()
-        return (annotation_type, field_info)
+        return (annotation_type, ...)
     else:
         default = param.default
         if param.annotation is inspect.Parameter.empty:
-            field_info = Field(default=default, title=param.name)
-            # No annotation — allow None since we can't infer intent.
-            return (annotation_type | None, field_info)
+            return (annotation_type | None, default)
         else:
-            field_info = Field(default=default)
-            # Respect the user's declared type. If they wrote `str | None`,
-            # annotation_type already includes None. Don't force-add it.
-            return (annotation_type, field_info)
+            return (annotation_type, default)
 
 
 def _warn_parameter_fallback(
@@ -123,18 +89,17 @@ def _warn_parameter_fallback(
     )
 
 
-def _is_json_schema_compatible(
-    param_name: str, field_def: tuple[Any, FieldInfo]
-) -> bool:
+def _is_json_schema_compatible(param_name: str, field_def: tuple[Any, Any]) -> bool:
     """Return whether a single field can produce JSON Schema."""
+    annotation_type = field_def[0]
+    if annotation_type is Any:
+        return True
     try:
-        field_definitions: dict[str, Any] = {param_name: field_def}
-        test_model = create_model(
-            f"_{param_name}SchemaProbe",
-            **field_definitions,
-            __base__=ArgModelBase,
-        )
-        test_model.model_json_schema()
+        struct = create_struct(f"_{param_name}Probe", {param_name: field_def})
+        schema = _json_schema(struct)
+        props = schema.get("properties", {})
+        if param_name in props and props[param_name] == {}:
+            return False
         return True
     except Exception:
         return False
@@ -158,12 +123,70 @@ def _warn_skipped_variadic_parameter(func: Callable, param: inspect.Parameter) -
     )
 
 
+_CONSTRAINT_MAP: dict[str, type] = {
+    "ge": Ge,
+    "gt": Gt,
+    "le": Le,
+    "lt": Lt,
+    "max_length": MaxLen,
+    "min_length": MinLen,
+}
+
+
+def _translate_single_meta(arg: Any) -> list[Any]:
+    """Convert one Annotated metadata item to zerodep equivalents."""
+    if isinstance(arg, (Ge, Gt, Le, Lt, MaxLen, MinLen, Doc)):
+        return [arg]
+
+    for attr, cls in _CONSTRAINT_MAP.items():
+        val = getattr(arg, attr, None)
+        if val is not None:
+            return [cls(val)]
+
+    if hasattr(arg, "metadata") and hasattr(arg, "description"):
+        result: list[Any] = []
+        if arg.description:
+            result.append(Doc(arg.description))
+        for m in getattr(arg, "metadata", []):
+            result.extend(_translate_single_meta(m))
+        return result
+
+    if hasattr(arg, "check") or hasattr(arg, "schema_kw"):
+        return [arg]
+
+    return []
+
+
+def _translate_annotated_metadata(annotation: Any) -> Any:
+    """Translate Pydantic/annotated_types constraints to zerodep equivalents."""
+    if typing.get_origin(annotation) is not typing.Annotated:
+        return annotation
+
+    args = typing.get_args(annotation)
+    base = args[0]
+    new_meta: list[Any] = []
+    for arg in args[1:]:
+        new_meta.extend(_translate_single_meta(arg))
+
+    if new_meta:
+        return typing.Annotated[tuple([base] + new_meta)]
+    return base
+
+
+def _resolve_enum(annotation: Any) -> Any:
+    """Convert Enum subclass annotations to Literal equivalents."""
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        values = tuple(e.value for e in annotation)
+        return Literal[values]  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
+    return annotation
+
+
 def _field_def_for_parameter(
     func: Callable,
     param: inspect.Parameter,
     globalns: dict[str, Any],
     resolved_hints: dict[str, Any],
-) -> tuple[Any, FieldInfo]:
+) -> tuple[Any, Any]:
     """Create a schema-safe field definition for one parameter."""
     if param.annotation is inspect.Parameter.empty:
         field_def = _create_field(param, Any)
@@ -174,6 +197,8 @@ def _field_def_for_parameter(
             annotation = resolved_hints.get(param.name)
             if annotation is None:
                 annotation = _get_typed_annotation(param.annotation, globalns)
+            annotation = _resolve_enum(annotation)
+            annotation = _translate_annotated_metadata(annotation)
             field_def = _create_field(param, annotation)
         except Exception as e:
             _warn_parameter_fallback(func, param.name, e)
@@ -191,92 +216,78 @@ def _field_def_for_parameter(
 
 
 def _simplify_nullable_schemas(schema: dict[str, Any]) -> dict[str, Any]:
-    """Collapse ``anyOf: [{type: T}, {type: null}]`` into ``type: T``.
+    """Collapse nullable schema patterns into simpler forms.
 
-    Pydantic v2 emits ``anyOf`` for ``Optional`` / ``T | None`` fields.
-    MCP clients (e.g. Claude Code) display these as "unknown" because they
-    don't resolve ``anyOf``.  Since optional parameters are already
-    expressed by omitting them from ``required`` and having a ``default``,
-    the ``null`` variant adds no information and can be safely removed.
+    Handles two patterns:
+    - Pydantic v2: ``anyOf: [{type: T}, {type: null}]`` → ``type: T``
+    - zerodep:     ``type: [T, "null"]`` → ``type: T``
 
     This function mutates *schema* in place and returns it.
 
-    .. note::
-
-       Earlier versions added ``"nullable": True`` to simplified
-       properties.  That key is not part of standard JSON Schema
-       draft 2020-12 and is rejected by many LLM providers
-       (Anthropic, Vertex AI).  It is no longer emitted.
-
     Args:
-        schema: A JSON Schema dict (output of ``model_json_schema()``).
+        schema: A JSON Schema dict.
 
     Returns:
-        The same dict with nullable ``anyOf`` patterns simplified.
+        The same dict with nullable patterns simplified.
     """
     props = schema.get("properties")
     if not props:
         return schema
 
     for prop_schema in props.values():
+        # Handle anyOf pattern (Pydantic v2 style)
         any_of = prop_schema.get("anyOf")
-        if not any_of or not isinstance(any_of, list):
-            continue
-        non_null = [v for v in any_of if v != {"type": "null"}]
-        if len(non_null) == len(any_of):
-            continue  # no null branch — nothing to simplify
-        if len(non_null) == 1:
-            # Simple nullable: [{type: T}, {type: null}] → type: T
-            del prop_schema["anyOf"]
-            prop_schema.update(non_null[0])
-        else:
-            # Multi-type nullable: [{type: T1}, {type: T2}, {type: null}]
-            # → anyOf: [{type: T1}, {type: T2}] (null branch removed)
-            prop_schema["anyOf"] = non_null
+        if any_of and isinstance(any_of, list):
+            non_null = [v for v in any_of if v != {"type": "null"}]
+            if len(non_null) < len(any_of):
+                if len(non_null) == 1:
+                    del prop_schema["anyOf"]
+                    prop_schema.update(non_null[0])
+                else:
+                    prop_schema["anyOf"] = non_null
+
+        # Handle type-array pattern (zerodep style): type: ["string", "null"]
+        type_val = prop_schema.get("type")
+        if isinstance(type_val, list) and "null" in type_val:
+            non_null_types = [t for t in type_val if t != "null"]
+            if len(non_null_types) == 1:
+                prop_schema["type"] = non_null_types[0]
+            elif len(non_null_types) > 1:
+                prop_schema["type"] = non_null_types
 
     return schema
 
 
-class _ArgModelBaseExtra(ArgModelBase):
-    """ArgModelBase variant that accepts additional properties.
-
-    Used when the wrapped function has a ``**kwargs`` parameter so the
-    generated JSON Schema includes ``"additionalProperties": true``.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-
 def _create_parameters_model(
     func: Callable,
-    field_definitions: dict[str, Any],
+    field_definitions: dict[str, tuple[Any, Any]],
     *,
     has_var_keyword: bool = False,
-) -> type[ArgModelBase] | None:
-    """Create and validate the final Pydantic parameter model."""
-    base = _ArgModelBaseExtra if has_var_keyword else ArgModelBase
+) -> type | None:
+    """Create and validate the final parameter struct type."""
     try:
-        model = create_model(
+        struct = create_struct(
             f"{getattr(func, '__name__', 'unknown')}Parameters",
-            **field_definitions,
-            __base__=base,
+            field_definitions,
         )
-        model.model_json_schema()
-        return model
+        struct.__has_var_keyword__ = has_var_keyword  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        _json_schema(struct)
+        return struct
     except Exception:
         return None
 
 
-def _generate_parameters_model(func: Callable) -> type[ArgModelBase] | None:
-    """Generate a Pydantic model from a function's parameters.
+def _generate_parameters_model(func: Callable) -> type | None:
+    """Generate a type from a function's parameters for validation and schema.
 
-    Creates a JSON Schema-compliant model that can validate the function's parameters.
+    Creates a TypedDict-based type that can validate the function's parameters
+    and produce JSON Schema.
 
     Args:
         func (Callable): The function to generate the parameter model for.
 
     Returns:
-        Optional[Type[ArgModelBase]]: Pydantic model class for the parameters, or None on error.
+        Optional[type]: TypedDict type for the parameters, or None on error.
 
     Raises:
         InvalidSignature: If unable to process function signature.
@@ -292,7 +303,7 @@ def _generate_parameters_model(func: Callable) -> type[ArgModelBase] | None:
     except Exception:
         resolved_hints = {}
 
-    field_definitions: dict[str, Any] = {}
+    field_definitions: dict[str, tuple[Any, Any]] = {}
     has_var_keyword = False
     for param in signature.parameters.values():
         if param.name == "self":

--- a/src/toolregistry/parameter_models.py
+++ b/src/toolregistry/parameter_models.py
@@ -2,7 +2,7 @@ import inspect
 import typing
 import warnings
 from enum import Enum
-from typing import Any, Literal, get_type_hints
+from typing import Any, Literal, Union, get_type_hints
 from collections.abc import Callable
 
 from ._vendor.validate import (
@@ -138,10 +138,13 @@ def _translate_single_meta(arg: Any) -> list[Any]:
     if isinstance(arg, (Ge, Gt, Le, Lt, MaxLen, MinLen, Doc)):
         return [arg]
 
+    matched: list[Any] = []
     for attr, cls in _CONSTRAINT_MAP.items():
         val = getattr(arg, attr, None)
         if val is not None:
-            return [cls(val)]
+            matched.append(cls(val))
+    if matched:
+        return matched
 
     if hasattr(arg, "metadata") and hasattr(arg, "description"):
         result: list[Any] = []
@@ -174,7 +177,15 @@ def _translate_annotated_metadata(annotation: Any) -> Any:
 
 
 def _resolve_enum(annotation: Any) -> Any:
-    """Convert Enum subclass annotations to Literal equivalents."""
+    """Convert Enum subclass annotations to Literal equivalents.
+
+    Recurses into Union/Optional so that ``Optional[MyEnum]`` becomes
+    ``Optional[Literal[...]]``.
+    """
+    origin = typing.get_origin(annotation)
+    if origin is Union:
+        args = tuple(_resolve_enum(a) for a in typing.get_args(annotation))
+        return Union[args]  # type: ignore[valid-type]
     if isinstance(annotation, type) and issubclass(annotation, Enum):
         values = tuple(e.value for e in annotation)
         return Literal[values]  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]

--- a/src/toolregistry/parameter_models.py
+++ b/src/toolregistry/parameter_models.py
@@ -270,7 +270,7 @@ def _create_parameters_model(
             f"{getattr(func, '__name__', 'unknown')}Parameters",
             field_definitions,
         )
-        struct.__has_var_keyword__ = has_var_keyword  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        struct._has_var_keyword = has_var_keyword  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         _json_schema(struct)
         return struct
     except Exception:

--- a/src/toolregistry/permissions/policy.py
+++ b/src/toolregistry/permissions/policy.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 from typing import Any
 from collections.abc import Callable
 
-from pydantic import BaseModel, ConfigDict, Field
+from dataclasses import dataclass, field
 
 from ..tool import Tool
 from .handler import AsyncPermissionHandler, PermissionHandler
 from .types import PermissionResult
 
 
-class PermissionRule(BaseModel):
+@dataclass
+class PermissionRule:
     """A single permission rule that maps a match predicate to a result.
 
     Rules are evaluated in order; the first rule whose ``match`` returns
@@ -27,15 +28,14 @@ class PermissionRule(BaseModel):
             result is ``ASK`` or ``DENY``.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     name: str
-    match: Callable[[Tool, dict[str, Any]], bool] = Field(exclude=True)
+    match: Callable[[Tool, dict[str, Any]], bool]
     result: PermissionResult
     reason: str = ""
 
 
-class PermissionPolicy(BaseModel):
+@dataclass
+class PermissionPolicy:
     """An ordered collection of permission rules with a fallback.
 
     Evaluation follows first-match-wins semantics: rules are checked in
@@ -52,13 +52,9 @@ class PermissionPolicy(BaseModel):
             ``set_permission_handler()``.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    rules: list[PermissionRule] = Field(default_factory=list)
+    rules: list[PermissionRule] = field(default_factory=list)
     fallback: PermissionResult = PermissionResult.DENY
-    handler: PermissionHandler | AsyncPermissionHandler | None = Field(
-        default=None, exclude=True
-    )
+    handler: PermissionHandler | AsyncPermissionHandler | None = None
 
     def evaluate(
         self, tool: Tool, parameters: dict[str, Any]

--- a/src/toolregistry/permissions/types.py
+++ b/src/toolregistry/permissions/types.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from dataclasses import dataclass, field
 
 from ..tool import ToolMetadata
 
@@ -22,7 +22,8 @@ class PermissionResult(str, Enum):
     ASK = "ask"
 
 
-class PermissionRequest(BaseModel):
+@dataclass
+class PermissionRequest:
     """Context passed to a PermissionHandler when a rule returns ASK.
 
     Attributes:
@@ -34,7 +35,7 @@ class PermissionRequest(BaseModel):
     """
 
     tool_name: str
-    parameters: dict[str, Any] = Field(default_factory=dict)
+    parameters: dict[str, Any] = field(default_factory=dict)
     reason: str = ""
     rule_name: str = ""
-    metadata: ToolMetadata = Field(default_factory=ToolMetadata)
+    metadata: ToolMetadata = field(default_factory=ToolMetadata)

--- a/src/toolregistry/permissions/types.py
+++ b/src/toolregistry/permissions/types.py
@@ -3,6 +3,7 @@
 from enum import Enum
 from typing import Any
 
+import dataclasses
 from dataclasses import dataclass, field
 
 from ..tool import ToolMetadata
@@ -39,3 +40,7 @@ class PermissionRequest:
     reason: str = ""
     rule_name: str = ""
     metadata: ToolMetadata = field(default_factory=ToolMetadata)
+
+    def model_dump(self) -> dict[str, Any]:
+        """Backward-compatible serialization."""
+        return dataclasses.asdict(self)

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -3,10 +3,8 @@ import inspect
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 from collections.abc import Callable
-
-from pydantic import BaseModel, Field, model_validator
 
 from .parameter_models import _generate_parameters_model, _simplify_nullable_schemas
 from .llm.tool_calls import API_FORMATS
@@ -156,68 +154,61 @@ class ToolMetadata:
         return {t.value for t in self.tags} | self.custom_tags
 
 
-class Tool(BaseModel):
+@dataclass(init=False)
+class Tool:
     """Base class representing an executable tool/function.
 
     Provides core functionality for:
         - Function wrapping and metadata management
-        - Parameter validation using Pydantic
+        - Parameter validation
         - Synchronous/asynchronous execution
         - JSON schema generation
     """
 
-    name: str = Field(description="Name of the tool")
+    name: str
     """The name of the tool.
-    
+
     Used as the primary identifier when calling the tool.
     Must be unique within a tool registry.
     """
 
-    description: str = Field(description="Description of what the tool does")
+    description: str
     """Detailed description of the tool's functionality.
-    
+
     Should clearly explain what the tool does, its purpose,
     and any important usage considerations.
     """
 
-    parameters: dict[str, Any] = Field(description="JSON schema for tool parameters")
+    parameters: dict[str, Any]
     """Parameter schema defining the tool's expected inputs.
-    
+
     Follows JSON Schema format. Automatically generated from
     the wrapped function's type hints when using from_function().
     """
 
-    callable: Callable[..., Any] = Field(exclude=True)
+    callable: Callable[..., Any]
     """The tool's callable, always a :class:`BaseToolWrapper` at runtime.
 
-    Typed as ``Callable`` for Pydantic compatibility (Pydantic cannot
-    generate a schema for ``BaseToolWrapper``).  Use ``call_sync()`` /
-    ``call_async()`` for sync/async transparent execution.
-
-    Excluded from serialization to prevent accidental exposure of
-    implementation details.
+    Use ``call_sync()`` / ``call_async()`` for sync/async transparent
+    execution.
     """
 
-    metadata: ToolMetadata = Field(default_factory=ToolMetadata)
+    metadata: ToolMetadata
     """Behavioral and classification metadata for this tool.
 
     Contains execution hints (``is_async``, ``is_concurrency_safe``,
     ``timeout``) and classification tags (``tags``, ``custom_tags``).
     """
 
-    parameters_model: Any | None = Field(
-        default=None, description="Pydantic Model for tool parameters"
-    )
-    """Pydantic model used for parameter validation.
-    
+    parameters_model: Any | None
+    """Type used for parameter validation.
+
     Automatically generated from the wrapped function's type hints
     when using from_function(). Can be None for tools without
     parameter validation.
     """
 
-    namespace: str | None = Field(
-        default=None, description="Namespace the tool belongs to"
-    )
+    namespace: str | None
     """The namespace this tool belongs to.
 
     Used to group tools logically and avoid name collisions.
@@ -228,9 +219,7 @@ class Tool(BaseModel):
     without parsing the ``name`` field.
     """
 
-    method_name: str | None = Field(
-        default=None, description="Original method name of the tool"
-    )
+    method_name: str | None
     """The original method/function name before namespace prefixing.
 
     Preserved so that the base name can be recovered without
@@ -239,19 +228,36 @@ class Tool(BaseModel):
     otherwise convert to ``_``).
     """
 
-    @model_validator(mode="before")
-    @classmethod
-    def _migrate_is_async(cls, data: Any) -> Any:
-        """Accept legacy ``is_async`` constructor kwarg and move it into metadata."""
-        if isinstance(data, dict) and "is_async" in data:
-            is_async = data.pop("is_async")
-            if "metadata" not in data:
-                data["metadata"] = ToolMetadata(is_async=is_async)
-            elif isinstance(data["metadata"], dict):
-                data["metadata"].setdefault("is_async", is_async)
-        return data
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: dict[str, Any],
+        callable: Callable[..., Any],
+        metadata: ToolMetadata | None = None,
+        parameters_model: Any | None = None,
+        namespace: str | None = None,
+        method_name: str | None = None,
+        is_async: bool | None = None,
+    ) -> None:
+        if metadata is None:
+            metadata = (
+                ToolMetadata(is_async=is_async)
+                if is_async is not None
+                else ToolMetadata()
+            )
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.callable = callable
+        self.metadata = metadata
+        self.parameters_model = parameters_model
+        self.namespace = namespace
+        self.method_name = method_name
+        self._inject_toolcall_reason()
 
-    def model_post_init(self, __context: Any) -> None:
+    def _inject_toolcall_reason(self) -> None:
         """Inject ``toolcall_reason`` property into the tool's parameter schema.
 
         Runs after every ``Tool`` (and subclass) construction, regardless
@@ -270,6 +276,17 @@ class Tool(BaseModel):
         props = self.parameters["properties"]
         if had_properties and "toolcall_reason" not in props:
             props["toolcall_reason"] = TOOLCALL_REASON_PROPERTY
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict, excluding non-serializable fields."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.parameters,
+            "metadata": self.metadata,
+            "namespace": self.namespace,
+            "method_name": self.method_name,
+        }
 
     @property
     def is_async(self) -> bool:
@@ -409,7 +426,7 @@ class Tool(BaseModel):
     #: Schema keys stripped during ``get_schema()`` sanitization.
     #: ``title`` and ``nullable`` are Pydantic v2 artifacts that most LLM
     #: providers either reject or misinterpret.
-    _EXTRA_STRIP_KEYS: set[str] = {"title", "nullable"}
+    _EXTRA_STRIP_KEYS: ClassVar[set[str]] = {"title", "nullable"}
 
     def get_schema(
         self,

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -1,5 +1,7 @@
+import dataclasses
 import inspect
 import warnings
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Literal
 from collections.abc import Callable
@@ -40,7 +42,8 @@ but uses a unique field name to avoid collisions with native tool parameters.
 """
 
 
-class ToolMetadata(BaseModel):
+@dataclass
+class ToolMetadata:
     """Behavioral and classification metadata for a Tool.
 
     Attributes:
@@ -71,8 +74,8 @@ class ToolMetadata(BaseModel):
     locality: Literal["local", "remote", "any"] = "any"
     max_result_size: int | None = None
 
-    tags: set[ToolTag] = Field(default_factory=set)
-    custom_tags: set[str] = Field(default_factory=set)
+    tags: set[ToolTag] = field(default_factory=set)
+    custom_tags: set[str] = field(default_factory=set)
 
     source: str = "native"
     """Origin of the tool.
@@ -89,7 +92,7 @@ class ToolMetadata(BaseModel):
     OpenAPI tools, or a class name for LangChain tools.
     """
 
-    extra: dict[str, Any] = Field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
     defer: bool = False
     """Whether this tool should be deferred from the initial prompt.
@@ -131,6 +134,21 @@ class ToolMetadata(BaseModel):
     HTTP APIs) set this to ``"inline"`` because pooling or pickling
     their transport would be wrong or impossible.
     """
+
+    _VALID_LOCALITY = {"local", "remote", "any"}
+    _VALID_BACKEND = {"inline", "thread", "process", None}
+
+    def __post_init__(self) -> None:
+        if self.locality not in self._VALID_LOCALITY:
+            raise ValueError(
+                f"Invalid locality {self.locality!r}, "
+                f"must be one of {self._VALID_LOCALITY}"
+            )
+        if self.natural_backend not in self._VALID_BACKEND:
+            raise ValueError(
+                f"Invalid natural_backend {self.natural_backend!r}, "
+                f"must be one of {self._VALID_BACKEND}"
+            )
 
     @property
     def all_tags(self) -> set[str]:
@@ -338,7 +356,7 @@ class Tool(BaseModel):
         if metadata is None:
             metadata = ToolMetadata(is_async=is_async)
         else:
-            metadata = metadata.model_copy(update={"is_async": is_async})
+            metadata = dataclasses.replace(metadata, is_async=is_async)
 
         parameters_model = None
         try:

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -153,6 +153,14 @@ class ToolMetadata:
         """Union of predefined and custom tags (all as str)."""
         return {t.value for t in self.tags} | self.custom_tags
 
+    def model_dump(self) -> dict[str, Any]:
+        """Serialize to dict. Backward-compatible alias."""
+        return dataclasses.asdict(self)
+
+    def model_copy(self, *, update: dict[str, Any] | None = None) -> "ToolMetadata":
+        """Clone with optional field overrides. Backward-compatible alias."""
+        return dataclasses.replace(self, **(update or {}))
+
 
 @dataclass(init=False)
 class Tool:
@@ -283,10 +291,14 @@ class Tool:
             "name": self.name,
             "description": self.description,
             "parameters": self.parameters,
-            "metadata": self.metadata,
+            "metadata": dataclasses.asdict(self.metadata),
             "namespace": self.namespace,
             "method_name": self.method_name,
         }
+
+    def model_dump(self) -> dict[str, Any]:
+        """Backward-compatible alias for :meth:`to_dict`."""
+        return self.to_dict()
 
     @property
     def is_async(self) -> bool:
@@ -390,7 +402,7 @@ class Tool:
             from ._vendor.validate import json_schema as _json_schema
 
             schema = _json_schema(parameters_model)
-            if getattr(parameters_model, "__has_var_keyword__", False):
+            if getattr(parameters_model, "_has_var_keyword", False):
                 schema["additionalProperties"] = True
             parameters_schema = _simplify_nullable_schemas(schema)
         else:
@@ -558,7 +570,7 @@ class Tool:
 
         validated = _validate_fn(parameters, self.parameters_model, coerce=True)
 
-        if getattr(self.parameters_model, "__has_var_keyword__", False):
+        if getattr(self.parameters_model, "_has_var_keyword", False):
             return validated
 
         declared = set(

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -3,7 +3,7 @@ import inspect
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, get_type_hints
 from collections.abc import Callable
 
 from .parameter_models import _generate_parameters_model, _simplify_nullable_schemas
@@ -386,11 +386,15 @@ class Tool:
                 stacklevel=2,
             )
             parameters_model = None
-        parameters_schema = (
-            _simplify_nullable_schemas(parameters_model.model_json_schema())
-            if parameters_model
-            else {}
-        )
+        if parameters_model is not None:
+            from ._vendor.validate import json_schema as _json_schema
+
+            schema = _json_schema(parameters_model)
+            if getattr(parameters_model, "__has_var_keyword__", False):
+                schema["additionalProperties"] = True
+            parameters_schema = _simplify_nullable_schemas(schema)
+        else:
+            parameters_schema = {}
         # Wrap bare functions so Tool.callable is always a BaseToolWrapper.
         if not isinstance(func, BaseToolWrapper):
             param_names = list(inspect.signature(func).parameters.keys())
@@ -541,8 +545,6 @@ class Tool:
     def _validate_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
         """Validate parameters against tool schema.
 
-        Uses Pydantic model if available, otherwise performs basic validation.
-
         Args:
             parameters (Dict[str, Any]): Raw input parameters.
 
@@ -550,11 +552,19 @@ class Tool:
             Dict[str, Any]: Validated and normalized parameters.
         """
         if self.parameters_model is None:
-            validated_params = parameters
-        else:
-            model = self.parameters_model(**parameters)
-            validated_params = model.model_dump_one_level()
-        return validated_params
+            return parameters
+
+        from ._vendor.validate import validate as _validate_fn
+
+        validated = _validate_fn(parameters, self.parameters_model, coerce=True)
+
+        if getattr(self.parameters_model, "__has_var_keyword__", False):
+            return validated
+
+        declared = set(
+            get_type_hints(self.parameters_model, include_extras=True).keys()
+        )
+        return {k: validated[k] for k in declared if k in validated}
 
     def run(self, parameters: dict[str, Any]) -> Any:
         """Execute tool synchronously.

--- a/tests/test_param_warnings.py
+++ b/tests/test_param_warnings.py
@@ -95,7 +95,7 @@ class TestVarKeywordHandling:
 
         model = _generate_parameters_model(func_with_custom_kwargs)
         assert model is not None
-        assert getattr(model, "__has_var_keyword__", False) is True
+        assert getattr(model, "_has_var_keyword", False) is True
 
 
 class TestBothArgsAndKwargs:
@@ -118,7 +118,7 @@ class TestBothArgsAndKwargs:
         assert any("*args" in m and "'*args'" in m for m in messages)
 
         assert model is not None
-        assert getattr(model, "__has_var_keyword__", False) is True
+        assert getattr(model, "_has_var_keyword", False) is True
 
 
 class TestParameterModelGenerationFailureWarning:

--- a/tests/test_param_warnings.py
+++ b/tests/test_param_warnings.py
@@ -95,8 +95,7 @@ class TestVarKeywordHandling:
 
         model = _generate_parameters_model(func_with_custom_kwargs)
         assert model is not None
-        schema = model.model_json_schema()
-        assert schema.get("additionalProperties") is True
+        assert getattr(model, "__has_var_keyword__", False) is True
 
 
 class TestBothArgsAndKwargs:
@@ -119,8 +118,7 @@ class TestBothArgsAndKwargs:
         assert any("*args" in m and "'*args'" in m for m in messages)
 
         assert model is not None
-        schema = model.model_json_schema()
-        assert schema.get("additionalProperties") is True
+        assert getattr(model, "__has_var_keyword__", False) is True
 
 
 class TestParameterModelGenerationFailureWarning:

--- a/tests/test_parameter_models.py
+++ b/tests/test_parameter_models.py
@@ -623,7 +623,7 @@ class TestComplexTypeSchemaGeneration:
         schema = _json_schema(model)
         assert "kwargs" not in schema.get("properties", {})
         assert "x" in schema["properties"]
-        assert getattr(model, "__has_var_keyword__", False) is True
+        assert getattr(model, "_has_var_keyword", False) is True
 
     def test_kwargs_only_function(self):
         """Function with only **kwargs should produce additionalProperties schema."""
@@ -633,7 +633,7 @@ class TestComplexTypeSchemaGeneration:
         model = _generate_parameters_model(f)
 
         assert model is not None
-        assert getattr(model, "__has_var_keyword__", False) is True
+        assert getattr(model, "_has_var_keyword", False) is True
 
     def test_args_and_kwargs_combo(self):
         """*args warns while **kwargs enables additionalProperties."""
@@ -647,7 +647,7 @@ class TestComplexTypeSchemaGeneration:
         schema = _json_schema(model)
         assert "x" in schema["properties"]
         assert "args" not in schema.get("properties", {})
-        assert getattr(model, "__has_var_keyword__", False) is True
+        assert getattr(model, "_has_var_keyword", False) is True
 
     def test_normal_function_no_additional_properties(self):
         """Normal functions should NOT have additionalProperties in schema."""

--- a/tests/test_parameter_models.py
+++ b/tests/test_parameter_models.py
@@ -6,11 +6,15 @@ from typing import Annotated, Any, Literal, Optional, Union
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import Field
-from pydantic.fields import FieldInfo
 
+from toolregistry._vendor.validate import (
+    Doc,
+    Ge,
+    MaxLen,
+    json_schema as _json_schema,
+    validate as _validate,
+)
 from toolregistry.parameter_models import (
-    ArgModelBase,
     InvalidSignature,
     _create_field,
     _generate_parameters_model,
@@ -30,69 +34,39 @@ class TestInvalidSignature:
         assert isinstance(exception, Exception)
 
 
-class TestArgModelBase:
-    """Test cases for the ArgModelBase class."""
+class TestParameterValidation:
+    """Test parameter validation and schema generation basics."""
 
-    def test_arg_model_base_creation(self):
-        """Test creating an ArgModelBase instance."""
+    def test_simple_struct_creation(self):
+        """Test creating a simple parameter struct."""
 
-        class TestModel(ArgModelBase):
-            name: str
-            age: int = 25
+        def simple(name: str, age: int = 25) -> None: ...
 
-        model = TestModel(name="John", age=30)
+        model = _generate_parameters_model(simple)
+        assert model is not None
+        result = _validate({"name": "John", "age": 30}, model)
+        assert result["name"] == "John"
+        assert result["age"] == 30
 
-        assert model.name == "John"
-        assert model.age == 30
+    def test_validate_returns_dict(self):
+        """validate() returns a plain dict, not an object with attributes."""
 
-    def test_model_dump_one_level(self):
-        """Test model_dump_one_level method."""
+        def f(name: str, meta: dict[str, Any] = {}) -> None: ...  # noqa: B006
 
-        class TestModel(ArgModelBase):
-            name: str
-            age: int
-            metadata: dict[str, Any] = {}
+        model = _generate_parameters_model(f)
+        result = _validate({"name": "Alice", "meta": {"key": "value"}}, model)
+        assert isinstance(result, dict)
+        assert result == {"name": "Alice", "meta": {"key": "value"}}
 
-        model = TestModel(name="Alice", age=25, metadata={"key": "value"})
+    def test_coercion_str_to_int(self):
+        """String-encoded numbers should coerce to int."""
 
-        dumped = model.model_dump_one_level()
+        def f(count: int) -> None: ...
 
-        assert dumped == {"name": "Alice", "age": 25, "metadata": {"key": "value"}}
-
-    def test_model_dump_one_level_with_nested_models(self):
-        """Test model_dump_one_level with nested models."""
-
-        class NestedModel(ArgModelBase):
-            value: str
-
-        class TestModel(ArgModelBase):
-            name: str
-            nested: NestedModel
-
-        nested = NestedModel(value="nested_value")
-        model = TestModel(name="test", nested=nested)
-
-        dumped = model.model_dump_one_level()
-
-        assert dumped["name"] == "test"
-        assert isinstance(dumped["nested"], NestedModel)
-        assert dumped["nested"].value == "nested_value"
-
-    def test_arbitrary_types_allowed(self):
-        """Test that arbitrary types are allowed in ArgModelBase."""
-
-        class CustomType:
-            def __init__(self, value):
-                self.value = value
-
-        class TestModel(ArgModelBase):
-            custom: CustomType
-
-        custom_obj = CustomType("test")
-        model = TestModel(custom=custom_obj)
-
-        assert model.custom == custom_obj
-        assert model.custom.value == "test"
+        model = _generate_parameters_model(f)
+        result = _validate({"count": "42"}, model, coerce=True)
+        assert result["count"] == 42
+        assert isinstance(result["count"], int)
 
     def test_arbitrary_type_schema_generation_requires_fallback(self):
         """Arbitrary runtime types should not block schema generation."""
@@ -107,7 +81,7 @@ class TestArgModelBase:
             model = _generate_parameters_model(f)
 
         assert model is not None
-        schema = model.model_json_schema()
+        schema = _json_schema(model)
         assert "custom" in schema["properties"]
         assert schema["properties"]["name"]["type"] == "string"
 
@@ -173,13 +147,10 @@ class TestCreateField:
             annotation=str,
         )
 
-        annotation_type, field_info = _create_field(param, str)
+        annotation_type, default = _create_field(param, str)
 
         assert annotation_type is str
-        assert isinstance(field_info, FieldInfo)
-        from pydantic_core import PydanticUndefined
-
-        assert field_info.default is PydanticUndefined
+        assert default is ...
 
     def test_create_field_required_parameter_without_annotation(self):
         """Test _create_field with required parameter without annotation."""
@@ -187,11 +158,10 @@ class TestCreateField:
             name="test_param", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD
         )
 
-        annotation_type, field_info = _create_field(param, Any)
+        annotation_type, default = _create_field(param, Any)
 
         assert annotation_type is Any
-        assert isinstance(field_info, FieldInfo)
-        assert field_info.title == "test_param"
+        assert default is ...
 
     def test_create_field_optional_parameter_with_annotation(self):
         """Test _create_field respects the declared annotation (no forced | None)."""
@@ -202,11 +172,10 @@ class TestCreateField:
             default="default_value",
         )
 
-        annotation_type, field_info = _create_field(param, str)
+        annotation_type, default = _create_field(param, str)
 
         assert annotation_type is str
-        assert isinstance(field_info, FieldInfo)
-        assert field_info.default == "default_value"
+        assert default == "default_value"
 
     def test_create_field_optional_parameter_without_annotation(self):
         """Test _create_field with optional parameter without annotation."""
@@ -216,12 +185,10 @@ class TestCreateField:
             default=42,
         )
 
-        annotation_type, field_info = _create_field(param, Any)
+        annotation_type, default = _create_field(param, Any)
 
         assert annotation_type == Any | None
-        assert isinstance(field_info, FieldInfo)
-        assert field_info.default == 42
-        assert field_info.title == "test_param"
+        assert default == 42
 
     def test_create_field_with_none_default(self):
         """Test _create_field with None default respects declared annotation."""
@@ -232,11 +199,10 @@ class TestCreateField:
             default=None,
         )
 
-        annotation_type, field_info = _create_field(param, str)
+        annotation_type, default = _create_field(param, str)
 
-        # User wrote `str` not `str | None` — respect the declaration.
         assert annotation_type is str
-        assert field_info.default is None
+        assert default is None
 
 
 class TestGenerateParametersModel:
@@ -251,13 +217,11 @@ class TestGenerateParametersModel:
         model_class = _generate_parameters_model(simple_func)
 
         assert model_class is not None
-        assert issubclass(model_class, ArgModelBase)
         assert model_class.__name__ == "simple_funcParameters"
 
-        # Test model instantiation
-        model = model_class(name="John", age=25)
-        assert model.name == "John"
-        assert model.age == 25
+        result = _validate({"name": "John", "age": 25}, model_class)
+        assert result["name"] == "John"
+        assert result["age"] == 25
 
     def test_generate_parameters_model_function_with_defaults(self):
         """Test generating parameters model for function with default values."""
@@ -269,17 +233,12 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        # Test with all parameters
-        model1 = model_class(name="Alice", age=25, city="NYC")
-        assert model1.name == "Alice"
-        assert model1.age == 25
-        assert model1.city == "NYC"
+        result1 = _validate({"name": "Alice", "age": 25, "city": "NYC"}, model_class)
+        assert result1["name"] == "Alice"
+        assert result1["age"] == 25
 
-        # Test with only required parameter
-        model2 = model_class(name="Bob")
-        assert model2.name == "Bob"
-        assert model2.age == 30  # Default value
-        assert model2.city == "Unknown"  # Default value
+        result2 = _validate({"name": "Bob"}, model_class)
+        assert result2["name"] == "Bob"
 
     def test_generate_parameters_model_function_without_annotations(self):
         """Test generating parameters model for function without type annotations."""
@@ -291,10 +250,8 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        # Should work with any types
-        model = model_class(x="hello", y="world")
-        assert model.x == "hello"
-        assert model.y == "world"
+        result = _validate({"x": "hello", "y": "world"}, model_class)
+        assert result["x"] == "hello"
 
     def test_generate_parameters_model_function_with_complex_types(self):
         """Test generating parameters model for function with complex types."""
@@ -310,12 +267,17 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        model = model_class(
-            items=["a", "b", "c"], metadata={"key": "value"}, optional_flag=True
+        result = _validate(
+            {
+                "items": ["a", "b", "c"],
+                "metadata": {"key": "value"},
+                "optional_flag": True,
+            },
+            model_class,
         )
-        assert model.items == ["a", "b", "c"]
-        assert model.metadata == {"key": "value"}
-        assert model.optional_flag is True
+        assert result["items"] == ["a", "b", "c"]
+        assert result["metadata"] == {"key": "value"}
+        assert result["optional_flag"] is True
 
     def test_generate_parameters_model_method_skips_self(self):
         """Test that 'self' parameter is skipped for methods."""
@@ -328,13 +290,13 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        # Should not include 'self' parameter
-        model = model_class(name="test", value=42)
-        assert model.name == "test"
-        assert model.value == 42
+        result = _validate({"name": "test", "value": 42}, model_class)
+        assert result["name"] == "test"
+        assert result["value"] == 42
 
-        # Verify 'self' is not in the model fields
-        assert "self" not in model.__pydantic_fields__
+        assert (
+            "self" not in model_class.__required_keys__ | model_class.__optional_keys__
+        )
 
     def test_generate_parameters_model_function_with_union_types(self):
         """Test generating parameters model for function with Union types."""
@@ -346,15 +308,12 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        # Test with string
-        model1 = model_class(value="hello", flag=False)
-        assert model1.value == "hello"
-        assert model1.flag is False
+        result1 = _validate({"value": "hello", "flag": False}, model_class)
+        assert result1["value"] == "hello"
+        assert result1["flag"] is False
 
-        # Test with int
-        model2 = model_class(value=42)
-        assert model2.value == 42
-        assert model2.flag is True
+        result2 = _validate({"value": 42}, model_class)
+        assert result2["value"] == 42
 
     def test_generate_parameters_model_no_parameters(self):
         """Test generating parameters model for function with no parameters."""
@@ -366,9 +325,8 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        # Should be able to create model with no arguments
-        model = model_class()
-        assert isinstance(model, ArgModelBase)
+        result = _validate({}, model_class)
+        assert result == {}
 
     def test_generate_parameters_model_with_string_annotations(self):
         """Test generating parameters model with string annotations."""
@@ -380,9 +338,9 @@ class TestGenerateParametersModel:
 
         assert model_class is not None
 
-        model = model_class(name="hello", count=3)
-        assert model.name == "hello"
-        assert model.count == 3
+        result = _validate({"name": "hello", "count": 3}, model_class)
+        assert result["name"] == "hello"
+        assert result["count"] == 3
 
     def test_generate_parameters_model_unresolved_annotation_falls_back(self):
         """Unresolved annotations should fall back per parameter instead of failing."""
@@ -396,10 +354,9 @@ class TestGenerateParametersModel:
             model_class = _generate_parameters_model(problematic_func)
 
         assert model_class is not None
-        schema = model_class.model_json_schema()
+        schema = _json_schema(model_class)
         assert schema["type"] == "object"
         assert "x" in schema["properties"]
-        assert "type" not in schema["properties"]["x"]
 
     def test_generate_parameters_model_mixed_unresolved_annotation_keeps_valid_fields(
         self,
@@ -419,7 +376,7 @@ class TestGenerateParametersModel:
             model_class = _generate_parameters_model(mixed_func)
 
         assert model_class is not None
-        schema = model_class.model_json_schema()
+        schema = _json_schema(model_class)
         assert schema["properties"]["name"]["type"] == "string"
         assert "value" in schema["properties"]
 
@@ -433,22 +390,17 @@ class TestGenerateParametersModel:
 
         assert model_class is None
 
-    def test_model_dump_one_level_integration(self):
-        """Test integration of model_dump_one_level with generated model."""
+    def test_validate_integration(self):
+        """Test integration of validate with generated model."""
 
         def test_func(name: str, age: int = 25, active: bool = True) -> str:
             return f"{name}-{age}-{active}"
 
         model_class = _generate_parameters_model(test_func)
-        model = model_class(name="test", age=30)
+        result = _validate({"name": "test", "age": 30}, model_class)
 
-        dumped = model.model_dump_one_level()
-
-        assert dumped == {
-            "name": "test",
-            "age": 30,
-            "active": True,  # Default value
-        }
+        assert result["name"] == "test"
+        assert result["age"] == 30
 
     def test_generate_parameters_model_preserves_function_name(self):
         """Test that generated model class name includes function name."""
@@ -463,15 +415,15 @@ class TestGenerateParametersModel:
     def test_generate_parameters_model_with_lambda(self):
         """Test generating parameters model for lambda function."""
         lambda_func = lambda x, y=10: x + y  # noqa: E731
-        lambda_func.__name__ = "lambda_func"  # Give it a name for testing
+        lambda_func.__name__ = "lambda_func"
 
         model_class = _generate_parameters_model(lambda_func)
 
         assert model_class is not None
 
-        model = model_class(x=5, y=15)
-        assert model.x == 5
-        assert model.y == 15
+        result = _validate({"x": 5, "y": 15}, model_class)
+        assert result["x"] == 5
+        assert result["y"] == 15
 
 
 class TestComplexTypeSchemaGeneration:
@@ -482,29 +434,30 @@ class TestComplexTypeSchemaGeneration:
         """Generate JSON Schema from function parameters."""
         model = _generate_parameters_model(func)
         assert model is not None, f"Model generation failed for {func.__name__}"
-        return model.model_json_schema()
+        return _json_schema(model)
 
     # --- Union / anyOf ---
 
     def test_union_produces_anyof(self):
-        """Union[str, int] should produce anyOf in schema."""
+        """Union[str, int] should produce oneOf/anyOf in schema."""
 
         def f(value: Union[str, int]) -> None: ...
 
         schema = self._schema_for(f)
         prop = schema["properties"]["value"]
-        assert "anyOf" in prop
-        types = {branch.get("type") for branch in prop["anyOf"]}
+        assert "oneOf" in prop or "anyOf" in prop
+        key = "oneOf" if "oneOf" in prop else "anyOf"
+        types = {branch.get("type") for branch in prop[key]}
         assert types == {"string", "integer"}
 
     def test_pipe_union_produces_anyof(self):
-        """str | int (PEP 604) should produce anyOf in schema."""
+        """str | int (PEP 604) should produce oneOf/anyOf in schema."""
 
         def f(value: str | int) -> None: ...
 
         schema = self._schema_for(f)
         prop = schema["properties"]["value"]
-        assert "anyOf" in prop
+        assert "oneOf" in prop or "anyOf" in prop
 
     # --- Nested generic types ---
 
@@ -528,30 +481,24 @@ class TestComplexTypeSchemaGeneration:
         assert prop["type"] == "object"
         assert prop["additionalProperties"]["type"] == "integer"
 
-    # --- Nested Pydantic BaseModel ---
+    # --- Nested dataclass ---
 
-    def test_nested_pydantic_model(self):
-        """A Pydantic BaseModel parameter should produce a $ref or inline schema."""
-        from pydantic import BaseModel
+    def test_nested_dataclass(self):
+        """A dataclass parameter should produce inline schema."""
+        from dataclasses import dataclass
 
-        class Address(BaseModel):
+        @dataclass
+        class Address:
             city: str
             zip_code: str
 
         def f(addr: Address) -> None: ...
 
         schema = self._schema_for(f)
-        # The property should reference the Address schema
         prop = schema["properties"]["addr"]
-        assert "$ref" in prop or "properties" in prop
-
-        # Address schema should be in $defs or inline
-        if "$ref" in prop:
-            assert "$defs" in schema
-            assert "Address" in schema["$defs"]
-            addr_schema = schema["$defs"]["Address"]
-            assert "city" in addr_schema["properties"]
-            assert "zip_code" in addr_schema["properties"]
+        assert "properties" in prop
+        assert "city" in prop["properties"]
+        assert "zip_code" in prop["properties"]
 
     # --- Literal ---
 
@@ -573,12 +520,12 @@ class TestComplexTypeSchemaGeneration:
         prop = schema["properties"]["level"]
         assert prop["enum"] == [1, 2, 3]
 
-    # --- Annotated with Field constraints ---
+    # --- Annotated with constraints ---
 
     def test_annotated_with_ge_constraint(self):
-        """Annotated[int, Field(ge=0)] should produce minimum constraint."""
+        """Annotated[int, Ge(0)] should produce minimum constraint."""
 
-        def f(count: Annotated[int, Field(ge=0)]) -> None: ...
+        def f(count: Annotated[int, Ge(0)]) -> None: ...
 
         schema = self._schema_for(f)
         prop = schema["properties"]["count"]
@@ -586,9 +533,9 @@ class TestComplexTypeSchemaGeneration:
         assert prop.get("minimum") == 0
 
     def test_annotated_with_max_length(self):
-        """Annotated[str, Field(max_length=10)] should produce maxLength."""
+        """Annotated[str, MaxLen(10)] should produce maxLength."""
 
-        def f(name: Annotated[str, Field(max_length=10)]) -> None: ...
+        def f(name: Annotated[str, MaxLen(10)]) -> None: ...
 
         schema = self._schema_for(f)
         prop = schema["properties"]["name"]
@@ -596,9 +543,9 @@ class TestComplexTypeSchemaGeneration:
         assert prop.get("maxLength") == 10
 
     def test_annotated_with_description(self):
-        """Annotated[int, Field(description='...')] should carry description."""
+        """Annotated[int, Doc('...')] should carry description."""
 
-        def f(x: Annotated[int, Field(description="The x value")]) -> None: ...
+        def f(x: Annotated[int, Doc("The x value")]) -> None: ...
 
         schema = self._schema_for(f)
         prop = schema["properties"]["x"]
@@ -613,7 +560,6 @@ class TestComplexTypeSchemaGeneration:
 
         schema = self._schema_for(f)
         prop = schema["properties"]["tags"]
-        # Pydantic may express this as anyOf with array + null, or type array with default
         prop_str = str(prop)
         assert "array" in prop_str or "items" in prop_str
 
@@ -630,13 +576,8 @@ class TestComplexTypeSchemaGeneration:
         def f(color: Color) -> None: ...
 
         schema = self._schema_for(f)
-        # Could be inline enum or $ref to Color
         prop = schema["properties"]["color"]
-        if "$ref" in prop:
-            color_schema = schema["$defs"]["Color"]
-            assert set(color_schema["enum"]) == {"red", "green", "blue"}
-        else:
-            assert set(prop["enum"]) == {"red", "green", "blue"}
+        assert set(prop.get("enum", [])) == {"red", "green", "blue"}
 
     # --- Default values with complex types ---
 
@@ -647,8 +588,6 @@ class TestComplexTypeSchemaGeneration:
 
         model = _generate_parameters_model(f)
         assert model is not None
-        instance = model()
-        assert instance.items == []
 
     def test_default_dict(self):
         """Default value of {} should work for dict parameter."""
@@ -657,8 +596,6 @@ class TestComplexTypeSchemaGeneration:
 
         model = _generate_parameters_model(f)
         assert model is not None
-        instance = model()
-        assert instance.meta == {}
 
     # --- *args / **kwargs warnings ---
 
@@ -671,8 +608,9 @@ class TestComplexTypeSchemaGeneration:
             model = _generate_parameters_model(f)
 
         assert model is not None
-        assert "args" not in model.model_json_schema()["properties"]
-        assert "x" in model.model_json_schema()["properties"]
+        schema = _json_schema(model)
+        assert "args" not in schema["properties"]
+        assert "x" in schema["properties"]
 
     def test_kwargs_enables_additional_properties(self):
         """**kwargs parameter should set additionalProperties: true."""
@@ -682,10 +620,10 @@ class TestComplexTypeSchemaGeneration:
         model = _generate_parameters_model(f)
 
         assert model is not None
-        schema = model.model_json_schema()
+        schema = _json_schema(model)
         assert "kwargs" not in schema.get("properties", {})
         assert "x" in schema["properties"]
-        assert schema.get("additionalProperties") is True
+        assert getattr(model, "__has_var_keyword__", False) is True
 
     def test_kwargs_only_function(self):
         """Function with only **kwargs should produce additionalProperties schema."""
@@ -695,9 +633,7 @@ class TestComplexTypeSchemaGeneration:
         model = _generate_parameters_model(f)
 
         assert model is not None
-        schema = model.model_json_schema()
-        assert schema.get("additionalProperties") is True
-        assert schema.get("properties", {}) == {}
+        assert getattr(model, "__has_var_keyword__", False) is True
 
     def test_args_and_kwargs_combo(self):
         """*args warns while **kwargs enables additionalProperties."""
@@ -708,10 +644,10 @@ class TestComplexTypeSchemaGeneration:
             model = _generate_parameters_model(f)
 
         assert model is not None
-        schema = model.model_json_schema()
+        schema = _json_schema(model)
         assert "x" in schema["properties"]
         assert "args" not in schema.get("properties", {})
-        assert schema.get("additionalProperties") is True
+        assert getattr(model, "__has_var_keyword__", False) is True
 
     def test_normal_function_no_additional_properties(self):
         """Normal functions should NOT have additionalProperties in schema."""
@@ -731,7 +667,6 @@ class TestComplexTypeSchemaGeneration:
         schema = self._schema_for(f)
         assert "name" in schema.get("required", [])
         assert "age" in schema.get("required", [])
-        # city has default, should not be required
         assert "city" not in schema.get("required", [])
 
     # --- Mixed complex scenario ---
@@ -747,7 +682,7 @@ class TestComplexTypeSchemaGeneration:
             name: str,
             tags: list[str],
             priority: Priority = Priority.LOW,
-            count: Annotated[int, Field(ge=0)] = 0,
+            count: Annotated[int, Ge(0)] = 0,
             mode: Literal["fast", "slow"] = "fast",
             extra: dict[str, Any] | None = None,
         ) -> None: ...
@@ -762,6 +697,5 @@ class TestComplexTypeSchemaGeneration:
         assert "mode" in props
         assert "extra" in props
 
-        # name should be required
         assert "name" in schema.get("required", [])
         assert "tags" in schema.get("required", [])

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -338,7 +338,7 @@ class TestTool:
 
     def test_tool_callable_field_excluded_from_serialization(self, sample_tool):
         """Test that callable field is excluded from model serialization."""
-        model_dict = sample_tool.model_dump()
+        model_dict = sample_tool.to_dict()
 
         assert "callable" not in model_dict
         assert "name" in model_dict

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -62,9 +62,11 @@ class TestToolMetadata:
         m = ToolMetadata(extra={"author": "alice", "version": 2})
         assert m.extra["author"] == "alice"
 
-    def test_model_copy_preserves_tags(self):
+    def test_replace_preserves_tags(self):
+        import dataclasses
+
         m = ToolMetadata(tags={ToolTag.SLOW}, timeout=10.0)
-        m2 = m.model_copy(update={"is_async": True})
+        m2 = dataclasses.replace(m, is_async=True)
         assert m2.is_async is True
         assert m2.tags == {ToolTag.SLOW}
         assert m2.timeout == 10.0

--- a/tests/test_tool_namespace.py
+++ b/tests/test_tool_namespace.py
@@ -291,7 +291,7 @@ class TestBackwardCompatibility:
 
     def test_tool_serialization_excludes_callable(self):
         tool = Tool.from_function(dummy_add, namespace="calc")
-        data = tool.model_dump()
+        data = tool.to_dict()
         assert "callable" not in data
         assert "namespace" in data
         assert "method_name" in data

--- a/tests/test_validate_parity.py
+++ b/tests/test_validate_parity.py
@@ -1,0 +1,885 @@
+"""Exhaustive parity tests: zerodep validate vs Pydantic.
+
+Compares behavior across every dimension the migration depends on:
+type validation, coercion, schema generation, defaults, constraints,
+error handling, and edge cases.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Annotated, Any, Literal, Union
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field, create_model
+
+from toolregistry._vendor.validate import (
+    Ge,
+    Le,
+    ValidationError,
+    create_struct,
+    json_schema as zd_json_schema,
+    validate as zd_validate,
+)
+from toolregistry.parameter_models import (
+    _generate_parameters_model,
+    _simplify_nullable_schemas,
+    _resolve_enum,
+    _translate_annotated_metadata,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+class _PydanticBase(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+def _pydantic_schema(func):
+    """Generate schema via Pydantic create_model (old path)."""
+    import inspect
+    from typing import get_type_hints
+
+    sig = inspect.signature(func)
+    globalns = getattr(func, "__globals__", {})
+    try:
+        hints = get_type_hints(func, globalns, include_extras=True)
+    except Exception:
+        hints = {}
+
+    fields = {}
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        ann = hints.get(name, param.annotation)
+        if ann is inspect.Parameter.empty:
+            ann = Any
+        if param.default is inspect.Parameter.empty:
+            fields[name] = (ann, Field())
+        else:
+            fields[name] = (ann, Field(default=param.default))
+
+    model = create_model(f"{func.__name__}Params", __base__=_PydanticBase, **fields)
+    return model.model_json_schema()
+
+
+def _zerodep_schema(func):
+    """Generate schema via zerodep (new path)."""
+    model = _generate_parameters_model(func)
+    assert model is not None
+    schema = zd_json_schema(model)
+    if getattr(model, "__has_var_keyword__", False):
+        schema["additionalProperties"] = True
+    return _simplify_nullable_schemas(schema)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. BASIC TYPE VALIDATION
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestBasicTypes:
+    """Both engines accept correct types and reject wrong ones."""
+
+    @pytest.mark.parametrize(
+        "tp,good,bad",
+        [
+            (str, "hello", 123),
+            (int, 42, "not_a_number"),
+            (float, 3.14, "not_a_float"),
+            (bool, True, "not_a_bool"),
+        ],
+    )
+    def test_accept_correct_reject_wrong(self, tp, good, bad):
+        T = create_struct("T", {"v": (tp, ...)})
+        assert zd_validate({"v": good}, T)["v"] == good
+        with pytest.raises(ValidationError):
+            zd_validate({"v": bad}, T)
+
+    def test_none_type(self):
+        T = create_struct("T", {"v": (type(None), ...)})
+        assert zd_validate({"v": None}, T)["v"] is None
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. COERCION (the critical LLM path)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCoercion:
+    """LLMs send string-encoded numbers. Both engines must coerce."""
+
+    def test_str_to_int(self):
+        """Pydantic: '42' → 42.  zerodep: same with coerce=True."""
+        T = create_struct("T", {"n": (int, ...)})
+        r = zd_validate({"n": "42"}, T, coerce=True)
+        assert r["n"] == 42
+        assert isinstance(r["n"], int)
+
+    def test_str_to_float(self):
+        T = create_struct("T", {"n": (float, ...)})
+        r = zd_validate({"n": "3.14"}, T, coerce=True)
+        assert r["n"] == 3.14
+        assert isinstance(r["n"], float)
+
+    def test_int_accepted_for_float(self):
+        """int is accepted for float (numeric tower) without conversion."""
+        T = create_struct("T", {"n": (float, ...)})
+        r = zd_validate({"n": 5}, T, coerce=True)
+        assert r["n"] == 5.0  # numerically equal
+        # int stays as int (accepted via numeric tower, not coerced)
+        assert isinstance(r["n"], (int, float))
+
+    def test_no_coerce_str_to_int_fails(self):
+        """Without coerce=True, string→int should fail."""
+        T = create_struct("T", {"n": (int, ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"n": "42"}, T, coerce=False)
+
+    def test_str_to_bool_not_coerced(self):
+        """zerodep does NOT coerce str→bool (Pydantic does)."""
+        T = create_struct("T", {"v": (bool, ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"v": "true"}, T, coerce=True)
+
+    def test_bool_not_treated_as_int(self):
+        """True should not pass as int."""
+        T = create_struct("T", {"v": (int, ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"v": True}, T)
+
+    def test_nested_struct_coercion(self):
+        """Coercion must propagate through nested structs."""
+        Inner = create_struct("Inner", {"count": (int, ...)})
+        Outer = create_struct("Outer", {"inner": (Inner, ...), "name": (str, ...)})
+        r = zd_validate({"inner": {"count": "7"}, "name": "test"}, Outer, coerce=True)
+        assert r["inner"]["count"] == 7
+        assert isinstance(r["inner"]["count"], int)
+
+    def test_coercion_in_list(self):
+        """Coercion inside list items."""
+        T = create_struct("T", {"items": (list[int], ...)})
+        r = zd_validate({"items": ["1", "2", "3"]}, T, coerce=True)
+        assert r["items"] == [1, 2, 3]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. OPTIONAL / NULLABLE
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestOptionalNullable:
+    """Optional[T] and T | None handling."""
+
+    def test_optional_accepts_none(self):
+        T = create_struct("T", {"v": (str | None, ...)})
+        assert zd_validate({"v": None}, T)["v"] is None
+
+    def test_optional_accepts_value(self):
+        T = create_struct("T", {"v": (int | None, ...)})
+        assert zd_validate({"v": 42}, T)["v"] == 42
+
+    def test_pipe_union_none(self):
+        T = create_struct("T", {"v": (str | None, ...)})
+        assert zd_validate({"v": None}, T)["v"] is None
+        assert zd_validate({"v": "hello"}, T)["v"] == "hello"
+
+    def test_missing_optional_field(self):
+        """Optional field with default should not be required."""
+        T = create_struct("T", {"v": (str | None, None)})
+        r = zd_validate({}, T)
+        assert r == {}  # zerodep doesn't fill defaults
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. UNION TYPES
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestUnionTypes:
+    def test_union_str_int_accepts_both(self):
+        T = create_struct("T", {"v": (Union[str, int], ...)})
+        assert zd_validate({"v": "hello"}, T)["v"] == "hello"
+        assert zd_validate({"v": 42}, T)["v"] == 42
+
+    def test_union_rejects_wrong_type(self):
+        T = create_struct("T", {"v": (Union[str, int], ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"v": [1, 2]}, T)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. COLLECTION TYPES
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCollectionTypes:
+    def test_list_str(self):
+        T = create_struct("T", {"v": (list[str], ...)})
+        r = zd_validate({"v": ["a", "b"]}, T)
+        assert r["v"] == ["a", "b"]
+
+    def test_list_rejects_wrong_item(self):
+        T = create_struct("T", {"v": (list[int], ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"v": ["not_int"]}, T)
+
+    def test_dict_str_int(self):
+        T = create_struct("T", {"v": (dict[str, int], ...)})
+        r = zd_validate({"v": {"a": 1, "b": 2}}, T)
+        assert r["v"] == {"a": 1, "b": 2}
+
+    def test_nested_list_of_dicts(self):
+        T = create_struct("T", {"v": (list[dict[str, int]], ...)})
+        r = zd_validate({"v": [{"a": 1}, {"b": 2}]}, T)
+        assert r["v"] == [{"a": 1}, {"b": 2}]
+
+    def test_set_type(self):
+        T = create_struct("T", {"v": (set[int], ...)})
+        r = zd_validate({"v": {1, 2, 3}}, T)
+        assert r["v"] == {1, 2, 3}
+
+    def test_tuple_variable_length(self):
+        T = create_struct("T", {"v": (tuple[int, ...], ...)})
+        r = zd_validate({"v": (1, 2, 3)}, T)
+        assert set(r["v"]) == {1, 2, 3}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. LITERAL TYPES
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestLiteralTypes:
+    def test_literal_str(self):
+        T = create_struct("T", {"v": (Literal["a", "b", "c"], ...)})
+        assert zd_validate({"v": "a"}, T)["v"] == "a"
+
+    def test_literal_rejects_invalid(self):
+        T = create_struct("T", {"v": (Literal["a", "b"], ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"v": "z"}, T)
+
+    def test_literal_int(self):
+        T = create_struct("T", {"v": (Literal[1, 2, 3], ...)})
+        assert zd_validate({"v": 2}, T)["v"] == 2
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 7. ENUM HANDLING (via _resolve_enum)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEnumHandling:
+    def test_str_enum_to_literal(self):
+        class Color(str, Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        resolved = _resolve_enum(Color)
+        # Should produce Literal["red", "green", "blue"]
+        assert resolved is not Color
+        T = create_struct("T", {"v": (resolved, ...)})
+        assert zd_validate({"v": "red"}, T)["v"] == "red"
+
+    def test_int_enum_to_literal(self):
+        class Priority(int, Enum):
+            LOW = 1
+            MED = 2
+            HIGH = 3
+
+        resolved = _resolve_enum(Priority)
+        T = create_struct("T", {"v": (resolved, ...)})
+        assert zd_validate({"v": 2}, T)["v"] == 2
+
+    def test_non_enum_passthrough(self):
+        assert _resolve_enum(str) is str
+        assert _resolve_enum(int) is int
+
+    def test_enum_schema_generation(self):
+        class Status(str, Enum):
+            ACTIVE = "active"
+            INACTIVE = "inactive"
+
+        def f(status: Status) -> None: ...
+
+        schema = _zerodep_schema(f)
+        prop = schema["properties"]["status"]
+        assert set(prop["enum"]) == {"active", "inactive"}
+
+    def test_enum_schema_parity(self):
+        """Pydantic and zerodep should produce equivalent enum schemas."""
+
+        class Mode(str, Enum):
+            FAST = "fast"
+            SLOW = "slow"
+
+        def f(mode: Mode) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        # Both should have "mode" in properties
+        assert "mode" in pd_schema["properties"]
+        assert "mode" in zd_schema["properties"]
+
+        # Both should have enum values (possibly via $ref or inline)
+        pd_prop = pd_schema["properties"]["mode"]
+        zd_prop = zd_schema["properties"]["mode"]
+
+        if "$ref" in pd_prop:
+            ref_name = pd_prop["$ref"].split("/")[-1]
+            pd_enum = set(pd_schema["$defs"][ref_name]["enum"])
+        else:
+            pd_enum = set(pd_prop.get("enum", []))
+
+        zd_enum = set(zd_prop.get("enum", []))
+        assert pd_enum == zd_enum == {"fast", "slow"}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 8. ANNOTATED CONSTRAINTS
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestAnnotatedConstraints:
+    """Test constraint translation from Pydantic Field → zerodep."""
+
+    def test_pydantic_field_ge_translates(self):
+        ann = Annotated[int, Field(ge=0)]
+        translated = _translate_annotated_metadata(ann)
+        T = create_struct("T", {"v": (translated, ...)})
+        assert zd_validate({"v": 5}, T)["v"] == 5
+        with pytest.raises(ValidationError):
+            zd_validate({"v": -1}, T)
+
+    def test_pydantic_field_le_translates(self):
+        ann = Annotated[int, Field(le=100)]
+        translated = _translate_annotated_metadata(ann)
+        T = create_struct("T", {"v": (translated, ...)})
+        assert zd_validate({"v": 50}, T)["v"] == 50
+        with pytest.raises(ValidationError):
+            zd_validate({"v": 101}, T)
+
+    def test_pydantic_field_max_length_translates(self):
+        ann = Annotated[str, Field(max_length=5)]
+        translated = _translate_annotated_metadata(ann)
+        T = create_struct("T", {"v": (translated, ...)})
+        assert zd_validate({"v": "abc"}, T)["v"] == "abc"
+        with pytest.raises(ValidationError):
+            zd_validate({"v": "toolregistry"}, T)
+
+    def test_pydantic_field_description_translates(self):
+        ann = Annotated[str, Field(description="A name")]
+        translated = _translate_annotated_metadata(ann)
+        schema = zd_json_schema(translated)
+        assert schema["description"] == "A name"
+
+    def test_native_zerodep_constraints_passthrough(self):
+        """zerodep's own Ge/Le/Doc should pass through unchanged."""
+        ann = Annotated[int, Ge(0), Le(100)]
+        translated = _translate_annotated_metadata(ann)
+        T = create_struct("T", {"v": (translated, ...)})
+        assert zd_validate({"v": 50}, T)["v"] == 50
+        with pytest.raises(ValidationError):
+            zd_validate({"v": -1}, T)
+        with pytest.raises(ValidationError):
+            zd_validate({"v": 101}, T)
+
+    def test_constraint_schema_parity(self):
+        """Ge(0) should produce minimum:0 in both engines."""
+
+        def f(count: Annotated[int, Field(ge=0)]) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        pd_min = pd_schema["properties"]["count"].get("minimum")
+        zd_min = zd_schema["properties"]["count"].get("minimum")
+        assert pd_min == zd_min == 0
+
+    def test_max_length_schema_parity(self):
+        def f(name: Annotated[str, Field(max_length=10)]) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["properties"]["name"].get("maxLength") == 10
+        assert zd_schema["properties"]["name"].get("maxLength") == 10
+
+    def test_description_schema_parity(self):
+        def f(x: Annotated[int, Field(description="The x")] = 0) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["properties"]["x"].get("description") == "The x"
+        assert zd_schema["properties"]["x"].get("description") == "The x"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 9. SCHEMA STRUCTURE PARITY
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestSchemaParity:
+    """Both engines should produce equivalent JSON Schema structures."""
+
+    def test_simple_function_schema(self):
+        def f(name: str, age: int) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["type"] == zd_schema["type"] == "object"
+        assert set(pd_schema["properties"]) == set(zd_schema["properties"])
+        assert set(pd_schema.get("required", [])) == set(zd_schema.get("required", []))
+
+    def test_defaults_schema(self):
+        def f(name: str, age: int = 30) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert "name" in pd_schema.get("required", [])
+        assert "name" in zd_schema.get("required", [])
+        assert "age" not in pd_schema.get("required", [])
+        assert "age" not in zd_schema.get("required", [])
+
+        pd_default = pd_schema["properties"]["age"].get("default")
+        zd_default = zd_schema["properties"]["age"].get("default")
+        assert pd_default == zd_default == 30
+
+    def test_type_mapping(self):
+        """Basic type → JSON Schema type mapping should match."""
+
+        def f(
+            s: str,
+            i: int,
+            fl: float,
+            b: bool,
+        ) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        for field in ("s", "i", "fl", "b"):
+            assert (
+                pd_schema["properties"][field]["type"]
+                == zd_schema["properties"][field]["type"]
+            ), (
+                f"Mismatch for {field}: "
+                f"pydantic={pd_schema['properties'][field]} "
+                f"zerodep={zd_schema['properties'][field]}"
+            )
+
+    def test_list_schema(self):
+        def f(items: list[str]) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["properties"]["items"]["type"] == "array"
+        assert zd_schema["properties"]["items"]["type"] == "array"
+        assert pd_schema["properties"]["items"]["items"]["type"] == "string"
+        assert zd_schema["properties"]["items"]["items"]["type"] == "string"
+
+    def test_dict_schema(self):
+        def f(m: dict[str, int]) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["properties"]["m"]["type"] == "object"
+        assert zd_schema["properties"]["m"]["type"] == "object"
+        assert pd_schema["properties"]["m"]["additionalProperties"]["type"] == "integer"
+        assert zd_schema["properties"]["m"]["additionalProperties"]["type"] == "integer"
+
+    def test_literal_schema(self):
+        def f(mode: Literal["a", "b"]) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["properties"]["mode"]["enum"] == ["a", "b"]
+        assert zd_schema["properties"]["mode"]["enum"] == ["a", "b"]
+
+    def test_union_schema(self):
+        def f(v: Union[str, int]) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        pd_prop = pd_schema["properties"]["v"]
+        zd_prop = zd_schema["properties"]["v"]
+
+        pd_key = "anyOf" if "anyOf" in pd_prop else "oneOf"
+        zd_key = "anyOf" if "anyOf" in zd_prop else "oneOf"
+
+        pd_types = {b.get("type") for b in pd_prop[pd_key]}
+        zd_types = {b.get("type") for b in zd_prop[zd_key]}
+        assert pd_types == zd_types == {"string", "integer"}
+
+    def test_optional_schema_after_simplify(self):
+        """After simplification, str | None should be type: string."""
+
+        def f(v: str | None = None) -> None: ...
+
+        pd_schema = _simplify_nullable_schemas(_pydantic_schema(f))
+        zd_schema = _zerodep_schema(f)  # already simplified
+
+        assert pd_schema["properties"]["v"]["type"] == "string"
+        assert zd_schema["properties"]["v"]["type"] == "string"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 10. REQUIRED / OPTIONAL FIELD TRACKING
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestRequiredOptional:
+    def test_required_fields(self):
+        T = create_struct("T", {"a": (str, ...), "b": (int, ...)})
+        schema = zd_json_schema(T)
+        assert set(schema["required"]) == {"a", "b"}
+
+    def test_optional_fields_not_required(self):
+        T = create_struct("T", {"a": (str, ...), "b": (int, 42)})
+        schema = zd_json_schema(T)
+        assert "a" in schema["required"]
+        assert "b" not in schema.get("required", [])
+
+    def test_missing_required_field_fails(self):
+        T = create_struct("T", {"a": (str, ...), "b": (int, ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"a": "hello"}, T)
+
+    def test_missing_optional_field_ok(self):
+        T = create_struct("T", {"a": (str, ...), "b": (int, 42)})
+        r = zd_validate({"a": "hello"}, T)
+        assert r["a"] == "hello"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 11. NESTED STRUCTS
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestNestedStructs:
+    def test_nested_typeddict(self):
+        Inner = create_struct("Inner", {"x": (int, ...), "y": (str, ...)})
+        Outer = create_struct("Outer", {"inner": (Inner, ...), "label": (str, ...)})
+        r = zd_validate({"inner": {"x": 1, "y": "two"}, "label": "test"}, Outer)
+        assert r["inner"]["x"] == 1
+        assert r["label"] == "test"
+
+    def test_nested_dataclass(self):
+        @dataclass
+        class Point:
+            x: int
+            y: int
+
+        T = create_struct("T", {"point": (Point, ...)})
+        r = zd_validate({"point": {"x": 1, "y": 2}}, T)
+        assert r["point"]["x"] == 1
+
+    def test_nested_schema_inline(self):
+        """zerodep inlines nested struct schemas (no $ref/$defs)."""
+        Inner = create_struct("Inner", {"value": (int, ...)})
+        Outer = create_struct("Outer", {"inner": (Inner, ...)})
+        schema = zd_json_schema(Outer)
+        prop = schema["properties"]["inner"]
+        assert "properties" in prop
+        assert "value" in prop["properties"]
+        assert "$ref" not in prop
+
+    def test_deeply_nested(self):
+        L3 = create_struct("L3", {"val": (str, ...)})
+        L2 = create_struct("L2", {"l3": (L3, ...)})
+        L1 = create_struct("L1", {"l2": (L2, ...)})
+        r = zd_validate({"l2": {"l3": {"val": "deep"}}}, L1)
+        assert r["l2"]["l3"]["val"] == "deep"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 12. ANY TYPE
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestAnyType:
+    def test_any_accepts_anything(self):
+        T = create_struct("T", {"v": (Any, ...)})
+        assert zd_validate({"v": "str"}, T)["v"] == "str"
+        assert zd_validate({"v": 42}, T)["v"] == 42
+        assert zd_validate({"v": [1, 2]}, T)["v"] == [1, 2]
+        assert zd_validate({"v": None}, T)["v"] is None
+
+    def test_any_schema_is_empty(self):
+        T = create_struct("T", {"v": (Any, ...)})
+        schema = zd_json_schema(T)
+        assert schema["properties"]["v"] == {}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 13. DEFAULT VALUES IN SCHEMA
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDefaults:
+    def test_default_in_schema(self):
+        T = create_struct("T", {"v": (int, 42)})
+        schema = zd_json_schema(T)
+        assert schema["properties"]["v"]["default"] == 42
+
+    def test_default_none_in_schema(self):
+        T = create_struct("T", {"v": (str | None, None)})
+        schema = zd_json_schema(T)
+        assert schema["properties"]["v"]["default"] is None
+
+    def test_no_default_for_required(self):
+        T = create_struct("T", {"v": (int, ...)})
+        schema = zd_json_schema(T)
+        assert "default" not in schema["properties"]["v"]
+
+    def test_default_parity(self):
+        """Default values in schema should match between engines."""
+
+        def f(x: int = 10, y: str = "hello") -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_schema = _zerodep_schema(f)
+
+        assert pd_schema["properties"]["x"]["default"] == 10
+        assert zd_schema["properties"]["x"]["default"] == 10
+        assert pd_schema["properties"]["y"]["default"] == "hello"
+        assert zd_schema["properties"]["y"]["default"] == "hello"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 14. _simplify_nullable_schemas
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestSimplifyNullable:
+    def test_pydantic_anyof_pattern(self):
+        """anyOf: [{type: str}, {type: null}] → type: str."""
+        schema = {
+            "properties": {"v": {"anyOf": [{"type": "string"}, {"type": "null"}]}}
+        }
+        result = _simplify_nullable_schemas(schema)
+        assert result["properties"]["v"] == {"type": "string"}
+
+    def test_zerodep_type_array_pattern(self):
+        """type: ["string", "null"] → type: "string"."""
+        schema = {"properties": {"v": {"type": ["string", "null"]}}}
+        result = _simplify_nullable_schemas(schema)
+        assert result["properties"]["v"] == {"type": "string"}
+
+    def test_multi_type_anyof(self):
+        """anyOf with 3+ types: strip only null."""
+        schema = {
+            "properties": {
+                "v": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "null"},
+                    ]
+                }
+            }
+        }
+        result = _simplify_nullable_schemas(schema)
+        assert result["properties"]["v"]["anyOf"] == [
+            {"type": "string"},
+            {"type": "integer"},
+        ]
+
+    def test_no_null_untouched(self):
+        """No null variant → unchanged."""
+        schema = {
+            "properties": {"v": {"anyOf": [{"type": "string"}, {"type": "integer"}]}}
+        }
+        result = _simplify_nullable_schemas(schema)
+        assert result["properties"]["v"]["anyOf"] == [
+            {"type": "string"},
+            {"type": "integer"},
+        ]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 15. ERROR REPORTING
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestErrorReporting:
+    def test_error_has_path(self):
+        T = create_struct("T", {"name": (str, ...), "age": (int, ...)})
+        with pytest.raises(ValidationError) as exc_info:
+            zd_validate({"name": 123, "age": "bad"}, T)
+        paths = {e.path for e in exc_info.value.errors}
+        assert "name" in paths
+        assert "age" in paths
+
+    def test_nested_error_path(self):
+        Inner = create_struct("Inner", {"x": (int, ...)})
+        Outer = create_struct("Outer", {"inner": (Inner, ...)})
+        with pytest.raises(ValidationError) as exc_info:
+            zd_validate({"inner": {"x": "bad"}}, Outer)
+        paths = {e.path for e in exc_info.value.errors}
+        assert "inner.x" in paths
+
+    def test_missing_required_error(self):
+        T = create_struct("T", {"a": (str, ...), "b": (int, ...)})
+        with pytest.raises(ValidationError) as exc_info:
+            zd_validate({}, T)
+        assert len(exc_info.value.errors) == 2
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 16. KNOWN BEHAVIORAL DIFFERENCES (DOCUMENTED)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestKnownDifferences:
+    """Differences between Pydantic and zerodep that are accepted."""
+
+    def test_zerodep_does_not_fill_defaults(self):
+        """zerodep validates but does NOT fill in default values."""
+        T = create_struct("T", {"a": (str, ...), "b": (int, 42)})
+        r = zd_validate({"a": "hello"}, T)
+        assert "b" not in r  # zerodep: missing optional → absent
+
+    def test_pydantic_fills_defaults(self):
+        """Pydantic fills in defaults — this is a known difference."""
+        M = create_model("M", a=(str, ...), b=(int, 42), __base__=_PydanticBase)
+        m = M(a="hello")
+        assert m.b == 42  # Pydantic fills it in
+
+    def test_zerodep_no_str_to_bool_coercion(self):
+        """Pydantic coerces 'true'→True; zerodep does not."""
+        T = create_struct("T", {"v": (bool, ...)})
+        with pytest.raises(ValidationError):
+            zd_validate({"v": "true"}, T, coerce=True)
+
+        M = create_model("M", v=(bool, ...), __base__=_PydanticBase)
+        assert M(v="true").v is True  # Pydantic does coerce
+
+    def test_zerodep_returns_dict_not_object(self):
+        """zerodep returns plain dict, not an object with attributes."""
+        T = create_struct("T", {"name": (str, ...)})
+        r = zd_validate({"name": "test"}, T)
+        assert isinstance(r, dict)
+        assert r["name"] == "test"
+
+    def test_schema_inlines_vs_ref(self):
+        """zerodep inlines nested schemas; Pydantic uses $ref/$defs."""
+        Inner = create_struct("Inner", {"x": (int, ...)})
+        Outer = create_struct("Outer", {"inner": (Inner, ...)})
+        schema = zd_json_schema(Outer)
+        assert "$defs" not in schema
+        assert "$ref" not in schema["properties"]["inner"]
+
+    def test_nullable_representation_differs(self):
+        """Pydantic: anyOf; zerodep: type array. Both simplified equally."""
+
+        def f(v: str | None = None) -> None: ...
+
+        pd_schema = _pydantic_schema(f)
+        zd_raw = _zerodep_schema(f)
+
+        # Pydantic raw uses anyOf
+        pd_prop = pd_schema["properties"]["v"]
+        assert "anyOf" in pd_prop
+
+        # zerodep raw uses type array — but _zerodep_schema already simplifies
+        zd_prop = zd_raw["properties"]["v"]
+        assert zd_prop["type"] == "string"  # simplified
+
+        # After simplification, both match
+        pd_simplified = _simplify_nullable_schemas(pd_schema)
+        assert pd_simplified["properties"]["v"]["type"] == "string"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 17. END-TO-END TOOL REGISTRATION FLOW
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEndToEnd:
+    """Test the full tool registration → validate → execute flow."""
+
+    def test_simple_function_roundtrip(self):
+        from toolregistry import Tool
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        tool = Tool.from_function(add)
+        assert tool.parameters["properties"]["a"]["type"] == "integer"
+        result = tool.run({"a": 3, "b": 4})
+        assert result == 7
+
+    def test_coercion_roundtrip(self):
+        """LLM sends strings → coerce → correct types for execution."""
+        from toolregistry import Tool
+
+        def multiply(x: int, y: float) -> float:
+            """Multiply."""
+            return x * y
+
+        tool = Tool.from_function(multiply)
+        result = tool.run({"x": "3", "y": "2.5"})
+        assert result == 7.5
+
+    def test_complex_function_roundtrip(self):
+        from toolregistry import Tool
+
+        class Priority(str, Enum):
+            LOW = "low"
+            HIGH = "high"
+
+        def process(
+            name: str,
+            tags: list[str],
+            priority: Priority = Priority.LOW,
+            count: Annotated[int, Ge(0)] = 0,
+            mode: Literal["fast", "slow"] = "fast",
+        ) -> dict:
+            """Process."""
+            return {"name": name, "tags": tags}
+
+        tool = Tool.from_function(process)
+        schema = tool.parameters
+        assert "name" in schema["properties"]
+        assert "tags" in schema["properties"]
+        assert "priority" in schema["properties"]
+
+        result = tool.run({"name": "test", "tags": ["a", "b"], "priority": "high"})
+        assert result == {"name": "test", "tags": ["a", "b"]}
+
+    def test_kwargs_function_roundtrip(self):
+        from toolregistry import Tool
+
+        def flexible(x: int, **kwargs) -> dict:
+            """Accept extra args."""
+            return {"x": x, **kwargs}
+
+        tool = Tool.from_function(flexible)
+        assert tool.parameters.get("additionalProperties") is True
+        result = tool.run({"x": 1, "extra": "value"})
+        assert result == {"x": 1, "extra": "value"}
+
+    def test_optional_param_roundtrip(self):
+        from toolregistry import Tool
+
+        def greet(name: str, greeting: str | None = None) -> str:
+            """Greet."""
+            return f"{greeting or 'Hello'}, {name}!"
+
+        tool = Tool.from_function(greet)
+        assert tool.run({"name": "World"}) == "Hello, World!"
+        assert tool.run({"name": "World", "greeting": "Hi"}) == "Hi, World!"

--- a/tests/test_validate_parity.py
+++ b/tests/test_validate_parity.py
@@ -339,6 +339,34 @@ class TestEnumHandling:
         zd_enum = set(zd_prop.get("enum", []))
         assert pd_enum == zd_enum == {"fast", "slow"}
 
+    def test_optional_enum(self):
+        """Optional[MyEnum] should resolve the enum inside the Union."""
+
+        class Status(str, Enum):
+            ON = "on"
+            OFF = "off"
+
+        def f(status: Status | None = None) -> None: ...
+
+        schema = _zerodep_schema(f)
+        prop = schema["properties"]["status"]
+        prop_str = str(prop)
+        assert "on" in prop_str and "off" in prop_str
+
+    def test_int_enum(self):
+        """IntEnum should produce integer Literal values."""
+
+        class Priority(int, Enum):
+            LOW = 1
+            MED = 2
+            HIGH = 3
+
+        def f(p: Priority) -> None: ...
+
+        schema = _zerodep_schema(f)
+        prop = schema["properties"]["p"]
+        assert set(prop["enum"]) == {1, 2, 3}
+
 
 # ═══════════════════════════════════════════════════════════════════
 # 8. ANNOTATED CONSTRAINTS
@@ -388,6 +416,23 @@ class TestAnnotatedConstraints:
             zd_validate({"v": -1}, T)
         with pytest.raises(ValidationError):
             zd_validate({"v": 101}, T)
+
+    def test_multi_constraint_field(self):
+        """Field(ge=0, le=100) should produce both minimum and maximum."""
+
+        def f(score: Annotated[int, Field(ge=0, le=100)]) -> None: ...
+
+        schema = _zerodep_schema(f)
+        prop = schema["properties"]["score"]
+        assert prop.get("minimum") == 0
+        assert prop.get("maximum") == 100
+
+        model = _generate_parameters_model(f)
+        assert zd_validate({"score": 50}, model)["score"] == 50
+        with pytest.raises(ValidationError):
+            zd_validate({"score": -1}, model)
+        with pytest.raises(ValidationError):
+            zd_validate({"score": 101}, model)
 
     def test_constraint_schema_parity(self):
         """Ge(0) should produce minimum:0 in both engines."""

--- a/tests/test_validate_parity.py
+++ b/tests/test_validate_parity.py
@@ -70,7 +70,7 @@ def _zerodep_schema(func):
     model = _generate_parameters_model(func)
     assert model is not None
     schema = zd_json_schema(model)
-    if getattr(model, "__has_var_keyword__", False):
+    if getattr(model, "_has_var_keyword", False):
         schema["additionalProperties"] = True
     return _simplify_nullable_schemas(schema)
 


### PR DESCRIPTION
## Summary

- Remove `pydantic` from runtime dependencies — the only heavy dep in toolregistry
- Convert all 7 Pydantic `BaseModel` classes to stdlib `@dataclass` (ToolCall, PermissionRequest, PermissionRule, PermissionPolicy, ToolMetadata, Tool)
- Rewrite `parameter_models.py` to use zerodep `create_struct` + `json_schema` + `validate` instead of Pydantic's `create_model` + `model_json_schema`
- Vendor zerodep `validate.py` v0.7.1 (single-file, stdlib-only)
- 81 exhaustive parity tests comparing zerodep vs Pydantic behavior across types, coercion, schema generation, constraints, and end-to-end tool roundtrips

### Key design decisions

- `Tool` uses `@dataclass(init=False)` with custom `__init__` to preserve legacy `is_async` kwarg compat
- Enum annotations are converted to `Literal[*values]` for schema generation (zerodep doesn't natively schema Enums)
- `_simplify_nullable_schemas` now handles both Pydantic-style `anyOf` and zerodep-style `type: [T, "null"]` patterns
- Annotated constraint translation shim converts `pydantic.Field(ge=0)` / `annotated_types.Ge` → zerodep `Ge`
- Defaults are NOT filled by `validate()` — Python's function call mechanism handles them via `func(**params)`

### Known behavioral differences (documented + tested)

| Behavior | Pydantic | zerodep |
|---|---|---|
| Default filling | Fills missing optional fields | Does not (Python func defaults handle it) |
| `str → bool` coercion | `"true"` → `True` | Not coerced (LLMs send JSON booleans) |
| Return type | Object with attributes | Plain dict |
| Nested schema | `$ref` / `$defs` | Inline |
| Nullable schema | `anyOf: [{type: T}, {type: null}]` | `type: [T, "null"]` (simplified by `_simplify_nullable_schemas`) |

Closes #243

## Test plan

- [x] 81 parity tests (`test_validate_parity.py`) — types, coercion, schema, constraints, end-to-end
- [x] 50 parameter model tests (`test_parameter_models.py`)
- [x] 161 tool/permission/metadata tests
- [x] Pre-commit hooks (ruff, ruff-format, ty, complexipy) all pass
- [ ] CI full suite