### PR TITLE
docs(examples): migrate register_from_* to unified register()

### DIFF
--- a/examples/admin_demo.py
+++ b/examples/admin_demo.py
@@ -55,7 +55,7 @@ class StringUtils:
         return len(text)
 
 
-registry.register_from_class(StringUtils, namespace="StringUtils")
+registry.register(StringUtils, source="class", namespace="StringUtils")
 
 
 # ── 2. Enable execution logging ─────────────────────────────────────────

--- a/examples/admin_demo.py
+++ b/examples/admin_demo.py
@@ -55,7 +55,7 @@ class StringUtils:
         return len(text)
 
 
-registry.register(StringUtils, source="class", namespace="StringUtils")
+registry.register(StringUtils, namespace="StringUtils")
 
 
 # ── 2. Enable execution logging ─────────────────────────────────────────

--- a/examples/hub_related/cicada_calculator_example.py
+++ b/examples/hub_related/cicada_calculator_example.py
@@ -25,7 +25,7 @@ llm = MultiModalModel(
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register(Calculator, source="class", namespace=True)
+tool_registry.register(Calculator, namespace=True)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/hub_related/cicada_calculator_example.py
+++ b/examples/hub_related/cicada_calculator_example.py
@@ -25,7 +25,7 @@ llm = MultiModalModel(
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_class(Calculator, namespace=True)
+tool_registry.register(Calculator, source="class", namespace=True)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/hub_related/cicada_calculator_fileops_example.py
+++ b/examples/hub_related/cicada_calculator_fileops_example.py
@@ -25,8 +25,8 @@ llm = MultiModalModel(
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_class(Calculator, namespace=True)
-tool_registry.register_from_class(FileOps, namespace=True)
+tool_registry.register(Calculator, source="class", namespace=True)
+tool_registry.register(FileOps, source="class", namespace=True)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/hub_related/cicada_calculator_fileops_example.py
+++ b/examples/hub_related/cicada_calculator_fileops_example.py
@@ -25,8 +25,8 @@ llm = MultiModalModel(
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register(Calculator, source="class", namespace=True)
-tool_registry.register(FileOps, source="class", namespace=True)
+tool_registry.register(Calculator, namespace=True)
+tool_registry.register(FileOps, namespace=True)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/hub_related/cicada_file_edit_example.py
+++ b/examples/hub_related/cicada_file_edit_example.py
@@ -25,7 +25,7 @@ llm = MultiModalModel(
 
 # Initialize tool registry and register FileOps static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_class(FileOps)
+tool_registry.register(FileOps, source="class")
 
 
 test_file = "examples/hub_related/sample.txt"

--- a/examples/hub_related/cicada_file_edit_example.py
+++ b/examples/hub_related/cicada_file_edit_example.py
@@ -25,7 +25,7 @@ llm = MultiModalModel(
 
 # Initialize tool registry and register FileOps static methods
 tool_registry = ToolRegistry()
-tool_registry.register(FileOps, source="class")
+tool_registry.register(FileOps)
 
 
 test_file = "examples/hub_related/sample.txt"

--- a/examples/hub_related/cicada_websearch_example.py
+++ b/examples/hub_related/cicada_websearch_example.py
@@ -49,8 +49,8 @@ else:
     websearch = WebSearchGoogle()  # Assuming there's a WebSearchGoogle class
 
 
-tool_registry.register_from_class(
-    websearch
+tool_registry.register(
+    websearch, source="class"
 )  # Register the web search tool with the registry
 
 print(tool_registry.list_tools())

--- a/examples/hub_related/cicada_websearch_example.py
+++ b/examples/hub_related/cicada_websearch_example.py
@@ -50,7 +50,8 @@ else:
 
 
 tool_registry.register(
-    websearch, source="class"
+    websearch,
+    source="class",  # source= needed: instance, not a type
 )  # Register the web search tool with the registry
 
 print(tool_registry.list_tools())

--- a/examples/hub_related/openai_calculator_example_chat_api.py
+++ b/examples/hub_related/openai_calculator_example_chat_api.py
@@ -18,7 +18,7 @@ BASE_URL = os.getenv("BASE_URL", "https://api.deepseek.com/")
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_class(Calculator, namespace=True)
+tool_registry.register(Calculator, source="class", namespace=True)
 
 # Set up OpenAI client
 client = OpenAI(

--- a/examples/hub_related/openai_calculator_example_chat_api.py
+++ b/examples/hub_related/openai_calculator_example_chat_api.py
@@ -18,7 +18,7 @@ BASE_URL = os.getenv("BASE_URL", "https://api.deepseek.com/")
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register(Calculator, source="class", namespace=True)
+tool_registry.register(Calculator, namespace=True)
 
 # Set up OpenAI client
 client = OpenAI(

--- a/examples/hub_related/openai_calculator_example_response_api.py
+++ b/examples/hub_related/openai_calculator_example_response_api.py
@@ -18,7 +18,7 @@ BASE_URL = os.getenv("BASE_URL", "https://api.deepseek.com/")
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register(Calculator, source="class", namespace=False)
+tool_registry.register(Calculator, namespace=False)
 
 # Set up OpenAI client
 client = OpenAI(

--- a/examples/hub_related/openai_calculator_example_response_api.py
+++ b/examples/hub_related/openai_calculator_example_response_api.py
@@ -18,7 +18,7 @@ BASE_URL = os.getenv("BASE_URL", "https://api.deepseek.com/")
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_class(Calculator, namespace=False)
+tool_registry.register(Calculator, source="class", namespace=False)
 
 # Set up OpenAI client
 client = OpenAI(

--- a/examples/hub_related/openai_calculator_fileops_example.py
+++ b/examples/hub_related/openai_calculator_fileops_example.py
@@ -18,8 +18,8 @@ BASE_URL = os.getenv("BASE_URL", "https://api.deepseek.com/")
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register(Calculator, source="class", namespace=True)
-tool_registry.register(FileOps, source="class", namespace=True)
+tool_registry.register(Calculator, namespace=True)
+tool_registry.register(FileOps, namespace=True)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/hub_related/openai_calculator_fileops_example.py
+++ b/examples/hub_related/openai_calculator_fileops_example.py
@@ -18,8 +18,8 @@ BASE_URL = os.getenv("BASE_URL", "https://api.deepseek.com/")
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_class(Calculator, namespace=True)
-tool_registry.register_from_class(FileOps, namespace=True)
+tool_registry.register(Calculator, source="class", namespace=True)
+tool_registry.register(FileOps, source="class", namespace=True)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/hub_related/openai_websearch_example.py
+++ b/examples/hub_related/openai_websearch_example.py
@@ -41,8 +41,9 @@ else:
     websearch = WebSearchGoogle()  # Assuming there's a WebSearchGoogle class
 
 
+# source= needed: websearch is an instance, not a type
 tool_registry.register(websearch, source="class", namespace=True)
-tool_registry.register(UnitConverter, source="class", namespace=True)
+tool_registry.register(UnitConverter, namespace=True)
 
 print(tool_registry.list_tools())
 

--- a/examples/hub_related/openai_websearch_example.py
+++ b/examples/hub_related/openai_websearch_example.py
@@ -41,8 +41,8 @@ else:
     websearch = WebSearchGoogle()  # Assuming there's a WebSearchGoogle class
 
 
-tool_registry.register_from_class(websearch, namespace=True)
-tool_registry.register_from_class(UnitConverter, namespace=True)
+tool_registry.register(websearch, source="class", namespace=True)
+tool_registry.register(UnitConverter, source="class", namespace=True)
 
 print(tool_registry.list_tools())
 

--- a/examples/hub_related/test_class_integration.py
+++ b/examples/hub_related/test_class_integration.py
@@ -17,19 +17,19 @@ class InstanceExample:
 
 
 registry = ToolRegistry()
-registry.register_from_class(StaticExample, namespace=True)
+registry.register(StaticExample, source="class", namespace=True)
 print(registry.list_tools())  # ['static_example.greet']
 print(registry["static_example-greet"]("Alice"))  # Hello, Alice!
 
 
-async def test_register_from_class_async():
+async def test_register_class_async():
     """Test async registration of static methods."""
-    return await registry.register_from_class_async(
-        InstanceExample("Bob"), namespace=True
+    return await registry.register_async(
+        InstanceExample("Bob"), source="class", namespace=True
     )
 
 
 registry = ToolRegistry()
-asyncio.run(test_register_from_class_async())
+asyncio.run(test_register_class_async())
 print(registry.list_tools())  # ['instance_example.greet']
 print(registry["instance_example-greet"]("Alice"))  # Hello, Alice! I'm Bob.

--- a/examples/hub_related/test_class_integration.py
+++ b/examples/hub_related/test_class_integration.py
@@ -17,7 +17,7 @@ class InstanceExample:
 
 
 registry = ToolRegistry()
-registry.register(StaticExample, source="class", namespace=True)
+registry.register(StaticExample, namespace=True)
 print(registry.list_tools())  # ['static_example.greet']
 print(registry["static_example-greet"]("Alice"))  # Hello, Alice!
 
@@ -25,7 +25,8 @@ print(registry["static_example-greet"]("Alice"))  # Hello, Alice!
 async def test_register_class_async():
     """Test async registration of static methods."""
     return await registry.register_async(
-        InstanceExample("Bob"), source="class", namespace=True
+        InstanceExample("Bob"),
+        source="class",  # source= needed: instance, not a type, namespace=True
     )
 
 

--- a/examples/langchain_related/openai_langchain_arxiv_example.py
+++ b/examples/langchain_related/openai_langchain_arxiv_example.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
     # Example usage of PubmedQueryRun
     arxiv_tool = ArxivQueryRun()
     pubmed_tool = PubmedQueryRun()
-    registry.register(arxiv_tool, source="langchain")
-    registry.register(pubmed_tool, source="langchain")
+    registry.register(arxiv_tool)
+    registry.register(pubmed_tool)
 
     print(registry.list_tools())
 

--- a/examples/langchain_related/openai_langchain_arxiv_example.py
+++ b/examples/langchain_related/openai_langchain_arxiv_example.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
     # Example usage of PubmedQueryRun
     arxiv_tool = ArxivQueryRun()
     pubmed_tool = PubmedQueryRun()
-    registry.register_from_langchain(arxiv_tool)
-    registry.register_from_langchain(pubmed_tool)
+    registry.register(arxiv_tool, source="langchain")
+    registry.register(pubmed_tool, source="langchain")
 
     print(registry.list_tools())
 

--- a/examples/mcp_related/cicada_mcp_calculator_example.py
+++ b/examples/mcp_related/cicada_mcp_calculator_example.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         # stdio
         transport = "/home/pding/projects/toolregistry/examples/mcp_related/mcp_servers/math_server.py"
 
-    tool_registry.register_from_mcp(transport, namespace=True)
+    tool_registry.register(transport, source="mcp", namespace=True)
 
     print(tool_registry.list_tools())
 

--- a/examples/mcp_related/mcp_from_diverse_transport.py
+++ b/examples/mcp_related/mcp_from_diverse_transport.py
@@ -29,6 +29,6 @@ transport = StreamableHttpTransport(
     url="https://mcphub.example.com/mcp", headers={"Authorization": "Bearer token"}
 )  # Transport instance, useful if you have custom headers
 
-registry.register_from_mcp(transport)
+registry.register(transport, source="mcp")
 print("Registered Tools:")
 pprint(registry)

--- a/examples/mcp_related/openai_mcp_calculator_example.py
+++ b/examples/mcp_related/openai_mcp_calculator_example.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         # stdio
         transport = "/home/pding/projects/toolregistry/examples/mcp_related/mcp_servers/math_server.py"
 
-    tool_registry.register_from_mcp(transport, namespace=True)
+    tool_registry.register(transport, source="mcp", namespace=True)
 
     print(tool_registry.list_tools())
     print(tool_registry.get_schemas())

--- a/examples/mcp_related/toolregistry_mcp_tests/test_echo_server.py
+++ b/examples/mcp_related/toolregistry_mcp_tests/test_echo_server.py
@@ -10,7 +10,7 @@ registry = ToolRegistry()
 
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
-registry.register_from_mcp(mcp_server_url)
+registry.register(mcp_server_url, source="mcp")
 print("Registered Tools:")
 pprint(registry)
 

--- a/examples/mcp_related/toolregistry_mcp_tests/test_everything_server.py
+++ b/examples/mcp_related/toolregistry_mcp_tests/test_everything_server.py
@@ -10,7 +10,7 @@ registry = ToolRegistry()
 
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
-registry.register_from_mcp(mcp_server_url)
+registry.register(mcp_server_url, source="mcp")
 print("Registered Tools:")
 pprint(registry)
 

--- a/examples/mcp_related/toolregistry_mcp_tests/test_math_server.py
+++ b/examples/mcp_related/toolregistry_mcp_tests/test_math_server.py
@@ -9,7 +9,7 @@ registry = ToolRegistry()
 
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
-registry.register_from_mcp(mcp_server_url)
+registry.register(mcp_server_url, source="mcp")
 print("Registered Math Tools:")
 pprint(registry)
 

--- a/examples/mcp_related/toolregistry_mcp_tests/test_sqlite_server.py
+++ b/examples/mcp_related/toolregistry_mcp_tests/test_sqlite_server.py
@@ -18,7 +18,7 @@ registry = ToolRegistry()
 
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
-registry.register_from_mcp(mcp_server_url)
+registry.register(mcp_server_url, source="mcp")
 print("Registered SQLite Tools:")
 pprint(registry)
 

--- a/examples/mcp_related/toolregistry_mcp_tests/test_str_ops_server.py
+++ b/examples/mcp_related/toolregistry_mcp_tests/test_str_ops_server.py
@@ -9,7 +9,7 @@ registry = ToolRegistry()
 
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
-registry.register_from_mcp(mcp_server_url)
+registry.register(mcp_server_url, source="mcp")
 print("Registered String Operations Tools:")
 pprint(registry)
 

--- a/examples/openapi_related/cicada_openapi_calculator_example.py
+++ b/examples/openapi_related/cicada_openapi_calculator_example.py
@@ -37,7 +37,7 @@ openapi_spec = load_openapi_spec(base_url)
 
 # Initialize tool registry and register Calculator static methods
 tool_registry = ToolRegistry()
-tool_registry.register_from_openapi(client_config, openapi_spec)
+tool_registry.register(client_config, source="openapi", openapi_spec=openapi_spec)
 print(tool_registry.list_tools())
 
 input_file = "examples/hub_related/concurrent_raw_results.txt"

--- a/examples/openapi_related/openai_openapi_calculator_example.py
+++ b/examples/openapi_related/openai_openapi_calculator_example.py
@@ -79,7 +79,9 @@ if __name__ == "__main__":
     )
     openapi_spec = load_openapi_spec(base_url)
 
-    tool_registry.register_from_openapi(client_config, openapi_spec, namespace=True)
+    tool_registry.register(
+        client_config, source="openapi", openapi_spec=openapi_spec, namespace=True
+    )
 
     print(tool_registry.list_tools())
 

--- a/examples/openapi_related/test_openapi_calculator.py
+++ b/examples/openapi_related/test_openapi_calculator.py
@@ -10,7 +10,9 @@ client_config = HttpClientConfig(base_url=base_url)
 
 # Initialize the ToolRegistry and register OpenAPI tools synchronously
 registry = ToolRegistry()
-registry.register_from_openapi(client_config, openapi_spec, namespace=True)
+registry.register(
+    client_config, source="openapi", openapi_spec=openapi_spec, namespace=True
+)
 
 # print("Registry:", registry)
 

--- a/examples/tool_use_examples/cicada_tool_usage_example.py
+++ b/examples/tool_use_examples/cicada_tool_usage_example.py
@@ -40,7 +40,7 @@ def get_weather(location: str):
 #     return f"{celsius} celsius degree == {fahrenheit} fahrenheit degree"
 
 # replace c_to_f with hub tool UnitConverter
-tool_registry.register_from_class(UnitConverter, namespace=True)
+tool_registry.register(UnitConverter, source="class", namespace=True)
 
 # query the model with tools
 response = llm.query(

--- a/examples/tool_use_examples/cicada_tool_usage_example.py
+++ b/examples/tool_use_examples/cicada_tool_usage_example.py
@@ -40,7 +40,7 @@ def get_weather(location: str):
 #     return f"{celsius} celsius degree == {fahrenheit} fahrenheit degree"
 
 # replace c_to_f with hub tool UnitConverter
-tool_registry.register(UnitConverter, source="class", namespace=True)
+tool_registry.register(UnitConverter, namespace=True)
 
 # query the model with tools
 response = llm.query(

--- a/examples/tool_use_examples/openai_tool_usage_example.py
+++ b/examples/tool_use_examples/openai_tool_usage_example.py
@@ -30,7 +30,7 @@ def get_weather(location: str):
 #     return f"{celsius} celsius degree == {fahrenheit} fahrenheit degree"
 
 # replace c_to_f with hub tool UnitConverter
-tool_registry.register_from_class(UnitConverter, namespace=True)
+tool_registry.register(UnitConverter, source="class", namespace=True)
 
 # Set up OpenAI client
 client = OpenAI(

--- a/examples/tool_use_examples/openai_tool_usage_example.py
+++ b/examples/tool_use_examples/openai_tool_usage_example.py
@@ -30,7 +30,7 @@ def get_weather(location: str):
 #     return f"{celsius} celsius degree == {fahrenheit} fahrenheit degree"
 
 # replace c_to_f with hub tool UnitConverter
-tool_registry.register(UnitConverter, source="class", namespace=True)
+tool_registry.register(UnitConverter, namespace=True)
 
 # Set up OpenAI client
 client = OpenAI(

--- a/examples/tool_use_examples/openai_toolregistry_mcp_math.py
+++ b/examples/tool_use_examples/openai_toolregistry_mcp_math.py
@@ -19,12 +19,12 @@ registry = ToolRegistry()
 
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
-# registry.register_from_mcp(mcp_server_url)
+# registry.register(mcp_server_url, source="mcp")
 # pprint(registry)
 
 
 async def async_register():
-    await registry.register_from_mcp_async(mcp_server_url, namespace=True)
+    await registry.register_async(mcp_server_url, source="mcp", namespace=True)
     pprint(registry)
 
 

--- a/examples/tool_use_examples/openai_toolregistry_mixed_math.py
+++ b/examples/tool_use_examples/openai_toolregistry_mixed_math.py
@@ -25,8 +25,8 @@ async def async_register():
     client_config = HttpClientConfig(base_url=openapi_spec_url)
     openapi_spec = await load_openapi_spec_async(openapi_spec_url)
 
-    await openapi_registry.register_from_openapi_async(
-        client_config, openapi_spec, namespace=True
+    await openapi_registry.register_async(
+        client_config, source="openapi", openapi_spec=openapi_spec, namespace=True
     )
 
 
@@ -50,7 +50,7 @@ MCP_PORT = os.getenv(
 )  # default MCP_PORT 8000, change via environment variable
 mcp_registry = ToolRegistry("mcp_math")
 mcp_server_url = f"http://localhost:{MCP_PORT}/sse"
-mcp_registry.register_from_mcp(mcp_server_url, namespace=True)
+mcp_registry.register(mcp_server_url, source="mcp", namespace=True)
 pprint(mcp_registry.list_tools())
 pprint(mcp_registry._sub_registries)
 

--- a/examples/tool_use_examples/openai_toolregistry_openapi_math.py
+++ b/examples/tool_use_examples/openai_toolregistry_openapi_math.py
@@ -27,7 +27,9 @@ spec_url = f"http://localhost:{PORT}"
 client_config = HttpClientConfig(base_url=spec_url)
 openapi_spec = load_openapi_spec(spec_url)
 
-registry.register_from_openapi(client_config, openapi_spec, namespace=True)
+registry.register(
+    client_config, source="openapi", openapi_spec=openapi_spec, namespace=True
+)
 pprint(registry)
 
 
@@ -35,8 +37,8 @@ async def async_register():
     client_config = HttpClientConfig(base_url=spec_url)
     openapi_spec = await load_openapi_spec_async(spec_url)
 
-    await registry.register_from_openapi_async(
-        client_config, openapi_spec, namespace=True
+    await registry.register_async(
+        client_config, source="openapi", openapi_spec=openapi_spec, namespace=True
     )
 
 

--- a/examples/tool_use_examples/test_toolregistry_concurrency.py
+++ b/examples/tool_use_examples/test_toolregistry_concurrency.py
@@ -144,7 +144,7 @@ def main():
     from toolregistry.hub import BaseCalculator
 
     registry = ToolRegistry()
-    registry.register(BaseCalculator, source="class", namespace=True)
+    registry.register(BaseCalculator, namespace=True)
     # print(registry.list_tools())
     if FUNC:
         target_func_name = [name for name in registry.list_tools() if FUNC in name][0]

--- a/examples/tool_use_examples/test_toolregistry_concurrency.py
+++ b/examples/tool_use_examples/test_toolregistry_concurrency.py
@@ -144,7 +144,7 @@ def main():
     from toolregistry.hub import BaseCalculator
 
     registry = ToolRegistry()
-    registry.register_from_class(BaseCalculator, namespace=True)
+    registry.register(BaseCalculator, source="class", namespace=True)
     # print(registry.list_tools())
     if FUNC:
         target_func_name = [name for name in registry.list_tools() if FUNC in name][0]
@@ -169,7 +169,9 @@ def main():
     client_config = HttpClientConfig(base_url=f"http://localhost:{OPENAPI_PORT}")
     openapi_spec = load_openapi_spec(f"http://localhost:{OPENAPI_PORT}")
 
-    registry.register_from_openapi(client_config, openapi_spec, namespace=True)
+    registry.register(
+        client_config, source="openapi", openapi_spec=openapi_spec, namespace=True
+    )
     # print(registry.list_tools())
     if FUNC:
         target_func_name = [name for name in registry.list_tools() if FUNC in name][0]
@@ -190,7 +192,7 @@ def main():
     registry = ToolRegistry()
 
     MCP_PORT = os.getenv("MCP_PORT", 8001)
-    registry.register_from_mcp(f"http://localhost:{MCP_PORT}/sse", namespace=True)
+    registry.register(f"http://localhost:{MCP_PORT}/sse", source="mcp", namespace=True)
     # print(registry.list_tools())
     if FUNC:
         target_func_name = [name for name in registry.list_tools() if FUNC in name][0]

--- a/examples/tool_use_examples/test_toolregistry_concurrency_async.py
+++ b/examples/tool_use_examples/test_toolregistry_concurrency_async.py
@@ -58,7 +58,7 @@ async def main():
 
     N = 10
     registry = ToolRegistry()
-    registry.register(AsyncCalculator, source="class")
+    registry.register(AsyncCalculator)
     print(registry.list_tools())
     tool_calls = generate_tool_calls(N)
 

--- a/examples/tool_use_examples/test_toolregistry_concurrency_async.py
+++ b/examples/tool_use_examples/test_toolregistry_concurrency_async.py
@@ -58,7 +58,7 @@ async def main():
 
     N = 10
     registry = ToolRegistry()
-    registry.register_from_class(AsyncCalculator)
+    registry.register(AsyncCalculator, source="class")
     print(registry.list_tools())
     tool_calls = generate_tool_calls(N)
 

--- a/examples/tool_use_examples/test_toolregistry_mcp.py
+++ b/examples/tool_use_examples/test_toolregistry_mcp.py
@@ -106,8 +106,8 @@ def main():
     registry = ToolRegistry()
 
     MCP_PORT = os.getenv("MCP_PORT", 8001)
-    registry.register_from_mcp(
-        f"http://localhost:{MCP_PORT}/{MCP_MODE}", namespace=True
+    registry.register(
+        f"http://localhost:{MCP_PORT}/{MCP_MODE}", source="mcp", namespace=True
     )
     # print(registry.list_tools())
     if FUNC:

--- a/examples/tool_use_examples/tools_mcp_math.py
+++ b/examples/tool_use_examples/tools_mcp_math.py
@@ -11,13 +11,13 @@ registry = ToolRegistry()
 mcp_server_url = f"http://localhost:{PORT}/sse"
 
 # sync register
-registry.register_from_mcp(mcp_server_url)
+registry.register(mcp_server_url, source="mcp")
 # pprint(registry)
 
 
 # async register
 async def async_register():
-    await registry.register_from_mcp_async(mcp_server_url)
+    await registry.register_async(mcp_server_url, source="mcp")
     pprint(registry)
 
 

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -266,6 +266,8 @@ class RegistrationMixin:
             )
         )
 
+        return tool_or_func
+
     def _unregister(self, name: str) -> bool:
         """Remove a tool from the registry.
 


### PR DESCRIPTION
## Summary

Follow-up to #249 (unified `register()` mega-method). Updates all example files and documentation to use the new API.

- **31 example files**: all `register_from_class/mcp/openapi/langchain` calls replaced with `register(target, source=...)` / `register_async(target, source=...)`
- **docs_en** (20 files): integration guides, API reference, migration guide, architecture overview, examples — already pushed to `docs_en` branch
- **docs_zh** (20 files): mirror of English changes — already pushed to `docs_zh` branch
- **migration.md**: new section documenting the unified `register()` entry point and deprecation of old methods
- **changelog**: added `[Unreleased]` entry in both languages

## Test plan

- [x] Zero `register_from_` references remain in examples (verified with grep)
- [x] Zero stale usage references remain in docs (only migration tables showing old→new mapping)
- [x] `ruff format` and `ruff check` pass on all example files
- [x] Doc worktree commits pushed to `docs_en` and `docs_zh` branches