### PR TITLE
feat: add remote tool source refresh for OpenAPI and MCP

### DIFF
--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -6,7 +6,13 @@ from .admin import (
     ExecutionStatus,
     TokenAuth,
 )
-from .events import ChangeCallback, ChangeEvent, ChangeEventType, PostRegisterHook
+from .events import (
+    ChangeCallback,
+    ChangeEvent,
+    ChangeEventType,
+    PostRegisterHook,
+    RefreshResult,
+)
 from .executor import (
     ExecutionContext,
     ProcessPoolBackend,
@@ -35,6 +41,7 @@ __all__ = [
     "AsyncPermissionHandler",
     "ChangeCallback",
     "ChangeEvent",
+    "RefreshResult",
     "ChangeEventType",
     "ExecutionContext",
     "ExecutionLog",

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -27,7 +27,7 @@ class RegistrationMixin:
     # Type stubs for attributes/methods from other mixins
     _tools: dict[str, Tool]
     _sub_registries: set[str]
-    _disabled: dict[str, str]
+    _disabled: dict[str, str]  # Owned by EnableDisableMixin
 
     if TYPE_CHECKING:
 
@@ -440,6 +440,11 @@ class RegistrationMixin:
         Returns:
             A :class:`RefreshResult` describing what changed.
         """
+        if index >= len(self._openapi_integrations):
+            raise IndexError(
+                f"No OpenAPI integration at index {index} "
+                f"({len(self._openapi_integrations)} registered)."
+            )
         return self._openapi_integrations[index].refresh(openapi_spec)
 
     async def refresh_from_openapi_async(
@@ -449,6 +454,11 @@ class RegistrationMixin:
         openapi_spec: dict[str, Any] | None = None,
     ) -> RefreshResult:
         """Async version of :meth:`refresh_from_openapi`."""
+        if index >= len(self._openapi_integrations):
+            raise IndexError(
+                f"No OpenAPI integration at index {index} "
+                f"({len(self._openapi_integrations)} registered)."
+            )
         return await self._openapi_integrations[index].refresh_async(openapi_spec)
 
     def refresh_from_mcp(self, index: int = 0) -> RefreshResult:
@@ -461,10 +471,20 @@ class RegistrationMixin:
         Returns:
             A :class:`RefreshResult` describing what changed.
         """
+        if index >= len(self._mcp_integrations):
+            raise IndexError(
+                f"No MCP integration at index {index} "
+                f"({len(self._mcp_integrations)} registered)."
+            )
         return self._mcp_integrations[index].refresh()
 
     async def refresh_from_mcp_async(self, index: int = 0) -> RefreshResult:
         """Async version of :meth:`refresh_from_mcp`."""
+        if index >= len(self._mcp_integrations):
+            raise IndexError(
+                f"No MCP integration at index {index} "
+                f"({len(self._mcp_integrations)} registered)."
+            )
         return await self._mcp_integrations[index].refresh_async()
 
     def refresh_all(self) -> list[RefreshResult]:

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from collections.abc import Callable
 
-from ..events import ChangeEvent, ChangeEventType
+from ..events import ChangeEvent, ChangeEventType, RefreshResult
 from ..tool import Tool
 from ..utils import HttpClientConfig, normalize_tool_name
 
@@ -27,6 +27,7 @@ class RegistrationMixin:
     # Type stubs for attributes/methods from other mixins
     _tools: dict[str, Tool]
     _sub_registries: set[str]
+    _disabled: dict[str, str]
 
     if TYPE_CHECKING:
 
@@ -86,6 +87,27 @@ class RegistrationMixin:
                 tool_name=registered_name,
             )
         )
+
+    def _unregister(self, name: str) -> bool:
+        """Remove a tool from the registry.
+
+        Args:
+            name: The registered name of the tool to remove.
+
+        Returns:
+            True if the tool was found and removed, False otherwise.
+        """
+        tool = self._tools.pop(name, None)
+        if tool is None:
+            return False
+        self._disabled.pop(name, None)
+        self._emit_change(
+            ChangeEvent(
+                event_type=ChangeEventType.UNREGISTER,
+                tool_name=name,
+            )
+        )
+        return True
 
     def register_from_mcp(
         self,
@@ -205,28 +227,30 @@ class RegistrationMixin:
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
+        spec_url: str | None = None,
         **kwargs,
     ):
         """Registers tools from OpenAPI specification synchronously.
 
         Args:
-            client (HttpClientConfig): The httpx client config instance.
-            openapi_spec (Dict[str, Any]): Parsed OpenAPI specification dictionary.
-            namespace (Union[bool, str]): Specifies namespace usage:
+            client: The HTTP client config instance.
+            openapi_spec: Parsed OpenAPI specification dictionary.
+            namespace: Specifies namespace usage:
                 - ``False``: No namespace is applied.
                 - ``True``: Namespace is derived from OpenAPI info.title.
                 - ``str``: Use the provided string as namespace.
                 Defaults to False.
-            persistent (bool): If True (default), reuse a persistent HTTP
-                client for connection pooling.
-
-        Returns:
-            Any: Result of the OpenAPI tool registration process.
+            persistent: If True (default), reuse a persistent HTTP client for
+                connection pooling.
+            spec_url: URL where the spec was originally fetched from.  Stored
+                for later ETag-based refresh via :meth:`refresh_from_openapi`.
         """
         namespace = _resolve_namespace_compat(namespace, kwargs)
         OpenAPIIntegration = _import_openapi_integration()
         openapi = OpenAPIIntegration(cast("ToolRegistry", self))
-        openapi.register_openapi_tools(client, openapi_spec, namespace, persistent)
+        openapi.register_openapi_tools(
+            client, openapi_spec, namespace, persistent, spec_url=spec_url
+        )
         self._openapi_integrations.append(openapi)
 
     async def register_from_openapi_async(
@@ -235,29 +259,25 @@ class RegistrationMixin:
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
+        spec_url: str | None = None,
         **kwargs,
     ):
         """Registers tools from OpenAPI specification asynchronously.
 
         Args:
-            client (HttpClientConfig): The httpx client config instance.
-            openapi_spec (Dict[str, Any]): Parsed OpenAPI specification dictionary.
-            namespace (Union[bool, str]): Specifies namespace usage:
-                - ``False``: No namespace is applied.
-                - ``True``: Namespace is derived from OpenAPI info.title.
-                - ``str``: Use the provided string as namespace.
-                Defaults to False.
-            persistent (bool): If True (default), reuse a persistent HTTP
-                client for connection pooling.
-
-        Returns:
-            Any: Result of the OpenAPI tool registration process.
+            client: The HTTP client config instance.
+            openapi_spec: Parsed OpenAPI specification dictionary.
+            namespace: Specifies namespace usage. Defaults to False.
+            persistent: If True (default), reuse a persistent HTTP client for
+                connection pooling.
+            spec_url: URL where the spec was originally fetched from.  Stored
+                for later ETag-based refresh via :meth:`refresh_from_openapi_async`.
         """
         namespace = _resolve_namespace_compat(namespace, kwargs)
         OpenAPIIntegration = _import_openapi_integration()
         openapi = OpenAPIIntegration(cast("ToolRegistry", self))
         await openapi.register_openapi_tools_async(
-            client, openapi_spec, namespace, persistent
+            client, openapi_spec, namespace, persistent, spec_url=spec_url
         )
         self._openapi_integrations.append(openapi)
 
@@ -400,6 +420,78 @@ class RegistrationMixin:
         return await hub.register_class_methods_async(
             cls, namespace, constructor_kwargs
         )
+
+    # ---- Refresh ----
+
+    def refresh_from_openapi(
+        self,
+        index: int = 0,
+        *,
+        openapi_spec: dict[str, Any] | None = None,
+    ) -> RefreshResult:
+        """Re-fetch the OpenAPI spec for an integration and update tools.
+
+        Args:
+            index: Index into the list of registered OpenAPI integrations
+                (in the order they were registered).  Defaults to 0.
+            openapi_spec: Optional pre-parsed spec dict.  When ``None``,
+                the spec is re-fetched from the stored URL (with ETag).
+
+        Returns:
+            A :class:`RefreshResult` describing what changed.
+        """
+        return self._openapi_integrations[index].refresh(openapi_spec)
+
+    async def refresh_from_openapi_async(
+        self,
+        index: int = 0,
+        *,
+        openapi_spec: dict[str, Any] | None = None,
+    ) -> RefreshResult:
+        """Async version of :meth:`refresh_from_openapi`."""
+        return await self._openapi_integrations[index].refresh_async(openapi_spec)
+
+    def refresh_from_mcp(self, index: int = 0) -> RefreshResult:
+        """Re-list tools from an MCP server and update the registry.
+
+        Args:
+            index: Index into the list of registered MCP integrations
+                (in the order they were registered).  Defaults to 0.
+
+        Returns:
+            A :class:`RefreshResult` describing what changed.
+        """
+        return self._mcp_integrations[index].refresh()
+
+    async def refresh_from_mcp_async(self, index: int = 0) -> RefreshResult:
+        """Async version of :meth:`refresh_from_mcp`."""
+        return await self._mcp_integrations[index].refresh_async()
+
+    def refresh_all(self) -> list[RefreshResult]:
+        """Refresh all registered remote sources (OpenAPI and MCP).
+
+        Returns:
+            A list of :class:`RefreshResult`, one per integration.
+        """
+        results: list[RefreshResult] = []
+        for integration in self._openapi_integrations:
+            results.append(integration.refresh())
+        for integration in self._mcp_integrations:
+            results.append(integration.refresh())
+        if results:
+            self._emit_change(ChangeEvent(event_type=ChangeEventType.REFRESH_ALL))
+        return results
+
+    async def refresh_all_async(self) -> list[RefreshResult]:
+        """Async version of :meth:`refresh_all`."""
+        results: list[RefreshResult] = []
+        for integration in self._openapi_integrations:
+            results.append(await integration.refresh_async())
+        for integration in self._mcp_integrations:
+            results.append(await integration.refresh_async())
+        if results:
+            self._emit_change(ChangeEvent(event_type=ChangeEventType.REFRESH_ALL))
+        return results
 
 
 def _resolve_namespace_compat(

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -73,3 +73,32 @@ Returns:
     A non-empty string to auto-disable the tool with that string as the
     reason, or ``None`` to leave the tool enabled.
 """
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    """Result of a remote source refresh operation.
+
+    Attributes:
+        source: Source type that was refreshed (``"openapi"`` or ``"mcp"``).
+        source_detail: Transport URI or spec URL identifying the source.
+        added: Names of newly discovered tools.
+        removed: Names of tools that no longer exist on the remote source.
+        updated: Names of tools whose schema or description changed.
+        unchanged: Count of tools that matched and required no update.
+        skipped: ``True`` when the remote source reported no changes
+            (e.g. HTTP 304 via ETag).
+    """
+
+    source: str
+    source_detail: str = ""
+    added: tuple[str, ...] = ()
+    removed: tuple[str, ...] = ()
+    updated: tuple[str, ...] = ()
+    unchanged: int = 0
+    skipped: bool = False
+
+    @property
+    def changed(self) -> bool:
+        """Whether the refresh produced any additions, removals, or updates."""
+        return bool(self.added or self.removed or self.updated)

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -1,4 +1,3 @@
-import logging
 import threading
 from collections.abc import Callable
 from pathlib import Path
@@ -496,7 +495,8 @@ class MCPIntegration:
         """Synchronous version of :meth:`refresh_async`."""
         from ..._async_runtime import AsyncRuntime
 
-        return AsyncRuntime.run_sync(self.refresh_async())
+        with self._refresh_lock:
+            return AsyncRuntime.run_sync(self.refresh_async())
 
     # ---- Background polling ----
 
@@ -529,7 +529,7 @@ class MCPIntegration:
             try:
                 self.refresh()
             except Exception:
-                logging.getLogger(__name__).exception("MCP refresh poll failed")
+                logger.exception("MCP refresh poll failed")
         self._schedule_next_poll()
 
     # ---- Lifecycle ----

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -1,3 +1,5 @@
+import logging
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -14,6 +16,7 @@ from mcp.types import Tool as ToolSpec
 
 from ..._vendor.structlog import get_logger
 from ._compat import get_field
+from ...events import ChangeEvent, ChangeEventType, RefreshResult
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
@@ -292,6 +295,14 @@ class MCPIntegration:
     def __init__(self, registry: ToolRegistry):
         self.registry = registry
         self._connections: list[MCPConnectionManager] = []
+        self._registered_tool_names: set[str] = set()
+        self._transport: str | dict[str, Any] | Path | None = None
+        self._resolved_ns: str | None = None
+        self._persistent: bool = True
+        self._headers: dict[str, str] | None = None
+        self._refresh_lock = threading.Lock()
+        self._poll_timer: threading.Timer | None = None
+        self._poll_interval: float | None = None
 
     async def register_mcp_tools_async(
         self,
@@ -303,23 +314,22 @@ class MCPIntegration:
         """Async implementation to register all tools from an MCP server.
 
         Args:
-            transport (Union[str, Dict[str, Any], Path]): Can be:
-                - URL string (http(s)://, ws(s)://)
-                - Path to script file (.py, .js)
-                - Dict with "command", "args", "env" keys for stdio transport
-            namespace (Union[bool, str]): Whether to prefix tool names with a namespace.
-                - If ``False``, no namespace is used.
-                - If ``True``, the namespace is derived from the server info name.
-                - If a string is provided, it is used as the namespace.
-                Defaults to False.
-            persistent (bool): If True (default), keep the connection open
-                across tool calls. If False, create a new connection per call.
-            headers (Optional[Dict[str, str]]): HTTP headers for SSE or
-                streamable-http transports (e.g. authentication).
+            transport: MCP server transport — URL string, script path, or
+                stdio dict with ``command``, ``args``, ``env`` keys.
+            namespace: Whether to prefix tool names with a namespace.
+                ``False`` (default) means no namespace, ``True`` derives it
+                from the server info, or pass a string directly.
+            persistent: If True (default), keep the connection open across
+                tool calls.
+            headers: HTTP headers for SSE or streamable-http transports.
 
         Raises:
             RuntimeError: If connection to server fails.
         """
+        self._transport = transport
+        self._persistent = persistent
+        self._headers = headers
+
         connection = MCPConnectionManager(
             transport=transport,
             persistent=persistent,
@@ -327,29 +337,27 @@ class MCPIntegration:
         )
         self._connections.append(connection)
 
-        # Use a temporary connection for tool discovery
         async with MCPClient(transport, headers=headers) as client:
             server_info: Implementation | None = client.server_info
 
             if isinstance(namespace, str):
                 resolved_ns = namespace
-            elif namespace:  # namespace is True
+            elif namespace:
                 resolved_ns = server_info.name if server_info else "MCP sse service"
             else:
                 resolved_ns = None
+            self._resolved_ns = resolved_ns
 
-            # Get available tools from server
             tools_response: list[ToolSpec] = await client.list_tools()
 
-            # Register each tool with the shared connection manager
             for tool_spec in tools_response:
                 mcp_tool = MCPTool.from_tool_json(
                     tool_spec=tool_spec,
                     connection=connection,
                     namespace=resolved_ns,
                 )
-
                 self.registry.register(mcp_tool, namespace=resolved_ns)
+                self._registered_tool_names.add(mcp_tool.name)
 
     def register_mcp_tools(
         self,
@@ -361,19 +369,12 @@ class MCPIntegration:
         """Register all tools from an MCP server (synchronous entry point).
 
         Args:
-            transport (Union[str, Dict[str, Any], Path]): Can be:
-                - URL string (http(s)://, ws(s)://)
-                - Path to script file (.py, .js)
-                - Dict with "command", "args", "env" keys for stdio transport
-            namespace (Union[bool, str]): Whether to prefix tool names with a namespace.
-                - If ``False``, no namespace is used.
-                - If ``True``, the namespace is derived from the server info name.
-                - If a string is provided, it is used as the namespace.
-                Defaults to False.
-            persistent (bool): If True (default), keep the connection open
-                across tool calls. If False, create a new connection per call.
-            headers (Optional[Dict[str, str]]): HTTP headers for SSE or
-                streamable-http transports (e.g. authentication).
+            transport: MCP server transport — URL string, script path, or
+                stdio dict with ``command``, ``args``, ``env`` keys.
+            namespace: Whether to prefix tool names with a namespace.
+            persistent: If True (default), keep the connection open across
+                tool calls.
+            headers: HTTP headers for SSE or streamable-http transports.
         """
         from ..._async_runtime import AsyncRuntime
 
@@ -383,8 +384,159 @@ class MCPIntegration:
             )
         )
 
+    # ---- Refresh ----
+
+    async def refresh_async(self) -> RefreshResult:
+        """Re-list tools from the MCP server and synchronise the registry.
+
+        Opens a temporary client connection to call ``list_tools()``,
+        compares with the currently registered set, and applies additions,
+        removals, and updates.
+
+        Returns:
+            A :class:`RefreshResult` describing what changed.
+
+        Raises:
+            ValueError: If transport was not stored (should not happen
+                after a successful registration).
+        """
+        if self._transport is None:
+            raise ValueError("Cannot refresh: no transport configured.")
+
+        if not self._connections:
+            raise ValueError("Cannot refresh: no connection available.")
+        connection = self._connections[0]
+
+        # Build source_detail for the result
+        transport = self._transport
+        if isinstance(transport, dict):
+            cmd = transport.get("command", "")
+            args = " ".join(transport.get("args", []))
+            source_detail = f"stdio:{cmd} {args}".strip()
+        else:
+            source_detail = str(transport)
+
+        async with MCPClient(self._transport, headers=self._headers) as client:
+            tools_response: list[ToolSpec] = await client.list_tools()
+
+        sep = getattr(self.registry, "_name_sep", "-")
+
+        # Build candidate tools from the fresh response
+        new_tools: dict[str, MCPTool] = {}
+        for tool_spec in tools_response:
+            candidate = MCPTool.from_tool_json(
+                tool_spec=tool_spec,
+                connection=connection,
+                namespace=self._resolved_ns,
+            )
+            candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
+            new_tools[candidate.name] = candidate
+
+        old_names = set(self._registered_tool_names)
+        new_names = set(new_tools.keys())
+
+        # Snapshot disabled state
+        disabled_snapshot: dict[str, str] = {}
+        for name in old_names:
+            if not self.registry.is_enabled(name):
+                disabled_snapshot[name] = self.registry.get_disable_reason(name) or ""
+
+        to_remove = old_names - new_names
+        to_add = new_names - old_names
+        maybe_updated = old_names & new_names
+
+        added: list[str] = []
+        removed: list[str] = []
+        updated: list[str] = []
+        unchanged = 0
+
+        for name in to_remove:
+            self.registry._unregister(name)
+            removed.append(name)
+
+        for name in to_add:
+            self.registry.register(new_tools[name], namespace=self._resolved_ns)
+            added.append(name)
+
+        for name in maybe_updated:
+            candidate = new_tools[name]
+            existing = self.registry._tools.get(name)
+            if existing and (
+                existing.parameters != candidate.parameters
+                or existing.description != candidate.description
+            ):
+                self.registry._tools[name] = candidate
+                self.registry._emit_change(
+                    ChangeEvent(
+                        event_type=ChangeEventType.REFRESH,
+                        tool_name=name,
+                    )
+                )
+                updated.append(name)
+            else:
+                unchanged += 1
+
+        # Restore disabled state for surviving tools
+        for name, reason in disabled_snapshot.items():
+            if name in new_names:
+                self.registry.disable(name, reason)
+
+        self._registered_tool_names = new_names
+
+        return RefreshResult(
+            source="mcp",
+            source_detail=source_detail,
+            added=tuple(added),
+            removed=tuple(removed),
+            updated=tuple(updated),
+            unchanged=unchanged,
+        )
+
+    def refresh(self) -> RefreshResult:
+        """Synchronous version of :meth:`refresh_async`."""
+        from ..._async_runtime import AsyncRuntime
+
+        return AsyncRuntime.run_sync(self.refresh_async())
+
+    # ---- Background polling ----
+
+    def start_polling(self, interval: float) -> None:
+        """Start periodic background refresh.
+
+        Args:
+            interval: Seconds between refresh attempts.
+        """
+        self.stop_polling()
+        self._poll_interval = interval
+        self._schedule_next_poll()
+
+    def stop_polling(self) -> None:
+        """Stop background polling if active."""
+        self._poll_interval = None
+        if self._poll_timer is not None:
+            self._poll_timer.cancel()
+            self._poll_timer = None
+
+    def _schedule_next_poll(self) -> None:
+        if self._poll_interval is None:
+            return
+        self._poll_timer = threading.Timer(self._poll_interval, self._poll_tick)
+        self._poll_timer.daemon = True
+        self._poll_timer.start()
+
+    def _poll_tick(self) -> None:
+        with self._refresh_lock:
+            try:
+                self.refresh()
+            except Exception:
+                logging.getLogger(__name__).exception("MCP refresh poll failed")
+        self._schedule_next_poll()
+
+    # ---- Lifecycle ----
+
     async def close(self) -> None:
         """Close all persistent connections (async)."""
+        self.stop_polling()
         for connection in self._connections:
             await connection.close()
         self._connections.clear()
@@ -395,6 +547,7 @@ class MCPIntegration:
         Shuts down background loop threads without requiring an
         event loop in the calling thread.
         """
+        self.stop_polling()
         for connection in self._connections:
             connection.close_sync()
         self._connections.clear()

--- a/src/toolregistry/integrations/openapi/__init__.py
+++ b/src/toolregistry/integrations/openapi/__init__.py
@@ -1,6 +1,11 @@
 from ...utils import HttpClientConfig, HttpxClientConfig
 from .integration import OpenAPIIntegration, OpenAPITool, OpenAPIToolWrapper
-from .utils import load_openapi_spec, load_openapi_spec_async
+from .utils import (
+    load_openapi_spec,
+    load_openapi_spec_async,
+    load_openapi_spec_conditional,
+    load_openapi_spec_conditional_async,
+)
 
 __all__ = [
     "OpenAPIIntegration",
@@ -11,4 +16,6 @@ __all__ = [
     "HttpxClientConfig",  # deprecated alias
     "load_openapi_spec",
     "load_openapi_spec_async",
+    "load_openapi_spec_conditional",
+    "load_openapi_spec_conditional_async",
 ]

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -1,4 +1,8 @@
+import logging
+import threading
 from typing import Any
+
+from ...events import ChangeEvent, ChangeEventType, RefreshResult
 
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
@@ -206,6 +210,9 @@ class OpenAPITool(Tool):
         return tool
 
 
+logger = logging.getLogger(__name__)
+
+
 class OpenAPIIntegration:
     """Handles integration with OpenAPI services for tool registration.
 
@@ -216,6 +223,16 @@ class OpenAPIIntegration:
     def __init__(self, registry: ToolRegistry) -> None:
         self.registry: ToolRegistry = registry
         self._client_configs: list[HttpClientConfig] = []
+        self._registered_tool_names: set[str] = set()
+        self._spec_url: str | None = None
+        self._client_config: HttpClientConfig | None = None
+        self._resolved_ns: str | None = None
+        self._persistent: bool = True
+        self._openapi_spec: dict[str, Any] | None = None
+        self._etag: str | None = None
+        self._refresh_lock = threading.Lock()
+        self._poll_timer: threading.Timer | None = None
+        self._poll_interval: float | None = None
 
     async def register_openapi_tools_async(
         self,
@@ -223,25 +240,29 @@ class OpenAPIIntegration:
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
+        spec_url: str | None = None,
     ) -> None:
         """Asynchronously register all tools defined in an OpenAPI specification.
 
         Args:
-            client_config (HttpClientConfig): Configuration for the HTTP client.
-            openapi_spec (Dict[str, Any]): The OpenAPI specification dictionary.
-            namespace (Union[bool, str]): Whether to prefix tool names with a namespace.
+            client_config: Configuration for the HTTP client.
+            openapi_spec: The OpenAPI specification dictionary.
+            namespace: Whether to prefix tool names with a namespace.
                 - If ``False``, no namespace is used.
                 - If ``True``, the namespace is derived from the OpenAPI info.title.
                 - If a string is provided, it is used as the namespace.
                 Defaults to False.
-            persistent (bool): If True (default), reuse a persistent HTTP
-                client for connection pooling.
-
-        Returns:
-            None
+            persistent: If True (default), reuse a persistent HTTP client for
+                connection pooling.
+            spec_url: Optional URL where the spec was fetched from.  Stored for
+                later ETag-based refresh via :meth:`refresh_async`.
         """
         try:
             self._client_configs.append(client_config)
+            self._client_config = client_config
+            self._persistent = persistent
+            self._spec_url = spec_url
+            self._openapi_spec = openapi_spec
 
             resolved_ns = (
                 namespace
@@ -250,8 +271,8 @@ class OpenAPIIntegration:
                 if namespace
                 else None
             )
+            self._resolved_ns = resolved_ns
 
-            # Process paths sequentially
             for path, methods in openapi_spec.get("paths", {}).items():
                 for method, spec in methods.items():
                     if method.lower() not in ["get", "post", "put", "delete"]:
@@ -266,6 +287,7 @@ class OpenAPIIntegration:
                         persistent=persistent,
                     )
                     self.registry.register(open_api_tool, namespace=resolved_ns)
+                    self._registered_tool_names.add(open_api_tool.name)
         except Exception as e:
             raise ValueError(f"Failed to register OpenAPI tools: {e}")
 
@@ -275,38 +297,244 @@ class OpenAPIIntegration:
         openapi_spec: dict[str, Any],
         namespace: bool | str = False,
         persistent: bool = True,
+        spec_url: str | None = None,
     ) -> None:
         """Synchronously register all tools defined in an OpenAPI specification.
 
         Args:
-            client_config (HttpClientConfig): Configuration for the HTTP client.
-            openapi_spec (Dict[str, Any]): The OpenAPI specification dictionary.
-            namespace (Union[bool, str]): Whether to prefix tool names with a namespace.
-                - If ``False``, no namespace is used.
-                - If ``True``, the namespace is derived from the OpenAPI info.title.
-                - If a string is provided, it is used as the namespace.
+            client_config: Configuration for the HTTP client.
+            openapi_spec: The OpenAPI specification dictionary.
+            namespace: Whether to prefix tool names with a namespace.
                 Defaults to False.
-            persistent (bool): If True (default), reuse a persistent HTTP
-                client for connection pooling.
-
-        Returns:
-            None
+            persistent: If True (default), reuse a persistent HTTP client for
+                connection pooling.
+            spec_url: Optional URL where the spec was fetched from.
         """
         from ..._async_runtime import AsyncRuntime
 
         AsyncRuntime.run_sync(
             self.register_openapi_tools_async(
-                client_config, openapi_spec, namespace, persistent
+                client_config, openapi_spec, namespace, persistent, spec_url
             )
         )
 
+    # ---- Refresh ----
+
+    async def _resolve_spec(
+        self,
+        openapi_spec: dict[str, Any] | None,
+    ) -> tuple[dict[str, Any] | None, bool]:
+        """Resolve the OpenAPI spec to use for refresh.
+
+        Returns:
+            ``(spec, skipped)`` — *spec* is ``None`` only when *skipped* is
+            ``True`` (ETag 304).
+        """
+        if openapi_spec is not None:
+            return openapi_spec, False
+
+        if self._spec_url:
+            from .utils import load_openapi_spec_conditional_async
+
+            spec, new_etag = await load_openapi_spec_conditional_async(
+                self._spec_url, self._etag
+            )
+            if spec is None:
+                return None, True
+            self._etag = new_etag
+            return spec, False
+
+        if self._openapi_spec is not None:
+            return self._openapi_spec, False
+
+        raise ValueError(
+            "Cannot refresh: no spec_url was provided at registration "
+            "time and no spec dict was passed to refresh()."
+        )
+
+    def _build_tool_map(
+        self,
+        openapi_spec: dict[str, Any],
+        client_config: HttpClientConfig,
+    ) -> dict[str, OpenAPITool]:
+        """Build ``{name: OpenAPITool}`` from a parsed spec."""
+        sep = getattr(self.registry, "_name_sep", "-")
+        tools: dict[str, OpenAPITool] = {}
+        for path, methods in openapi_spec.get("paths", {}).items():
+            for method, spec in methods.items():
+                if method.lower() not in ["get", "post", "put", "delete"]:
+                    continue
+                candidate = OpenAPITool.from_openapi_spec(
+                    client_config=client_config,
+                    path=path,
+                    method=method,
+                    spec=spec,
+                    namespace=self._resolved_ns,
+                    persistent=self._persistent,
+                )
+                candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
+                tools[candidate.name] = candidate
+        return tools
+
+    def _apply_diff(
+        self,
+        new_tools: dict[str, OpenAPITool],
+    ) -> tuple[list[str], list[str], list[str], int]:
+        """Diff *new_tools* against registered tools and apply changes.
+
+        Returns:
+            ``(added, removed, updated, unchanged)`` lists/count.
+        """
+        old_names = set(self._registered_tool_names)
+        new_names = set(new_tools.keys())
+        sep = getattr(self.registry, "_name_sep", "-")
+
+        # Snapshot disabled state
+        disabled_snapshot: dict[str, str] = {}
+        for name in old_names:
+            if not self.registry.is_enabled(name):
+                disabled_snapshot[name] = self.registry.get_disable_reason(name) or ""
+
+        added: list[str] = []
+        removed: list[str] = []
+        updated: list[str] = []
+        unchanged = 0
+
+        for name in old_names - new_names:
+            self.registry._unregister(name)
+            removed.append(name)
+
+        for name in new_names - old_names:
+            self.registry.register(new_tools[name], namespace=self._resolved_ns)
+            added.append(name)
+
+        for name in old_names & new_names:
+            candidate = new_tools[name]
+            existing = self.registry._tools.get(name)
+            if existing and (
+                existing.parameters != candidate.parameters
+                or existing.description != candidate.description
+            ):
+                candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
+                self.registry._tools[name] = candidate
+                self.registry._emit_change(
+                    ChangeEvent(
+                        event_type=ChangeEventType.REFRESH,
+                        tool_name=name,
+                    )
+                )
+                updated.append(name)
+            else:
+                unchanged += 1
+
+        for name, reason in disabled_snapshot.items():
+            if name in new_names:
+                self.registry.disable(name, reason)
+
+        self._registered_tool_names = new_names
+        return added, removed, updated, unchanged
+
+    async def refresh_async(
+        self,
+        openapi_spec: dict[str, Any] | None = None,
+    ) -> RefreshResult:
+        """Re-fetch the OpenAPI spec and synchronise registered tools.
+
+        Args:
+            openapi_spec: A pre-parsed spec dict.  When ``None``, the spec is
+                re-fetched from :attr:`_spec_url` (with ETag support) or the
+                last stored spec is reused.
+
+        Returns:
+            A :class:`RefreshResult` describing what changed.
+
+        Raises:
+            ValueError: If no spec can be obtained (no URL and no stored spec).
+        """
+        source_detail = self._spec_url or (
+            self._client_config.base_url if self._client_config else ""
+        )
+
+        resolved, skipped = await self._resolve_spec(openapi_spec)
+        if skipped:
+            return RefreshResult(
+                source="openapi", source_detail=source_detail, skipped=True
+            )
+        assert resolved is not None
+        self._openapi_spec = resolved
+
+        if self._client_config is None:
+            raise ValueError(
+                "Cannot refresh: no client config stored. "
+                "Call register_openapi_tools() first."
+            )
+
+        new_tools = self._build_tool_map(resolved, self._client_config)
+        added, removed, updated, unchanged = self._apply_diff(new_tools)
+
+        return RefreshResult(
+            source="openapi",
+            source_detail=source_detail,
+            added=tuple(added),
+            removed=tuple(removed),
+            updated=tuple(updated),
+            unchanged=unchanged,
+        )
+
+    def refresh(
+        self,
+        openapi_spec: dict[str, Any] | None = None,
+    ) -> RefreshResult:
+        """Synchronous version of :meth:`refresh_async`."""
+        from ..._async_runtime import AsyncRuntime
+
+        return AsyncRuntime.run_sync(self.refresh_async(openapi_spec))
+
+    # ---- Background polling ----
+
+    def start_polling(self, interval: float) -> None:
+        """Start periodic background refresh.
+
+        Args:
+            interval: Seconds between refresh attempts.
+        """
+        self.stop_polling()
+        self._poll_interval = interval
+        self._schedule_next_poll()
+
+    def stop_polling(self) -> None:
+        """Stop background polling if active."""
+        self._poll_interval = None
+        if self._poll_timer is not None:
+            self._poll_timer.cancel()
+            self._poll_timer = None
+
+    def _schedule_next_poll(self) -> None:
+        if self._poll_interval is None:
+            return
+        self._poll_timer = threading.Timer(self._poll_interval, self._poll_tick)
+        self._poll_timer.daemon = True
+        self._poll_timer.start()
+
+    def _poll_tick(self) -> None:
+        with self._refresh_lock:
+            try:
+                self.refresh()
+            except Exception:
+                logger.exception("OpenAPI refresh poll failed")
+        self._schedule_next_poll()
+
+    # ---- Lifecycle ----
+
     def close(self) -> None:
         """Close all persistent HTTP clients (sync)."""
+        self.stop_polling()
         for config in self._client_configs:
             config.close()
 
     async def close_async(self) -> None:
         """Close all persistent HTTP clients (async)."""
+        self.stop_polling()
         for config in self._client_configs:
             await config.close_async()
         self._client_configs.clear()

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -387,7 +387,6 @@ class OpenAPIIntegration:
         """
         old_names = set(self._registered_tool_names)
         new_names = set(new_tools.keys())
-        sep = getattr(self.registry, "_name_sep", "-")
 
         # Snapshot disabled state
         disabled_snapshot: dict[str, str] = {}
@@ -415,7 +414,6 @@ class OpenAPIIntegration:
                 existing.parameters != candidate.parameters
                 or existing.description != candidate.description
             ):
-                candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
@@ -488,7 +486,8 @@ class OpenAPIIntegration:
         """Synchronous version of :meth:`refresh_async`."""
         from ..._async_runtime import AsyncRuntime
 
-        return AsyncRuntime.run_sync(self.refresh_async(openapi_spec))
+        with self._refresh_lock:
+            return AsyncRuntime.run_sync(self.refresh_async(openapi_spec))
 
     # ---- Background polling ----
 
@@ -531,6 +530,7 @@ class OpenAPIIntegration:
         self.stop_polling()
         for config in self._client_configs:
             config.close()
+        self._client_configs.clear()
 
     async def close_async(self) -> None:
         """Close all persistent HTTP clients (async)."""

--- a/src/toolregistry/integrations/openapi/utils.py
+++ b/src/toolregistry/integrations/openapi/utils.py
@@ -153,3 +153,69 @@ def load_openapi_spec(uri: str) -> dict[str, Any]:
     Raises:
         ValueError: If URI retrieval, parsing, or decoding fails."""
     return asyncio.run(load_openapi_spec_async(uri))
+
+
+async def load_openapi_spec_conditional_async(
+    uri: str,
+    etag: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Fetch an OpenAPI spec with ETag-based conditional request support.
+
+    When *etag* is provided, an ``If-None-Match`` header is sent.  If the
+    server responds with ``304 Not Modified`` the spec is unchanged and
+    ``(None, etag)`` is returned, avoiding re-parsing.
+
+    Args:
+        uri: URL pointing to an OpenAPI specification.
+        etag: ETag value from a previous fetch.  ``None`` for the first request.
+        headers: Extra HTTP headers to include in the request.
+
+    Returns:
+        A ``(spec_dict, new_etag)`` tuple.  ``spec_dict`` is ``None`` when the
+        server returned 304.
+    """
+    try:
+        req_headers: dict[str, str] = dict(headers or {})
+        if etag is not None:
+            req_headers["If-None-Match"] = etag
+
+        async with AsyncClient(timeout=10) as client:
+            response = await client.get(uri, headers=req_headers)
+            assert isinstance(response, Response)
+
+            if response.status_code == 304:
+                return None, etag
+
+            response.raise_for_status()
+
+            new_etag = response.headers.get("ETag") or response.headers.get("etag")
+            openapi_spec_content = response.content
+
+        loop = asyncio.get_event_loop()
+        openapi_spec_dict = await loop.run_in_executor(
+            None,
+            lambda: resolve_refs(yaml_load(openapi_spec_content.decode("utf-8"))),
+        )
+
+        if not isinstance(openapi_spec_dict, dict):
+            raise ValueError("OpenAPI spec must be a dictionary")
+        return dict(openapi_spec_dict), new_etag
+
+    except YAMLError as e:
+        raise ValueError(f"Failed to parse OpenAPI content: {e}")
+    except HTTPError as e:
+        raise ValueError(f"HTTP error: {e.status_code} for {e.url}")
+    except HttpClientError as e:
+        raise ValueError(f"Network error when fetching URI: {e}")
+    except Exception as e:
+        raise ValueError(f"Unexpected error: {e}")
+
+
+def load_openapi_spec_conditional(
+    uri: str,
+    etag: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Sync version of :func:`load_openapi_spec_conditional_async`."""
+    return asyncio.run(load_openapi_spec_conditional_async(uri, etag, headers))

--- a/src/toolregistry/integrations/openapi/utils.py
+++ b/src/toolregistry/integrations/openapi/utils.py
@@ -192,7 +192,7 @@ async def load_openapi_spec_conditional_async(
             new_etag = response.headers.get("ETag") or response.headers.get("etag")
             openapi_spec_content = response.content
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         openapi_spec_dict = await loop.run_in_executor(
             None,
             lambda: resolve_refs(yaml_load(openapi_spec_content.decode("utf-8"))),

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,7 +1,7 @@
 """Tests for remote tool source refresh (OpenAPI + MCP)."""
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -381,5 +381,119 @@ class TestPolling:
         assert integration._poll_timer is not None
 
         registry.close()
-        # After close, integrations list is cleared
-        # The integration's timer should have been cancelled via close()
+        assert integration._poll_timer is None
+        assert integration._poll_interval is None
+
+
+# ---------------------------------------------------------------------------
+# MCP refresh (mocked)
+# ---------------------------------------------------------------------------
+
+
+class _MockToolSpec:
+    """Minimal stand-in for mcp.types.Tool."""
+
+    def __init__(self, name, description="", input_schema=None):
+        self.name = name
+        self.description = description
+        self.input_schema = input_schema or {"type": "object", "properties": {}}
+
+
+class TestMCPRefresh:
+    """Tests for MCPIntegration.refresh() using mocked MCP clients."""
+
+    def _make_integration(self, registry, tool_specs):
+        """Register mocked MCP tools and return the integration."""
+        from toolregistry.integrations.mcp.integration import (
+            MCPIntegration,
+            MCPTool,
+        )
+        from toolregistry.integrations.mcp.connection import MCPConnectionManager
+
+        integration = MCPIntegration(registry)
+        connection = MagicMock(spec=MCPConnectionManager)
+        connection.transport = "http://mock-mcp:8000"
+        integration._connections.append(connection)
+        integration._transport = "http://mock-mcp:8000"
+        integration._resolved_ns = None
+        integration._persistent = True
+        integration._headers = None
+
+        sep = getattr(registry, "_name_sep", "-")
+        for ts in tool_specs:
+            tool = MCPTool.from_tool_json(ts, connection, namespace=None)
+            tool.update_namespace(None, force=True, sep=sep)
+            registry.register(tool)
+            integration._registered_tool_names.add(tool.name)
+
+        return integration
+
+    def _patch_mcp_client(self, tool_specs):
+        """Return a context manager that mocks MCPClient to return given specs."""
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=tool_specs)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        return patch(
+            "toolregistry.integrations.mcp.integration.MCPClient",
+            return_value=mock_client,
+        )
+
+    def test_mcp_refresh_unchanged(self):
+        specs = [_MockToolSpec("add"), _MockToolSpec("multiply")]
+        registry = ToolRegistry()
+        integration = self._make_integration(registry, specs)
+
+        with self._patch_mcp_client(specs):
+            result = integration.refresh()
+
+        assert result.changed is False
+        assert result.unchanged == 2
+
+    def test_mcp_refresh_add_tool(self):
+        initial = [_MockToolSpec("add")]
+        updated = [_MockToolSpec("add"), _MockToolSpec("subtract")]
+        registry = ToolRegistry()
+        integration = self._make_integration(registry, initial)
+
+        with self._patch_mcp_client(updated):
+            result = integration.refresh()
+
+        assert "subtract" in result.added
+        assert "subtract" in registry._tools
+
+    def test_mcp_refresh_remove_tool(self):
+        initial = [_MockToolSpec("add"), _MockToolSpec("multiply")]
+        updated = [_MockToolSpec("add")]
+        registry = ToolRegistry()
+        integration = self._make_integration(registry, initial)
+
+        with self._patch_mcp_client(updated):
+            result = integration.refresh()
+
+        assert "multiply" in result.removed
+        assert "multiply" not in registry._tools
+
+    def test_mcp_refresh_update_tool(self):
+        initial = [_MockToolSpec("add", description="Add numbers")]
+        changed = [_MockToolSpec("add", description="Add two integers")]
+        registry = ToolRegistry()
+        integration = self._make_integration(registry, initial)
+
+        with self._patch_mcp_client(changed):
+            result = integration.refresh()
+
+        assert "add" in result.updated
+        assert registry._tools["add"].description == "Add two integers"
+
+    def test_mcp_refresh_preserves_disabled_state(self):
+        specs = [_MockToolSpec("add"), _MockToolSpec("multiply")]
+        registry = ToolRegistry()
+        integration = self._make_integration(registry, specs)
+        registry.disable("add", "maintenance")
+
+        with self._patch_mcp_client(specs):
+            integration.refresh()
+
+        assert not registry.is_enabled("add")
+        assert registry.get_disable_reason("add") == "maintenance"

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,0 +1,385 @@
+"""Tests for remote tool source refresh (OpenAPI + MCP)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from toolregistry import ToolRegistry
+from toolregistry.events import ChangeEvent, ChangeEventType, RefreshResult
+from toolregistry.integrations.openapi.integration import (
+    OpenAPIIntegration,
+)
+from toolregistry.utils import HttpClientConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SPEC_V1 = {
+    "openapi": "3.0.0",
+    "info": {"title": "TestAPI", "version": "1.0.0"},
+    "paths": {
+        "/items": {
+            "get": {
+                "operationId": "listItems",
+                "summary": "List items",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer"},
+                    }
+                ],
+            },
+        },
+        "/items/{id}": {
+            "get": {
+                "operationId": "getItem",
+                "summary": "Get one item",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+            },
+        },
+    },
+}
+
+SPEC_V2_ADDED = {
+    **SPEC_V1,
+    "paths": {
+        **SPEC_V1["paths"],
+        "/items": {
+            **SPEC_V1["paths"]["/items"],
+            "post": {
+                "operationId": "createItem",
+                "summary": "Create item",
+                "parameters": [],
+            },
+        },
+    },
+}
+
+SPEC_V2_REMOVED = {
+    **SPEC_V1,
+    "paths": {
+        "/items": SPEC_V1["paths"]["/items"],
+    },
+}
+
+SPEC_V2_UPDATED = {
+    **SPEC_V1,
+    "paths": {
+        "/items": {
+            "get": {
+                "operationId": "listItems",
+                "summary": "List all items (v2)",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer"},
+                    },
+                ],
+            },
+        },
+        "/items/{id}": SPEC_V1["paths"]["/items/{id}"],
+    },
+}
+
+
+def _make_client_config(base_url: str = "http://test.example.com") -> HttpClientConfig:
+    return HttpClientConfig(base_url=base_url)
+
+
+# ---------------------------------------------------------------------------
+# RefreshResult
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshResult:
+    def test_defaults(self):
+        r = RefreshResult(source="openapi")
+        assert r.source == "openapi"
+        assert r.added == ()
+        assert r.removed == ()
+        assert r.updated == ()
+        assert r.unchanged == 0
+        assert r.skipped is False
+        assert r.changed is False
+
+    def test_changed_property(self):
+        assert RefreshResult(source="mcp", added=("x",)).changed is True
+        assert RefreshResult(source="mcp", removed=("x",)).changed is True
+        assert RefreshResult(source="mcp", updated=("x",)).changed is True
+        assert RefreshResult(source="mcp", unchanged=5).changed is False
+        assert RefreshResult(source="mcp", skipped=True).changed is False
+
+
+# ---------------------------------------------------------------------------
+# _unregister
+# ---------------------------------------------------------------------------
+
+
+class TestUnregister:
+    def test_removes_tool_and_emits_event(self):
+        registry = ToolRegistry()
+        registry.register(lambda x: x, name="my_tool")
+        assert "my_tool" in registry._tools
+
+        events: list[ChangeEvent] = []
+        registry.on_change(events.append)
+
+        result = registry._unregister("my_tool")
+        assert result is True
+        assert "my_tool" not in registry._tools
+        assert any(
+            e.event_type == ChangeEventType.UNREGISTER and e.tool_name == "my_tool"
+            for e in events
+        )
+
+    def test_cleans_disabled_state(self):
+        registry = ToolRegistry()
+        registry.register(lambda x: x, name="my_tool")
+        registry.disable("my_tool", "test reason")
+        assert not registry.is_enabled("my_tool")
+
+        registry._unregister("my_tool")
+        assert "my_tool" not in registry._disabled
+
+    def test_returns_false_for_nonexistent(self):
+        registry = ToolRegistry()
+        assert registry._unregister("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI refresh
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPIRefresh:
+    def _register(self, registry, spec=None, namespace=False, spec_url=None):
+        spec = spec or SPEC_V1
+        client = _make_client_config()
+        registry.register_from_openapi(
+            client, spec, namespace=namespace, spec_url=spec_url
+        )
+
+    def test_refresh_unchanged(self):
+        registry = ToolRegistry()
+        self._register(registry)
+        result = registry.refresh_from_openapi(openapi_spec=SPEC_V1)
+        assert result.skipped is False
+        assert result.changed is False
+        assert result.unchanged == 2
+
+    def test_refresh_add_tool(self):
+        registry = ToolRegistry()
+        self._register(registry)
+        initial_count = len(registry._tools)
+
+        result = registry.refresh_from_openapi(openapi_spec=SPEC_V2_ADDED)
+        assert "create_item" in result.added
+        assert len(registry._tools) == initial_count + 1
+
+    def test_refresh_remove_tool(self):
+        registry = ToolRegistry()
+        self._register(registry)
+        assert "get_item" in registry._tools
+
+        result = registry.refresh_from_openapi(openapi_spec=SPEC_V2_REMOVED)
+        assert "get_item" in result.removed
+        assert "get_item" not in registry._tools
+
+    def test_refresh_update_tool(self):
+        registry = ToolRegistry()
+        self._register(registry)
+
+        result = registry.refresh_from_openapi(openapi_spec=SPEC_V2_UPDATED)
+        assert "list_items" in result.updated
+        updated_tool = registry._tools["list_items"]
+        assert "offset" in updated_tool.parameters.get("properties", {})
+
+    def test_refresh_preserves_disabled_state(self):
+        registry = ToolRegistry()
+        self._register(registry)
+        registry.disable("list_items", "maintenance")
+
+        registry.refresh_from_openapi(openapi_spec=SPEC_V1)
+        assert not registry.is_enabled("list_items")
+        assert registry.get_disable_reason("list_items") == "maintenance"
+
+    def test_refresh_removes_disabled_for_removed_tools(self):
+        registry = ToolRegistry()
+        self._register(registry)
+        registry.disable("get_item", "test")
+
+        registry.refresh_from_openapi(openapi_spec=SPEC_V2_REMOVED)
+        assert "get_item" not in registry._disabled
+
+    def test_refresh_with_namespace(self):
+        registry = ToolRegistry()
+        self._register(registry, namespace="api")
+        assert "api-list_items" in registry._tools
+
+        result = registry.refresh_from_openapi(openapi_spec=SPEC_V2_ADDED)
+        assert any("create_item" in name for name in result.added)
+
+    def test_refresh_emits_events(self):
+        registry = ToolRegistry()
+        self._register(registry)
+
+        events: list[ChangeEvent] = []
+        registry.on_change(events.append)
+
+        registry.refresh_from_openapi(openapi_spec=SPEC_V2_UPDATED)
+
+        refresh_events = [e for e in events if e.event_type == ChangeEventType.REFRESH]
+        assert len(refresh_events) >= 1
+
+    def test_refresh_no_spec_url_no_stored_spec_raises(self):
+        registry = ToolRegistry()
+        integration = OpenAPIIntegration(registry)
+        with pytest.raises(ValueError, match="Cannot refresh"):
+            integration.refresh()
+
+    def test_refresh_uses_stored_spec(self):
+        registry = ToolRegistry()
+        self._register(registry)
+        integration = registry._openapi_integrations[0]
+        assert integration._openapi_spec is not None
+
+        result = integration.refresh()
+        assert result.unchanged == 2
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI ETag conditional fetch
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPIConditionalFetch:
+    @pytest.mark.asyncio
+    async def test_etag_304(self):
+        from toolregistry._vendor.httpclient import Response
+
+        mock_response = Response(304, {}, b"", "http://test.example.com/openapi.json")
+
+        with patch("toolregistry.integrations.openapi.utils.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            from toolregistry.integrations.openapi.utils import (
+                load_openapi_spec_conditional_async,
+            )
+
+            spec, etag = await load_openapi_spec_conditional_async(
+                "http://test.example.com/openapi.json", etag='"abc123"'
+            )
+            assert spec is None
+            assert etag == '"abc123"'
+
+    @pytest.mark.asyncio
+    async def test_etag_200_with_new_etag(self):
+        from toolregistry._vendor.httpclient import Response
+
+        spec_bytes = json.dumps(SPEC_V1).encode()
+        mock_response = Response(
+            200,
+            {"content-type": "application/json", "ETag": '"new-etag"'},
+            spec_bytes,
+            "http://test.example.com/openapi.json",
+        )
+
+        with patch("toolregistry.integrations.openapi.utils.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            from toolregistry.integrations.openapi.utils import (
+                load_openapi_spec_conditional_async,
+            )
+
+            spec, etag = await load_openapi_spec_conditional_async(
+                "http://test.example.com/openapi.json"
+            )
+            assert spec is not None
+            assert etag == '"new-etag"'
+
+
+# ---------------------------------------------------------------------------
+# refresh_all
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshAll:
+    def test_refresh_all_single_openapi(self):
+        registry = ToolRegistry()
+        client = _make_client_config()
+        registry.register_from_openapi(client, SPEC_V1)
+
+        events: list[ChangeEvent] = []
+        registry.on_change(events.append)
+
+        results = registry.refresh_all()
+        assert len(results) == 1
+        assert results[0].source == "openapi"
+        assert any(e.event_type == ChangeEventType.REFRESH_ALL for e in events)
+
+    def test_refresh_all_empty(self):
+        registry = ToolRegistry()
+        results = registry.refresh_all()
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Background polling
+# ---------------------------------------------------------------------------
+
+
+class TestPolling:
+    def test_openapi_start_stop_polling(self):
+        registry = ToolRegistry()
+        client = _make_client_config()
+        registry.register_from_openapi(client, SPEC_V1)
+        integration = registry._openapi_integrations[0]
+
+        integration.start_polling(100.0)
+        assert integration._poll_timer is not None
+        assert integration._poll_timer.is_alive()
+
+        integration.stop_polling()
+        assert integration._poll_timer is None
+        assert integration._poll_interval is None
+
+    def test_close_stops_polling(self):
+        registry = ToolRegistry()
+        client = _make_client_config()
+        registry.register_from_openapi(client, SPEC_V1)
+        integration = registry._openapi_integrations[0]
+
+        integration.start_polling(100.0)
+        assert integration._poll_timer is not None
+
+        registry.close()
+        # After close, integrations list is cleared
+        # The integration's timer should have been cancelled via close()


### PR DESCRIPTION
## Summary

- Adds `refresh_from_openapi()` / `refresh_from_mcp()` / `refresh_all()` methods to `ToolRegistry` for refreshing tool definitions from remote sources at runtime
- Implements ETag conditional requests for efficient OpenAPI spec polling (304 Not Modified skips re-parsing)
- Diff-based update logic: adds new tools, removes stale ones, updates changed schemas — preserves disable state across refreshes
- Optional background polling via `start_polling(interval)` / `stop_polling()` on integration instances
- Adds `RefreshResult` dataclass for structured reporting of what changed
- Adds `_unregister()` for clean tool removal with `UNREGISTER` event emission
- Wires up previously-unused `REFRESH`, `REFRESH_ALL`, and `UNREGISTER` event types

Closes #72

## Test plan

- [x] `RefreshResult` defaults and `changed` property
- [x] `_unregister()` removes tool, emits event, cleans disabled state
- [x] OpenAPI refresh: unchanged / add / remove / update scenarios
- [x] OpenAPI refresh preserves disabled state for surviving tools
- [x] OpenAPI refresh with namespace
- [x] OpenAPI refresh emits REFRESH events
- [x] OpenAPI ETag conditional fetch (304 and 200 with new ETag)
- [x] `refresh_all()` collects results and emits REFRESH_ALL
- [x] Background polling start/stop lifecycle
- [x] `close()` stops active pollers
- [x] Full test suite (1265 tests) — no regressions
- [x] `ruff check` + `ruff format` + `ty check` + `complexipy` all pass