### PR TITLE
feat: add schema fingerprint and staleness timestamp to ToolMetadata

### DIFF
--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -19,16 +19,9 @@ from ...events import ChangeEvent, ChangeEventType, RefreshResult
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
-from ...utils import normalize_tool_name
+from ...utils import normalize_tool_name, utc_iso_now
 from .client import MCPClient
 from .connection import MCPConnectionManager
-
-
-def _utc_iso() -> str:
-    """Return the current UTC time as an ISO 8601 string."""
-    from datetime import datetime, timezone
-
-    return datetime.now(timezone.utc).isoformat()
 
 
 logger = get_logger()
@@ -424,7 +417,7 @@ class MCPIntegration:
             self.registry.register(new_tools[name], namespace=self._resolved_ns)
             added.append(name)
 
-        now = _utc_iso()
+        now = utc_iso_now()
         for name in old_names & new_names:
             candidate = new_tools[name]
             existing = self.registry._tools.get(name)
@@ -445,6 +438,7 @@ class MCPIntegration:
                 existing.metadata.last_refreshed_at = now
                 unchanged += 1
             else:
+                logger.warning("tool tracked but missing from _tools", tool_name=name)
                 unchanged += 1
 
         for name, reason in disabled_snapshot.items():

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -23,6 +23,14 @@ from ...utils import normalize_tool_name
 from .client import MCPClient
 from .connection import MCPConnectionManager
 
+
+def _utc_iso() -> str:
+    """Return the current UTC time as an ISO 8601 string."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
 logger = get_logger()
 
 
@@ -385,6 +393,67 @@ class MCPIntegration:
 
     # ---- Refresh ----
 
+    def _apply_diff(
+        self,
+        new_tools: dict[str, "MCPTool"],
+    ) -> tuple[list[str], list[str], list[str], int]:
+        """Diff *new_tools* against registered tools and apply changes.
+
+        Returns:
+            ``(added, removed, updated, unchanged)`` lists/count.
+        """
+        old_names = set(self._registered_tool_names)
+        new_names = set(new_tools.keys())
+
+        # Snapshot disabled state
+        disabled_snapshot: dict[str, str] = {}
+        for name in old_names:
+            if not self.registry.is_enabled(name):
+                disabled_snapshot[name] = self.registry.get_disable_reason(name) or ""
+
+        added: list[str] = []
+        removed: list[str] = []
+        updated: list[str] = []
+        unchanged = 0
+
+        for name in old_names - new_names:
+            self.registry._unregister(name)
+            removed.append(name)
+
+        for name in new_names - old_names:
+            self.registry.register(new_tools[name], namespace=self._resolved_ns)
+            added.append(name)
+
+        now = _utc_iso()
+        for name in old_names & new_names:
+            candidate = new_tools[name]
+            existing = self.registry._tools.get(name)
+            if existing and (
+                existing.metadata.schema_hash != candidate.metadata.schema_hash
+                or existing.description != candidate.description
+            ):
+                candidate.metadata.last_refreshed_at = now
+                self.registry._tools[name] = candidate
+                self.registry._emit_change(
+                    ChangeEvent(
+                        event_type=ChangeEventType.REFRESH,
+                        tool_name=name,
+                    )
+                )
+                updated.append(name)
+            elif existing:
+                existing.metadata.last_refreshed_at = now
+                unchanged += 1
+            else:
+                unchanged += 1
+
+        for name, reason in disabled_snapshot.items():
+            if name in new_names:
+                self.registry.disable(name, reason)
+
+        self._registered_tool_names = new_names
+        return added, removed, updated, unchanged
+
     async def refresh_async(self) -> RefreshResult:
         """Re-list tools from the MCP server and synchronise the registry.
 
@@ -431,56 +500,7 @@ class MCPIntegration:
             candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
             new_tools[candidate.name] = candidate
 
-        old_names = set(self._registered_tool_names)
-        new_names = set(new_tools.keys())
-
-        # Snapshot disabled state
-        disabled_snapshot: dict[str, str] = {}
-        for name in old_names:
-            if not self.registry.is_enabled(name):
-                disabled_snapshot[name] = self.registry.get_disable_reason(name) or ""
-
-        to_remove = old_names - new_names
-        to_add = new_names - old_names
-        maybe_updated = old_names & new_names
-
-        added: list[str] = []
-        removed: list[str] = []
-        updated: list[str] = []
-        unchanged = 0
-
-        for name in to_remove:
-            self.registry._unregister(name)
-            removed.append(name)
-
-        for name in to_add:
-            self.registry.register(new_tools[name], namespace=self._resolved_ns)
-            added.append(name)
-
-        for name in maybe_updated:
-            candidate = new_tools[name]
-            existing = self.registry._tools.get(name)
-            if existing and (
-                existing.parameters != candidate.parameters
-                or existing.description != candidate.description
-            ):
-                self.registry._tools[name] = candidate
-                self.registry._emit_change(
-                    ChangeEvent(
-                        event_type=ChangeEventType.REFRESH,
-                        tool_name=name,
-                    )
-                )
-                updated.append(name)
-            else:
-                unchanged += 1
-
-        # Restore disabled state for surviving tools
-        for name, reason in disabled_snapshot.items():
-            if name in new_names:
-                self.registry.disable(name, reason)
-
-        self._registered_tool_names = new_names
+        added, removed, updated, unchanged = self._apply_diff(new_tools)
 
         return RefreshResult(
             source="mcp",

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -7,14 +7,7 @@ from ...events import ChangeEvent, ChangeEventType, RefreshResult
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
-from ...utils import HttpClientConfig, normalize_tool_name
-
-
-def _utc_iso() -> str:
-    """Return the current UTC time as an ISO 8601 string."""
-    from datetime import datetime, timezone
-
-    return datetime.now(timezone.utc).isoformat()
+from ...utils import HttpClientConfig, normalize_tool_name, utc_iso_now
 
 
 class OpenAPIToolWrapper(BaseToolWrapper):
@@ -414,6 +407,7 @@ class OpenAPIIntegration:
             self.registry.register(new_tools[name], namespace=self._resolved_ns)
             added.append(name)
 
+        now = utc_iso_now()
         for name in old_names & new_names:
             candidate = new_tools[name]
             existing = self.registry._tools.get(name)
@@ -421,7 +415,7 @@ class OpenAPIIntegration:
                 existing.metadata.schema_hash != candidate.metadata.schema_hash
                 or existing.description != candidate.description
             ):
-                candidate.metadata.last_refreshed_at = _utc_iso()
+                candidate.metadata.last_refreshed_at = now
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
@@ -432,7 +426,7 @@ class OpenAPIIntegration:
                 updated.append(name)
             else:
                 if existing:
-                    existing.metadata.last_refreshed_at = _utc_iso()
+                    existing.metadata.last_refreshed_at = now
                 unchanged += 1
 
         for name, reason in disabled_snapshot.items():

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -10,6 +10,13 @@ from ...tool_wrapper import BaseToolWrapper
 from ...utils import HttpClientConfig, normalize_tool_name
 
 
+def _utc_iso() -> str:
+    """Return the current UTC time as an ISO 8601 string."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
 class OpenAPIToolWrapper(BaseToolWrapper):
     """Wrapper class that provides both synchronous and asynchronous methods for OpenAPI tool calls.
 
@@ -411,9 +418,10 @@ class OpenAPIIntegration:
             candidate = new_tools[name]
             existing = self.registry._tools.get(name)
             if existing and (
-                existing.parameters != candidate.parameters
+                existing.metadata.schema_hash != candidate.metadata.schema_hash
                 or existing.description != candidate.description
             ):
+                candidate.metadata.last_refreshed_at = _utc_iso()
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
@@ -423,6 +431,8 @@ class OpenAPIIntegration:
                 )
                 updated.append(name)
             else:
+                if existing:
+                    existing.metadata.last_refreshed_at = _utc_iso()
                 unchanged += 1
 
         for name, reason in disabled_snapshot.items():

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -103,6 +103,9 @@ class ToolMetadata:
     fast equality checks (compare hashes) instead of deep dict
     comparison, and lets consumers detect schema changes without
     inspecting the full schema.
+
+    If set before ``Tool.__init__`` runs, the value is trusted and
+    not recomputed.
     """
 
     last_refreshed_at: str = ""

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from .parameter_models import _generate_parameters_model, _simplify_nullable_schemas
 from .llm.tool_calls import API_FORMATS
 from .tool_wrapper import BaseToolWrapper, _FunctionToolWrapper
-from .utils import normalize_tool_name
+from .utils import compute_schema_hash, normalize_tool_name
 
 
 class ToolTag(str, Enum):
@@ -63,6 +63,12 @@ class ToolMetadata:
             ``"openapi"``, ``"langchain"``).
         source_detail: Extra detail about the tool's origin (e.g. a
             transport URI, spec URL, or class name).
+        schema_hash: SHA-256 hex digest of the canonical JSON Schema for
+            the tool's parameters.  Computed at registration time and
+            updated on refresh.
+        last_refreshed_at: ISO 8601 timestamp of the most recent
+            successful refresh, or empty string for tools that have
+            never been refreshed.
         extra: Arbitrary key-value pairs for application-specific use.
     """
 
@@ -88,6 +94,24 @@ class ToolMetadata:
     Free-form string providing additional context about where the tool
     came from, e.g. a transport URI for MCP tools, a spec URL for
     OpenAPI tools, or a class name for LangChain tools.
+    """
+
+    schema_hash: str = ""
+    """SHA-256 hex digest of the canonical ``Tool.parameters`` JSON Schema.
+
+    Computed at registration time and updated on refresh.  Enables
+    fast equality checks (compare hashes) instead of deep dict
+    comparison, and lets consumers detect schema changes without
+    inspecting the full schema.
+    """
+
+    last_refreshed_at: str = ""
+    """ISO 8601 timestamp of the last successful refresh.
+
+    Empty string for tools that have never been refreshed (i.e.
+    registered but never had ``refresh()`` called).  Set even when
+    the refresh found no changes — "I checked and it's current"
+    is valid freshness information.
     """
 
     extra: dict[str, Any] = field(default_factory=dict)
@@ -264,6 +288,8 @@ class Tool:
         self.namespace = namespace
         self.method_name = method_name
         self._inject_toolcall_reason()
+        if not self.metadata.schema_hash:
+            self.metadata.schema_hash = compute_schema_hash(self.parameters)
 
     def _inject_toolcall_reason(self) -> None:
         """Inject ``toolcall_reason`` property into the tool's parameter schema.

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -288,6 +288,7 @@ class Tool:
         self.namespace = namespace
         self.method_name = method_name
         self._inject_toolcall_reason()
+        # Hash after toolcall_reason injection so it reflects the final schema.
         if not self.metadata.schema_hash:
             self.metadata.schema_hash = compute_schema_hash(self.parameters)
 

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -1,6 +1,9 @@
+import hashlib
+import json
 import re
 import uuid
 import warnings
+from datetime import datetime, timezone
 from typing import Any, Literal, overload
 
 from ._vendor.httpclient import AsyncClient, Client
@@ -323,8 +326,10 @@ def compute_schema_hash(parameters: dict[str, Any]) -> str:
     Returns:
         A 64-character lowercase hex string.
     """
-    import hashlib
-    import json
-
     canonical = json.dumps(parameters, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def utc_iso_now() -> str:
+    """Return the current UTC time as an ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat()

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -312,3 +312,19 @@ def normalize_tool_name(name: str) -> str:
 
     # Collapse multiple underscores into single underscore
     return re.sub(r"_+", "_", name)
+
+
+def compute_schema_hash(parameters: dict[str, Any]) -> str:
+    """Compute a deterministic SHA-256 hex digest of a JSON Schema dict.
+
+    Args:
+        parameters: The JSON Schema dict (typically ``Tool.parameters``).
+
+    Returns:
+        A 64-character lowercase hex string.
+    """
+    import hashlib
+    import json
+
+    canonical = json.dumps(parameters, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()

--- a/tests/test_schema_fingerprint.py
+++ b/tests/test_schema_fingerprint.py
@@ -147,3 +147,81 @@ class TestRegistrySchemaHash:
         tool = registry.get_tool("hello")
         assert tool is not None
         assert tool.metadata.last_refreshed_at == ""
+
+
+# ---- Refresh-path integration tests ----
+
+
+class TestRefreshPathIntegration:
+    """Verify schema_hash and last_refreshed_at are used/set during refresh."""
+
+    def _make_openapi_spec(self, params: dict) -> dict:
+        return {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/greet": {
+                    "get": {
+                        "operationId": "greet",
+                        "summary": "Say hello",
+                        "parameters": [
+                            {
+                                "name": k,
+                                "in": "query",
+                                "required": v.get("required", False),
+                                "schema": {"type": v["type"]},
+                            }
+                            for k, v in params.items()
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+
+    def test_refresh_sets_last_refreshed_at(self):
+        from toolregistry.utils import HttpClientConfig
+
+        registry = ToolRegistry()
+        spec_v1 = self._make_openapi_spec(
+            {"name": {"type": "string", "required": True}}
+        )
+        client = HttpClientConfig(base_url="https://api.example.com")
+        registry.register(client, source="openapi", openapi_spec=spec_v1)
+
+        tool = registry.get_tool("greet")
+        assert tool is not None
+        assert tool.metadata.last_refreshed_at == ""
+
+        result = registry.refresh_from_openapi(openapi_spec=spec_v1)
+        assert result.unchanged == 1
+
+        tool = registry.get_tool("greet")
+        assert tool is not None
+        assert tool.metadata.last_refreshed_at != ""
+
+    def test_refresh_uses_schema_hash_for_diff(self):
+        from toolregistry.utils import HttpClientConfig
+
+        registry = ToolRegistry()
+        spec_v1 = self._make_openapi_spec(
+            {"name": {"type": "string", "required": True}}
+        )
+        client = HttpClientConfig(base_url="https://api.example.com")
+        registry.register(client, source="openapi", openapi_spec=spec_v1)
+
+        old_hash = registry.get_tool("greet").metadata.schema_hash
+        assert old_hash
+
+        spec_v2 = self._make_openapi_spec(
+            {
+                "name": {"type": "string", "required": True},
+                "greeting": {"type": "string", "required": False},
+            }
+        )
+        result = registry.refresh_from_openapi(openapi_spec=spec_v2)
+        assert result.updated == ("greet",)
+
+        new_hash = registry.get_tool("greet").metadata.schema_hash
+        assert new_hash != old_hash
+        assert registry.get_tool("greet").metadata.last_refreshed_at != ""

--- a/tests/test_schema_fingerprint.py
+++ b/tests/test_schema_fingerprint.py
@@ -1,0 +1,149 @@
+"""Tests for schema fingerprint and staleness timestamp on ToolMetadata."""
+
+from toolregistry import Tool, ToolMetadata, ToolRegistry
+from toolregistry.utils import compute_schema_hash
+
+
+# ---- compute_schema_hash ----
+
+
+class TestComputeSchemaHash:
+    def test_deterministic(self):
+        schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+        h1 = compute_schema_hash(schema)
+        h2 = compute_schema_hash(schema)
+        assert h1 == h2
+
+    def test_key_order_invariant(self):
+        s1 = {"type": "object", "properties": {"a": {"type": "string"}}}
+        s2 = {"properties": {"a": {"type": "string"}}, "type": "object"}
+        assert compute_schema_hash(s1) == compute_schema_hash(s2)
+
+    def test_different_schemas_differ(self):
+        s1 = {"type": "object", "properties": {"a": {"type": "string"}}}
+        s2 = {"type": "object", "properties": {"a": {"type": "integer"}}}
+        assert compute_schema_hash(s1) != compute_schema_hash(s2)
+
+    def test_hex_length(self):
+        h = compute_schema_hash({"type": "object"})
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_empty_schema(self):
+        h = compute_schema_hash({})
+        assert len(h) == 64
+
+
+# ---- ToolMetadata fields ----
+
+
+class TestToolMetadataFields:
+    def test_defaults(self):
+        meta = ToolMetadata()
+        assert meta.schema_hash == ""
+        assert meta.last_refreshed_at == ""
+
+    def test_schema_hash_set_explicitly(self):
+        meta = ToolMetadata(schema_hash="abc123")
+        assert meta.schema_hash == "abc123"
+
+    def test_last_refreshed_at_set_explicitly(self):
+        meta = ToolMetadata(last_refreshed_at="2025-01-01T00:00:00+00:00")
+        assert meta.last_refreshed_at == "2025-01-01T00:00:00+00:00"
+
+    def test_model_dump_includes_new_fields(self):
+        meta = ToolMetadata(schema_hash="abc", last_refreshed_at="2025-01-01")
+        d = meta.model_dump()
+        assert d["schema_hash"] == "abc"
+        assert d["last_refreshed_at"] == "2025-01-01"
+
+
+# ---- Tool auto-populates schema_hash ----
+
+
+class TestToolSchemaHash:
+    def test_from_function_populates_hash(self):
+        def greet(name: str) -> str:
+            """Say hello."""
+            return f"Hello, {name}!"
+
+        tool = Tool.from_function(greet)
+        assert tool.metadata.schema_hash
+        assert len(tool.metadata.schema_hash) == 64
+
+    def test_direct_construction_populates_hash(self):
+        tool = Tool(
+            name="test",
+            description="test tool",
+            parameters={"type": "object", "properties": {"x": {"type": "integer"}}},
+            callable=lambda: None,
+        )
+        assert tool.metadata.schema_hash
+        assert len(tool.metadata.schema_hash) == 64
+
+    def test_hash_matches_parameters(self):
+        params = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        tool = Tool(
+            name="test",
+            description="test tool",
+            parameters=params,
+            callable=lambda: None,
+        )
+        # Note: Tool.__init__ may modify parameters (inject toolcall_reason),
+        # so we hash the final parameters
+        expected = compute_schema_hash(tool.parameters)
+        assert tool.metadata.schema_hash == expected
+
+    def test_different_params_different_hash(self):
+        def add(a: int, b: int) -> int:
+            """Add numbers."""
+            return a + b
+
+        def greet(name: str) -> str:
+            """Say hello."""
+            return f"Hello, {name}!"
+
+        t1 = Tool.from_function(add)
+        t2 = Tool.from_function(greet)
+        assert t1.metadata.schema_hash != t2.metadata.schema_hash
+
+    def test_pre_set_hash_not_overwritten(self):
+        meta = ToolMetadata(schema_hash="custom_hash")
+        tool = Tool(
+            name="test",
+            description="test tool",
+            parameters={"type": "object", "properties": {}},
+            callable=lambda: None,
+            metadata=meta,
+        )
+        assert tool.metadata.schema_hash == "custom_hash"
+
+
+# ---- Registry registration populates hash ----
+
+
+class TestRegistrySchemaHash:
+    def test_registered_tool_has_hash(self):
+        registry = ToolRegistry()
+
+        def hello(name: str) -> str:
+            """Say hello."""
+            return f"Hi, {name}!"
+
+        registry.register(hello)
+        tool = registry.get_tool("hello")
+        assert tool is not None
+        assert tool.metadata.schema_hash
+        assert len(tool.metadata.schema_hash) == 64
+
+    def test_last_refreshed_at_empty_after_registration(self):
+        registry = ToolRegistry()
+
+        def hello(name: str) -> str:
+            """Say hello."""
+            return f"Hi, {name}!"
+
+        registry.register(hello)
+        tool = registry.get_tool("hello")
+        assert tool is not None
+        assert tool.metadata.last_refreshed_at == ""


### PR DESCRIPTION
## Summary

- Add `schema_hash` (SHA-256 hex digest of canonical JSON Schema) and `last_refreshed_at` (ISO 8601 timestamp) fields to `ToolMetadata`
- `schema_hash` auto-computed in `Tool.__init__` after toolcall_reason injection — enables fast hash-based equality checks on refresh instead of deep dict comparison
- `last_refreshed_at` set by both MCP and OpenAPI refresh on updated *and* unchanged tools ("I checked and it's still current" is valid freshness info)
- Extract MCP `_apply_diff()` helper to match OpenAPI's existing pattern, keeping `refresh_async` under the complexity threshold
- Add `compute_schema_hash()` utility in `utils.py`

## Test plan

- [x] `compute_schema_hash`: deterministic, key-order-invariant, different schemas → different hashes
- [x] `ToolMetadata` defaults: both fields empty string
- [x] `Tool.__init__` auto-populates `schema_hash` from final `parameters`
- [x] Pre-set `schema_hash` on metadata is preserved (not overwritten)
- [x] Different functions → different hashes
- [x] Registered tools have hash; `last_refreshed_at` empty until refreshed
- [x] All existing refresh tests pass (MCP + OpenAPI)
- [x] Full test suite regression check: 287+ tests pass

Closes #251