### PR TITLE
chore(deps): remove upper bound on llm-rosetta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle>=3.0.0",
-    "llm-rosetta>=0.7.1,<0.10.0",
+    "llm-rosetta>=0.7.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Remove the `<0.10.0` upper bound from `llm-rosetta` dependency, changing `>=0.7.1,<0.10.0` → `>=0.7.1`
- The converter API surface (`OpenAIChatToolOps`, `OpenAIResponsesToolOps`, `AnthropicToolOps`, `GoogleGenAIToolOps`) has been stable through v0.12.0
- Both projects share the same maintainer, so an upper bound adds friction without meaningful protection

## Test plan

- [x] Verified all 4 converter imports work with llm-rosetta 0.12.0
- [x] 255/256 tests pass (1 flaky timing test unrelated to this change)