### PR TITLE
refactor(llm): migrate to tool_ops API and add google-interactions format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle>=3.0.0",
-    "llm-rosetta>=0.7.1,<0.10.0",
+    "llm-rosetta>=0.13.0",
 ]
 
 [project.optional-dependencies]

--- a/src/toolregistry/llm/_rosetta.py
+++ b/src/toolregistry/llm/_rosetta.py
@@ -13,6 +13,9 @@ from typing import Any
 def _get_tool_ops(provider: str) -> Any:
     """Return the ToolOps class for *provider* via llm-rosetta dispatch.
 
+    Uses ``llm_rosetta.tool_ops._get_tool_ops`` which is currently
+    underscore-prefixed upstream; planned for promotion to public API.
+
     Args:
         provider: Canonical provider name (e.g. ``"openai_chat"``,
             ``"google"``, ``"google_interactions"``).

--- a/src/toolregistry/llm/_rosetta.py
+++ b/src/toolregistry/llm/_rosetta.py
@@ -1,7 +1,8 @@
 """Lazy-import helpers for llm-rosetta integration.
 
-Provides accessor functions that import llm-rosetta converter components
-on demand to avoid circular imports and reduce startup cost.
+Provides a thin wrapper around :mod:`llm_rosetta.tool_ops` for
+provider-specific ToolOps dispatch, and a helper to build IR
+tool definition dicts.
 """
 
 from __future__ import annotations
@@ -9,32 +10,19 @@ from __future__ import annotations
 from typing import Any
 
 
-def _get_openai_chat_tool_ops() -> Any:
-    """Lazily import OpenAIChatToolOps from llm-rosetta."""
-    from llm_rosetta.converters.openai_chat import OpenAIChatToolOps
+def _get_tool_ops(provider: str) -> Any:
+    """Return the ToolOps class for *provider* via llm-rosetta dispatch.
 
-    return OpenAIChatToolOps
+    Args:
+        provider: Canonical provider name (e.g. ``"openai_chat"``,
+            ``"google"``, ``"google_interactions"``).
 
+    Returns:
+        The corresponding ToolOps class.
+    """
+    from llm_rosetta.tool_ops import _get_tool_ops as _rosetta_get_tool_ops
 
-def _get_openai_responses_tool_ops() -> Any:
-    """Lazily import OpenAIResponsesToolOps from llm-rosetta."""
-    from llm_rosetta.converters.openai_responses import OpenAIResponsesToolOps
-
-    return OpenAIResponsesToolOps
-
-
-def _get_anthropic_tool_ops() -> Any:
-    """Lazily import AnthropicToolOps from llm-rosetta."""
-    from llm_rosetta.converters.anthropic import AnthropicToolOps
-
-    return AnthropicToolOps
-
-
-def _get_google_tool_ops() -> Any:
-    """Lazily import GoogleGenAIToolOps from llm-rosetta."""
-    from llm_rosetta.converters.google_genai import GoogleGenAIToolOps
-
-    return GoogleGenAIToolOps
+    return _rosetta_get_tool_ops(provider)
 
 
 def _make_ir_tool_definition(

--- a/src/toolregistry/llm/content_blocks.py
+++ b/src/toolregistry/llm/content_blocks.py
@@ -144,6 +144,39 @@ def extract_multimodal_content(
     return text_only, extra_parts
 
 
+def _convert_google_parts(
+    content_parts: list[dict[str, Any]], interactions: bool = False
+) -> list[dict[str, Any]]:
+    """Convert canonical content blocks to Google-family part format."""
+    parts: list[dict[str, Any]] = []
+    for part in content_parts:
+        if part.get("type") == "text":
+            if interactions:
+                parts.append({"type": "text", "text": part["text"]})
+            else:
+                parts.append({"text": part["text"]})
+        elif part.get("type") == "image":
+            source = part["source"]
+            if interactions:
+                parts.append(
+                    {
+                        "type": "image",
+                        "data": source["data"],
+                        "mime_type": source["media_type"],
+                    }
+                )
+            else:
+                parts.append(
+                    {
+                        "inline_data": {
+                            "mime_type": source["media_type"],
+                            "data": source["data"],
+                        }
+                    }
+                )
+    return parts
+
+
 def build_multimodal_user_message(
     content_parts: list[dict[str, Any]],
     api_format: str,
@@ -157,7 +190,7 @@ def build_multimodal_user_message(
         content_parts: List of content block dicts produced by
             :func:`extract_multimodal_content`.
         api_format: Target API format (e.g. ``"openai-chat"``,
-            ``"anthropic"``, ``"gemini"``).
+            ``"anthropic"``, ``"gemini"``, ``"google-interactions"``).
 
     Returns:
         A user message dict ready to append to the conversation.
@@ -174,25 +207,16 @@ def build_multimodal_user_message(
         return {"role": "user", "content": parts}
 
     elif api_format == "anthropic":
-        # Anthropic uses the same format as our canonical content blocks
         return {"role": "user", "content": content_parts}
 
     elif api_format == "gemini":
-        parts = []
-        for part in content_parts:
-            if part.get("type") == "text":
-                parts.append({"text": part["text"]})
-            elif part.get("type") == "image":
-                source = part["source"]
-                parts.append(
-                    {
-                        "inline_data": {
-                            "mime_type": source["media_type"],
-                            "data": source["data"],
-                        }
-                    }
-                )
-        return {"role": "user", "parts": parts}
+        return {"role": "user", "parts": _convert_google_parts(content_parts)}
+
+    elif api_format == "google-interactions":
+        return {
+            "type": "user_input",
+            "content": _convert_google_parts(content_parts, interactions=True),
+        }
 
     # Fallback: text only
     texts = [p["text"] for p in content_parts if p.get("type") == "text"]

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -163,6 +163,10 @@ class ToolCall:
         # Vendor-specific formats (anthropic, gemini) are tried before generic
         # OpenAI formats because the OpenAI parsers are lenient and may
         # successfully (but incorrectly) parse Anthropic/Gemini dicts.
+        # google-interactions shares key names with anthropic (type/id/name),
+        # but anthropic checks for type="tool_use" so it rejects
+        # type="function_call" dicts. Placed before openai-responses which
+        # is the most lenient parser.
         for fmt in (
             "anthropic",
             "gemini",

--- a/src/toolregistry/llm/tool_calls.py
+++ b/src/toolregistry/llm/tool_calls.py
@@ -22,6 +22,7 @@ API_FORMATS = Literal[
     "open-responses",  # alias for openai-responses
     "anthropic",
     "gemini",
+    "google-interactions",
     "rosetta-ir",
 ]
 
@@ -61,6 +62,14 @@ def _normalize_api_format(api_format: API_FORMATS) -> API_FORMATS:
 
 # ── Rosetta tool ops accessors ─────────────────────────────────────
 
+_FORMAT_TO_PROVIDER: dict[str, str] = {
+    "openai-chat": "openai_chat",
+    "openai-responses": "openai_responses",
+    "anthropic": "anthropic",
+    "gemini": "google",
+    "google-interactions": "google_interactions",
+}
+
 
 def _get_tool_ops(api_format: API_FORMATS) -> Any:
     """Return the rosetta ToolOps class for the given format.
@@ -74,23 +83,12 @@ def _get_tool_ops(api_format: API_FORMATS) -> Any:
     Raises:
         ValueError: If the format is unsupported.
     """
-    if api_format == "openai-chat":
-        from llm_rosetta.converters.openai_chat import OpenAIChatToolOps
+    provider = _FORMAT_TO_PROVIDER.get(api_format)
+    if provider is None:
+        raise ValueError(f"Unsupported API format: {api_format}")
+    from ._rosetta import _get_tool_ops as _rosetta_get
 
-        return OpenAIChatToolOps
-    elif api_format == "openai-responses":
-        from llm_rosetta.converters.openai_responses import OpenAIResponsesToolOps
-
-        return OpenAIResponsesToolOps
-    elif api_format == "anthropic":
-        from llm_rosetta.converters.anthropic import AnthropicToolOps
-
-        return AnthropicToolOps
-    elif api_format == "gemini":
-        from llm_rosetta.converters.google_genai import GoogleGenAIToolOps
-
-        return GoogleGenAIToolOps
-    raise ValueError(f"Unsupported API format: {api_format}")
+    return _rosetta_get(provider)
 
 
 # ── Internal types ─────────────────────────────────────────────────
@@ -165,7 +163,13 @@ class ToolCall:
         # Vendor-specific formats (anthropic, gemini) are tried before generic
         # OpenAI formats because the OpenAI parsers are lenient and may
         # successfully (but incorrectly) parse Anthropic/Gemini dicts.
-        for fmt in ("anthropic", "gemini", "openai-chat", "openai-responses"):
+        for fmt in (
+            "anthropic",
+            "gemini",
+            "google-interactions",
+            "openai-chat",
+            "openai-responses",
+        ):
             try:
                 ops = _get_tool_ops(fmt)
                 ir = ops.p_tool_call_to_ir(tc_dict)
@@ -178,7 +182,8 @@ class ToolCall:
 
         raise TypeError(
             f"Unsupported tool call format: {type(tool_call)}. "
-            f"Expected OpenAI, Anthropic, or Gemini tool call format."
+            f"Expected OpenAI, Anthropic, Gemini, or Google Interactions "
+            f"tool call format."
         )
 
 
@@ -374,6 +379,8 @@ def build_assistant_messages(
         return [{"role": "assistant", "content": provider_calls}]
     elif api_format == "gemini":
         return [{"role": "model", "parts": provider_calls}]
+    elif api_format == "google-interactions":
+        return provider_calls
     raise ValueError(f"Unsupported API format: {api_format}")
 
 
@@ -435,6 +442,8 @@ def build_tool_result_messages(
         return [{"role": "user", "content": provider_results}]
     elif api_format == "gemini":
         return [{"role": "user", "parts": provider_results}]
+    elif api_format == "google-interactions":
+        return provider_results
     raise ValueError(f"Unsupported API format: {api_format}")
 
 

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -474,8 +474,8 @@ class Tool:
         Returns:
             Provider-specific tool definition dict.
         """
-        from .llm._rosetta import _get_tool_ops, _make_ir_tool_definition
-        from .llm.tool_calls import _normalize_api_format
+        from .llm._rosetta import _make_ir_tool_definition
+        from .llm.tool_calls import _get_tool_ops, _normalize_api_format
         from ._vendor.jsonschema import flatten_schema
 
         api_format = _normalize_api_format(api_format)
@@ -504,21 +504,16 @@ class Tool:
 
         if api_format == "rosetta-ir":
             return ir_tool
-        elif api_format == "openai-chat":
-            return _get_tool_ops("openai_chat").ir_tool_definition_to_p(ir_tool)
-        elif api_format == "openai-responses":
-            return _get_tool_ops("openai_responses").ir_tool_definition_to_p(ir_tool)
-        elif api_format == "anthropic":
-            return _get_tool_ops("anthropic").ir_tool_definition_to_p(ir_tool)
-        elif api_format == "gemini":
-            result = _get_tool_ops("google").ir_tool_definition_to_p(ir_tool)
+
+        ops = _get_tool_ops(api_format)
+        result = ops.ir_tool_definition_to_p(ir_tool)
+
+        if api_format == "gemini":
             # Unwrap the function_declarations wrapper to return a single
             # tool definition, consistent with other format outputs.
             return result["function_declarations"][0]
-        elif api_format == "google-interactions":
-            return _get_tool_ops("google_interactions").ir_tool_definition_to_p(ir_tool)
-        else:
-            raise ValueError(f"Unsupported API format: {api_format}")
+
+        return result
 
     def get_json_schema(
         self,

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -474,7 +474,7 @@ class Tool:
         Returns:
             Provider-specific tool definition dict.
         """
-        from .llm._rosetta import _make_ir_tool_definition
+        from .llm._rosetta import _get_tool_ops, _make_ir_tool_definition
         from .llm.tool_calls import _normalize_api_format
         from ._vendor.jsonschema import flatten_schema
 
@@ -505,24 +505,18 @@ class Tool:
         if api_format == "rosetta-ir":
             return ir_tool
         elif api_format == "openai-chat":
-            from .llm._rosetta import _get_openai_chat_tool_ops
-
-            return _get_openai_chat_tool_ops().ir_tool_definition_to_p(ir_tool)
+            return _get_tool_ops("openai_chat").ir_tool_definition_to_p(ir_tool)
         elif api_format == "openai-responses":
-            from .llm._rosetta import _get_openai_responses_tool_ops
-
-            return _get_openai_responses_tool_ops().ir_tool_definition_to_p(ir_tool)
+            return _get_tool_ops("openai_responses").ir_tool_definition_to_p(ir_tool)
         elif api_format == "anthropic":
-            from .llm._rosetta import _get_anthropic_tool_ops
-
-            return _get_anthropic_tool_ops().ir_tool_definition_to_p(ir_tool)
+            return _get_tool_ops("anthropic").ir_tool_definition_to_p(ir_tool)
         elif api_format == "gemini":
-            from .llm._rosetta import _get_google_tool_ops
-
-            result = _get_google_tool_ops().ir_tool_definition_to_p(ir_tool)
+            result = _get_tool_ops("google").ir_tool_definition_to_p(ir_tool)
             # Unwrap the function_declarations wrapper to return a single
             # tool definition, consistent with other format outputs.
             return result["function_declarations"][0]
+        elif api_format == "google-interactions":
+            return _get_tool_ops("google_interactions").ir_tool_definition_to_p(ir_tool)
         else:
             raise ValueError(f"Unsupported API format: {api_format}")
 

--- a/tests/test_anthropic_gemini_formats.py
+++ b/tests/test_anthropic_gemini_formats.py
@@ -125,7 +125,7 @@ class TestGetJsonSchemaOpenAI:
     def test_schema_sanitization_strips_unsupported_keywords(self):
         """Rosetta sanitizes schemas (removes $ref, $schema, etc)."""
         from toolregistry.llm._rosetta import (
-            _get_anthropic_tool_ops,
+            _get_tool_ops,
             _make_ir_tool_definition,
         )
 
@@ -138,7 +138,7 @@ class TestGetJsonSchemaOpenAI:
                 "properties": {"x": {"type": "string"}},
             },
         )
-        ops = _get_anthropic_tool_ops()
+        ops = _get_tool_ops("anthropic")
         result = ops.ir_tool_definition_to_p(ir_tool)
         assert "$schema" not in result["input_schema"]
 
@@ -390,3 +390,125 @@ class TestRoundTrip:
         part = recovered[0]["parts"][0]
         assert part["functionCall"]["name"] == original["functionCall"]["name"]
         assert part["functionCall"]["args"] == original["functionCall"]["args"]
+
+
+# ---------------------------------------------------------------------------
+# Google Interactions format tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetJsonSchemaGoogleInteractions:
+    """Tests for get_schema() with google-interactions format."""
+
+    def test_basic_schema_structure(self):
+        tool = _sample_tool()
+        schema = tool.get_schema(api_format="google-interactions")
+        assert schema["type"] == "function"
+        assert schema["name"] == "add"
+        assert "description" in schema
+        assert "parameters" in schema
+        assert "function_declarations" not in schema
+
+    def test_parameters_are_json_schema(self):
+        tool = _sample_tool()
+        schema = tool.get_schema(api_format="google-interactions")
+        params = schema["parameters"]
+        assert params["type"] == "object"
+        assert "a" in params["properties"]
+        assert "b" in params["properties"]
+
+
+class TestFromToolCallGoogleInteractions:
+    """Tests for ToolCall.from_tool_call() with google-interactions dicts.
+
+    Note: auto-detection via from_tool_call() may match google-interactions
+    dicts as anthropic format (both share type/id/name keys). Format-aware
+    parsing via _get_tool_ops("google-interactions") is the reliable path.
+    """
+
+    def test_format_aware_parsing(self):
+        """Direct parsing via GoogleInteractionsToolOps preserves arguments."""
+        from toolregistry.llm.tool_calls import _get_tool_ops
+
+        tc_dict = {
+            "type": "function_call",
+            "id": "fc_123",
+            "name": "add",
+            "arguments": {"a": 1, "b": 2},
+        }
+        ops = _get_tool_ops("google-interactions")
+        ir = ops.p_tool_call_to_ir(tc_dict)
+        tc = ToolCall.from_ir(ir)
+        assert tc.id == "fc_123"
+        assert tc.name == "add"
+        assert '"a": 1' in tc.arguments
+
+
+class TestRecoverAssistantMessageGoogleInteractions:
+    """Tests for build_assistant_messages() with google-interactions format."""
+
+    def test_flat_steps_returned(self):
+        tcs = [ToolCall(id="fc_1", name="add", arguments='{"a": 1, "b": 2}')]
+        result = build_assistant_messages(tcs, api_format="google-interactions")
+        assert len(result) == 1
+        step = result[0]
+        assert step["type"] == "function_call"
+        assert step["id"] == "fc_1"
+        assert step["name"] == "add"
+
+    def test_multiple_tool_calls(self):
+        tcs = [
+            ToolCall(id="fc_1", name="add", arguments='{"a": 1}'),
+            ToolCall(id="fc_2", name="sub", arguments='{"b": 2}'),
+        ]
+        result = build_assistant_messages(tcs, api_format="google-interactions")
+        assert len(result) == 2
+        assert result[0]["name"] == "add"
+        assert result[1]["name"] == "sub"
+
+
+class TestRecoverToolMessageGoogleInteractions:
+    """Tests for build_tool_result_messages() with google-interactions format."""
+
+    def test_flat_steps_with_call_id(self):
+        result = build_tool_result_messages(
+            {"fc_1": "42"}, api_format="google-interactions"
+        )
+        assert len(result) == 1
+        step = result[0]
+        assert step["type"] == "function_result"
+        assert step["call_id"] == "fc_1"
+        assert step["result"] == "42"
+
+    def test_uses_call_id_not_function_name(self):
+        """Unlike gemini, google-interactions uses call_id directly."""
+        tcs = [ToolCall(id="fc_1", name="add", arguments="{}")]
+        result = build_tool_result_messages(
+            {"fc_1": "42"}, api_format="google-interactions", tool_calls=tcs
+        )
+        step = result[0]
+        # call_id should be the tool call ID, not the function name
+        assert step["call_id"] == "fc_1"
+
+
+class TestGoogleInteractionsRoundTrip:
+    """Round-trip: parse via ToolOps -> build_assistant_messages."""
+
+    def test_round_trip(self):
+        from toolregistry.llm.tool_calls import _get_tool_ops
+
+        original = {
+            "type": "function_call",
+            "id": "fc_rt1",
+            "name": "multiply",
+            "arguments": {"x": 3, "y": 7},
+        }
+        ops = _get_tool_ops("google-interactions")
+        ir = ops.p_tool_call_to_ir(original)
+        tc = ToolCall.from_ir(ir)
+        recovered = build_assistant_messages([tc], api_format="google-interactions")
+        step = recovered[0]
+        assert step["type"] == original["type"]
+        assert step["id"] == original["id"]
+        assert step["name"] == original["name"]
+        assert step["arguments"] == original["arguments"]

--- a/tests/test_content_blocks.py
+++ b/tests/test_content_blocks.py
@@ -254,6 +254,16 @@ class TestBuildExpandedUserMessage:
         assert len(image_parts) == 1
         assert image_parts[0]["inline_data"]["mime_type"] == "image/png"
 
+    def test_google_interactions_format(self, sample_parts):
+        msg = build_multimodal_user_message(sample_parts, "google-interactions")
+        assert msg["type"] == "user_input"
+        parts = msg["content"]
+        text_parts = [p for p in parts if p.get("type") == "text"]
+        assert len(text_parts) == 3
+        image_parts = [p for p in parts if p.get("type") == "image"]
+        assert len(image_parts) == 1
+        assert image_parts[0]["mime_type"] == "image/png"
+
     def test_unknown_format_text_fallback(self, sample_parts):
         msg = build_multimodal_user_message(sample_parts, "unknown-api")
         assert msg["role"] == "user"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -377,6 +377,13 @@ class TestToolRegistryIntegration:
         assert anthropic_format[0]["name"] == "simple_func"
         assert gemini_format[0]["name"] == "simple_func"
 
+        # Verify Google Interactions format
+        interactions_format = registry.get_schemas(api_format="google-interactions")
+        assert interactions_format[0]["type"] == "function"
+        assert interactions_format[0]["name"] == "simple_func"
+        assert "parameters" in interactions_format[0]
+        assert "function_declarations" not in interactions_format[0]
+
     def test_execution_mode_integration(self):
         """Test integration with different execution modes."""
         registry = ToolRegistry(name="execution_mode_test")

--- a/tests/test_schema_sanitization.py
+++ b/tests/test_schema_sanitization.py
@@ -92,7 +92,9 @@ def fn_nested_optional(
 class TestSchemaSanitization:
     """Verify that get_schema() strips Pydantic v2 artifacts."""
 
-    @pytest.mark.parametrize("api_format", ["openai-chat", "anthropic", "gemini"])
+    @pytest.mark.parametrize(
+        "api_format", ["openai-chat", "anthropic", "gemini", "google-interactions"]
+    )
     def test_no_title_in_schema(self, api_format: str):
         """title keys should be stripped from output schemas."""
         tool = Tool.from_function(fn_optional_int)
@@ -103,7 +105,7 @@ class TestSchemaSanitization:
             params = schema["function"]["parameters"]
         elif api_format == "anthropic":
             params = schema["input_schema"]
-        elif api_format == "gemini":
+        elif api_format in ("gemini", "google-interactions"):
             params = schema.get("parameters", schema)
         else:
             params = schema
@@ -111,7 +113,9 @@ class TestSchemaSanitization:
         found = _collect_keys_recursive(params, {"title"})
         assert not found, f"Found 'title' keys in {api_format} schema: {params}"
 
-    @pytest.mark.parametrize("api_format", ["openai-chat", "anthropic", "gemini"])
+    @pytest.mark.parametrize(
+        "api_format", ["openai-chat", "anthropic", "gemini", "google-interactions"]
+    )
     def test_no_nullable_in_schema(self, api_format: str):
         """nullable keys should be stripped from output schemas."""
         tool = Tool.from_function(fn_multiple_optional)
@@ -121,7 +125,7 @@ class TestSchemaSanitization:
             params = schema["function"]["parameters"]
         elif api_format == "anthropic":
             params = schema["input_schema"]
-        elif api_format == "gemini":
+        elif api_format in ("gemini", "google-interactions"):
             params = schema.get("parameters", schema)
         else:
             params = schema
@@ -129,7 +133,9 @@ class TestSchemaSanitization:
         found = _collect_keys_recursive(params, {"nullable"})
         assert not found, f"Found 'nullable' keys in {api_format} schema: {params}"
 
-    @pytest.mark.parametrize("api_format", ["openai-chat", "anthropic", "gemini"])
+    @pytest.mark.parametrize(
+        "api_format", ["openai-chat", "anthropic", "gemini", "google-interactions"]
+    )
     def test_no_anyof_null_in_schema(self, api_format: str):
         """anyOf with {type: null} branches should be collapsed."""
         tool = Tool.from_function(fn_multiple_optional)
@@ -139,7 +145,7 @@ class TestSchemaSanitization:
             params = schema["function"]["parameters"]
         elif api_format == "anthropic":
             params = schema["input_schema"]
-        elif api_format == "gemini":
+        elif api_format in ("gemini", "google-interactions"):
             params = schema.get("parameters", schema)
         else:
             params = schema

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -130,6 +130,15 @@ class TestTool:
         assert schema["name"] == sample_tool.name
         assert "parameters" in schema
 
+    def test_get_json_schema_google_interactions_format(self, sample_tool):
+        """Test getting JSON schema in Google Interactions format."""
+        schema = sample_tool.get_schema("google-interactions")
+
+        assert schema["type"] == "function"
+        assert schema["name"] == sample_tool.name
+        assert "parameters" in schema
+        assert "function_declarations" not in schema
+
     def test_get_json_schema_unsupported_format_raises_error(self, sample_tool):
         """Test that unsupported API format raises ValueError."""
         with pytest.raises(ValueError, match="Unsupported API format"):
@@ -370,6 +379,11 @@ class TestThinkAugmented:
     def test_toolcall_reason_in_gemini_format(self, sample_tool):
         """Test that toolcall_reason appears in Gemini format schema."""
         schema = sample_tool.get_schema("gemini")
+        assert "toolcall_reason" in schema["parameters"]["properties"]
+
+    def test_toolcall_reason_in_google_interactions_format(self, sample_tool):
+        """Test that toolcall_reason appears in Google Interactions format."""
+        schema = sample_tool.get_schema("google-interactions")
         assert "toolcall_reason" in schema["parameters"]["properties"]
 
     def test_toolcall_reason_stripped_on_run(self, sample_tool):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,6 +39,13 @@ GEMINI_TC = {
     "functionCall": {"name": "gemini_func", "args": {"z": 30}},
 }
 
+GOOGLE_INTERACTIONS_TC = {
+    "type": "function_call",
+    "id": "fc_int_123",
+    "name": "interactions_func",
+    "arguments": {"w": 40},
+}
+
 
 # ---------------------------------------------------------------------------
 # ToolCall
@@ -86,6 +93,18 @@ class TestToolCall:
         tc = ToolCall.from_tool_call(GEMINI_TC)
 
         assert tc.name == "gemini_func"
+
+    def test_from_tool_call_google_interactions_via_ops(self):
+        """Test parsing Google Interactions dict via format-aware ToolOps."""
+        from toolregistry.llm.tool_calls import _get_tool_ops
+
+        ops = _get_tool_ops("google-interactions")
+        ir = ops.p_tool_call_to_ir(GOOGLE_INTERACTIONS_TC)
+        tc = ToolCall.from_ir(ir)
+
+        assert tc.id == "fc_int_123"
+        assert tc.name == "interactions_func"
+        assert '"w": 40' in tc.arguments
 
     def test_from_tool_call_unsupported_raises_error(self):
         """Test that unsupported format raises TypeError."""
@@ -338,6 +357,20 @@ class TestBuildAssistantMessage:
         assert messages[0]["role"] == "model"
         assert "functionCall" in messages[0]["parts"][0]
 
+    def test_google_interactions_format(self):
+        tool_calls = [
+            ToolCall(id="call_1", name="test_function", arguments='{"param": "value"}')
+        ]
+
+        messages = build_assistant_messages(
+            tool_calls, api_format="google-interactions"
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["type"] == "function_call"
+        assert messages[0]["id"] == "call_1"
+        assert messages[0]["name"] == "test_function"
+
     def test_filters_invalid_tool_calls(self):
         """Empty name or arguments are skipped."""
         tool_calls = [
@@ -416,6 +449,16 @@ class TestBuildToolResponse:
         assert messages[0]["role"] == "user"
         assert "functionResponse" in messages[0]["parts"][0]
         assert messages[0]["parts"][0]["functionResponse"]["name"] == "my_func"
+
+    def test_google_interactions_format(self):
+        messages = build_tool_result_messages(
+            {"call_1": "result"}, api_format="google-interactions"
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["type"] == "function_result"
+        assert messages[0]["call_id"] == "call_1"
+        assert messages[0]["result"] == "result"
 
     def test_non_string_results_converted(self):
         messages = build_tool_result_messages(


### PR DESCRIPTION
## Summary

- Replace hand-rolled lazy imports of individual `*ToolOps` classes with delegation to `llm_rosetta.tool_ops` convenience module (0.13.0)
- Add `"google-interactions"` as new API format for Gemini 2.x Interactions API (flat step-based format)
- Bump `llm-rosetta` minimum from `>=0.7.1,<0.10.0` to `>=0.13.0`
- Eliminates deprecation warnings from `google_genai` shim — all Google format access now routes through `google_generate` and `google_interactions` directly

### Key changes
- `_rosetta.py`: 4 accessor functions → single `_get_tool_ops(provider)` wrapper
- `tool_calls.py`: if/elif chain → `_FORMAT_TO_PROVIDER` mapping dict + delegation
- `tool.py`: per-format imports → centralized `_get_tool_ops(provider)` calls
- `content_blocks.py`: extracted `_convert_google_parts()` helper, added google-interactions multimodal support

Closes #246

## Test plan

- [x] All 4 converter imports verified with llm-rosetta 0.13.0 (+ new google_interactions)
- [x] No DeprecationWarning from `google_genai` with `-W error::DeprecationWarning`
- [x] 264/265 tests pass (1 pre-existing flaky timing test unrelated to this change)
- [x] All pre-commit hooks pass (ruff, ruff-format, ty, complexipy)