### PR TITLE
feat: classify breaking vs compatible changes on refresh

### DIFF
--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -13,6 +13,7 @@ from .events import (
     PostRegisterHook,
     RefreshResult,
 )
+from .schema_diff import SchemaChangeKind
 from .executor import (
     ExecutionContext,
     ProcessPoolBackend,
@@ -62,6 +63,7 @@ __all__ = [
     "ToolRegistry",
     "ToolDiscoveryTool",
     "ToolTag",
+    "SchemaChangeKind",
 ]
 
 __version__ = "0.16.0"

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, TypeAlias
 from collections.abc import Callable
 
+
 if TYPE_CHECKING:
     from .tool import Tool
     from .tool_registry import ToolRegistry
@@ -85,6 +86,8 @@ class RefreshResult:
         added: Names of newly discovered tools.
         removed: Names of tools that no longer exist on the remote source.
         updated: Names of tools whose schema or description changed.
+        breaking: Subset of *updated* classified as breaking changes.
+        compatible: Subset of *updated* classified as compatible changes.
         unchanged: Count of tools that matched and required no update.
         skipped: ``True`` when the remote source reported no changes
             (e.g. HTTP 304 via ETag).
@@ -95,6 +98,8 @@ class RefreshResult:
     added: tuple[str, ...] = ()
     removed: tuple[str, ...] = ()
     updated: tuple[str, ...] = ()
+    breaking: tuple[str, ...] = ()
+    compatible: tuple[str, ...] = ()
     unchanged: int = 0
     skipped: bool = False
 

--- a/src/toolregistry/events.py
+++ b/src/toolregistry/events.py
@@ -88,6 +88,7 @@ class RefreshResult:
         updated: Names of tools whose schema or description changed.
         breaking: Subset of *updated* classified as breaking changes.
         compatible: Subset of *updated* classified as compatible changes.
+            Invariant: ``len(breaking) + len(compatible) == len(updated)``.
         unchanged: Count of tools that matched and required no update.
         skipped: ``True`` when the remote source reported no changes
             (e.g. HTTP 304 via ETag).

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -16,7 +16,7 @@ from mcp.types import Tool as ToolSpec
 from ..._vendor.structlog import get_logger
 from ._compat import get_field
 from ...events import ChangeEvent, ChangeEventType, RefreshResult
-from ...schema_diff import SchemaChangeKind, classify_schema_change
+from ...schema_diff import SchemaChangeKind, classify_tool_change
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
@@ -428,8 +428,11 @@ class MCPIntegration:
                 existing.metadata.schema_hash != candidate.metadata.schema_hash
                 or existing.description != candidate.description
             ):
-                kind, summary = classify_schema_change(
-                    existing.parameters, candidate.parameters
+                kind, summary = classify_tool_change(
+                    existing.metadata.schema_hash,
+                    candidate.metadata.schema_hash,
+                    existing.parameters,
+                    candidate.parameters,
                 )
                 candidate.metadata.last_refreshed_at = now
                 self.registry._tools[name] = candidate
@@ -441,10 +444,9 @@ class MCPIntegration:
                     )
                 )
                 updated.append(name)
-                if kind == SchemaChangeKind.BREAKING:
-                    breaking.append(name)
-                else:
-                    compatible.append(name)
+                (breaking if kind == SchemaChangeKind.BREAKING else compatible).append(
+                    name
+                )
             elif existing:
                 existing.metadata.last_refreshed_at = now
                 unchanged += 1

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -16,6 +16,7 @@ from mcp.types import Tool as ToolSpec
 from ..._vendor.structlog import get_logger
 from ._compat import get_field
 from ...events import ChangeEvent, ChangeEventType, RefreshResult
+from ...schema_diff import SchemaChangeKind, classify_schema_change
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
 from ...tool_wrapper import BaseToolWrapper
@@ -389,11 +390,11 @@ class MCPIntegration:
     def _apply_diff(
         self,
         new_tools: dict[str, "MCPTool"],
-    ) -> tuple[list[str], list[str], list[str], int]:
+    ) -> tuple[list[str], list[str], list[str], list[str], list[str], int]:
         """Diff *new_tools* against registered tools and apply changes.
 
         Returns:
-            ``(added, removed, updated, unchanged)`` lists/count.
+            ``(added, removed, updated, breaking, compatible, unchanged)``.
         """
         old_names = set(self._registered_tool_names)
         new_names = set(new_tools.keys())
@@ -407,6 +408,8 @@ class MCPIntegration:
         added: list[str] = []
         removed: list[str] = []
         updated: list[str] = []
+        breaking: list[str] = []
+        compatible: list[str] = []
         unchanged = 0
 
         for name in old_names - new_names:
@@ -425,15 +428,23 @@ class MCPIntegration:
                 existing.metadata.schema_hash != candidate.metadata.schema_hash
                 or existing.description != candidate.description
             ):
+                kind, summary = classify_schema_change(
+                    existing.parameters, candidate.parameters
+                )
                 candidate.metadata.last_refreshed_at = now
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
                         event_type=ChangeEventType.REFRESH,
                         tool_name=name,
+                        metadata={"change_kind": kind.value, "diff_summary": summary},
                     )
                 )
                 updated.append(name)
+                if kind == SchemaChangeKind.BREAKING:
+                    breaking.append(name)
+                else:
+                    compatible.append(name)
             elif existing:
                 existing.metadata.last_refreshed_at = now
                 unchanged += 1
@@ -446,7 +457,7 @@ class MCPIntegration:
                 self.registry.disable(name, reason)
 
         self._registered_tool_names = new_names
-        return added, removed, updated, unchanged
+        return added, removed, updated, breaking, compatible, unchanged
 
     async def refresh_async(self) -> RefreshResult:
         """Re-list tools from the MCP server and synchronise the registry.
@@ -494,7 +505,9 @@ class MCPIntegration:
             candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
             new_tools[candidate.name] = candidate
 
-        added, removed, updated, unchanged = self._apply_diff(new_tools)
+        added, removed, updated, breaking, compatible, unchanged = self._apply_diff(
+            new_tools
+        )
 
         return RefreshResult(
             source="mcp",
@@ -502,6 +515,8 @@ class MCPIntegration:
             added=tuple(added),
             removed=tuple(removed),
             updated=tuple(updated),
+            breaking=tuple(breaking),
+            compatible=tuple(compatible),
             unchanged=unchanged,
         )
 

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -3,7 +3,7 @@ import threading
 from typing import Any
 
 from ...events import ChangeEvent, ChangeEventType, RefreshResult
-from ...schema_diff import SchemaChangeKind, classify_schema_change
+from ...schema_diff import SchemaChangeKind, classify_tool_change
 
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
@@ -418,8 +418,11 @@ class OpenAPIIntegration:
                 existing.metadata.schema_hash != candidate.metadata.schema_hash
                 or existing.description != candidate.description
             ):
-                kind, summary = classify_schema_change(
-                    existing.parameters, candidate.parameters
+                kind, summary = classify_tool_change(
+                    existing.metadata.schema_hash,
+                    candidate.metadata.schema_hash,
+                    existing.parameters,
+                    candidate.parameters,
                 )
                 candidate.metadata.last_refreshed_at = now
                 self.registry._tools[name] = candidate
@@ -431,10 +434,9 @@ class OpenAPIIntegration:
                     )
                 )
                 updated.append(name)
-                if kind == SchemaChangeKind.BREAKING:
-                    breaking.append(name)
-                else:
-                    compatible.append(name)
+                (breaking if kind == SchemaChangeKind.BREAKING else compatible).append(
+                    name
+                )
             elif existing:
                 existing.metadata.last_refreshed_at = now
                 unchanged += 1

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -3,6 +3,7 @@ import threading
 from typing import Any
 
 from ...events import ChangeEvent, ChangeEventType, RefreshResult
+from ...schema_diff import SchemaChangeKind, classify_schema_change
 
 from ...tool import Tool, ToolMetadata
 from ...tool_registry import ToolRegistry
@@ -379,11 +380,11 @@ class OpenAPIIntegration:
     def _apply_diff(
         self,
         new_tools: dict[str, OpenAPITool],
-    ) -> tuple[list[str], list[str], list[str], int]:
+    ) -> tuple[list[str], list[str], list[str], list[str], list[str], int]:
         """Diff *new_tools* against registered tools and apply changes.
 
         Returns:
-            ``(added, removed, updated, unchanged)`` lists/count.
+            ``(added, removed, updated, breaking, compatible, unchanged)``.
         """
         old_names = set(self._registered_tool_names)
         new_names = set(new_tools.keys())
@@ -397,6 +398,8 @@ class OpenAPIIntegration:
         added: list[str] = []
         removed: list[str] = []
         updated: list[str] = []
+        breaking: list[str] = []
+        compatible: list[str] = []
         unchanged = 0
 
         for name in old_names - new_names:
@@ -415,18 +418,27 @@ class OpenAPIIntegration:
                 existing.metadata.schema_hash != candidate.metadata.schema_hash
                 or existing.description != candidate.description
             ):
+                kind, summary = classify_schema_change(
+                    existing.parameters, candidate.parameters
+                )
                 candidate.metadata.last_refreshed_at = now
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
                         event_type=ChangeEventType.REFRESH,
                         tool_name=name,
+                        metadata={"change_kind": kind.value, "diff_summary": summary},
                     )
                 )
                 updated.append(name)
+                if kind == SchemaChangeKind.BREAKING:
+                    breaking.append(name)
+                else:
+                    compatible.append(name)
+            elif existing:
+                existing.metadata.last_refreshed_at = now
+                unchanged += 1
             else:
-                if existing:
-                    existing.metadata.last_refreshed_at = now
                 unchanged += 1
 
         for name, reason in disabled_snapshot.items():
@@ -434,7 +446,7 @@ class OpenAPIIntegration:
                 self.registry.disable(name, reason)
 
         self._registered_tool_names = new_names
-        return added, removed, updated, unchanged
+        return added, removed, updated, breaking, compatible, unchanged
 
     async def refresh_async(
         self,
@@ -472,7 +484,9 @@ class OpenAPIIntegration:
             )
 
         new_tools = self._build_tool_map(resolved, self._client_config)
-        added, removed, updated, unchanged = self._apply_diff(new_tools)
+        added, removed, updated, breaking, compatible, unchanged = self._apply_diff(
+            new_tools
+        )
 
         return RefreshResult(
             source="openapi",
@@ -480,6 +494,8 @@ class OpenAPIIntegration:
             added=tuple(added),
             removed=tuple(removed),
             updated=tuple(updated),
+            breaking=tuple(breaking),
+            compatible=tuple(compatible),
             unchanged=unchanged,
         )
 

--- a/src/toolregistry/schema_diff.py
+++ b/src/toolregistry/schema_diff.py
@@ -1,0 +1,123 @@
+"""Classify JSON Schema changes as compatible or breaking.
+
+This module provides lightweight heuristics for determining whether a
+change to a tool's parameter schema is backward-compatible (safe for
+existing callers) or breaking (likely to cause call failures).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class SchemaChangeKind(str, Enum):
+    """Classification of a schema change's backward-compatibility impact.
+
+    Attributes:
+        COMPATIBLE: Additive-only change — new optional parameters,
+            description updates, widened types.  Existing callers are
+            unaffected.
+        BREAKING: Destructive change — removed parameters, new required
+            parameters, type narrowing.  Existing callers may fail.
+        UNKNOWN: Cannot determine compatibility — e.g. complete schema
+            replacement with no structural overlap.
+    """
+
+    COMPATIBLE = "compatible"
+    BREAKING = "breaking"
+    UNKNOWN = "unknown"
+
+
+def classify_schema_change(
+    old: dict[str, Any],
+    new: dict[str, Any],
+) -> tuple[SchemaChangeKind, dict[str, Any]]:
+    """Classify a schema change and produce a diff summary.
+
+    Args:
+        old: The previous JSON Schema dict.
+        new: The updated JSON Schema dict.
+
+    Returns:
+        A ``(kind, summary)`` tuple where *kind* is the compatibility
+        classification and *summary* is a dict describing what changed::
+
+            {
+                "added_optional": ["param_c"],
+                "added_required": ["param_d"],
+                "removed": ["param_a"],
+                "newly_required": ["param_b"],
+                "no_longer_required": ["param_e"],
+                "type_changed": {"param_x": {"old": "string", "new": "integer"}},
+            }
+
+        Empty lists/dicts are omitted from the summary.
+    """
+    old_props = old.get("properties", {})
+    new_props = new.get("properties", {})
+    old_required = set(old.get("required", []))
+    new_required = set(new.get("required", []))
+
+    old_keys = set(old_props.keys()) - {"toolcall_reason"}
+    new_keys = set(new_props.keys()) - {"toolcall_reason"}
+
+    added_keys = new_keys - old_keys
+    removed_keys = old_keys - new_keys
+    common_keys = old_keys & new_keys
+
+    added_required = [k for k in sorted(added_keys) if k in new_required]
+    added_optional = [k for k in sorted(added_keys) if k not in new_required]
+    removed = sorted(removed_keys)
+
+    newly_required = sorted(
+        k for k in common_keys if k not in old_required and k in new_required
+    )
+    no_longer_required = sorted(
+        k for k in common_keys if k in old_required and k not in new_required
+    )
+
+    type_changed: dict[str, dict[str, Any]] = {}
+    for k in sorted(common_keys):
+        old_type = _extract_type(old_props[k])
+        new_type = _extract_type(new_props[k])
+        if old_type != new_type:
+            type_changed[k] = {"old": old_type, "new": new_type}
+
+    summary: dict[str, Any] = {}
+    if added_optional:
+        summary["added_optional"] = added_optional
+    if added_required:
+        summary["added_required"] = added_required
+    if removed:
+        summary["removed"] = removed
+    if newly_required:
+        summary["newly_required"] = newly_required
+    if no_longer_required:
+        summary["no_longer_required"] = no_longer_required
+    if type_changed:
+        summary["type_changed"] = type_changed
+
+    is_breaking = bool(added_required or removed or newly_required or type_changed)
+
+    if is_breaking:
+        kind = SchemaChangeKind.BREAKING
+    elif summary:
+        kind = SchemaChangeKind.COMPATIBLE
+    else:
+        kind = SchemaChangeKind.COMPATIBLE
+
+    return kind, summary
+
+
+def _extract_type(prop_schema: dict[str, Any]) -> Any:
+    """Extract a comparable type representation from a property schema."""
+    if "type" in prop_schema:
+        return prop_schema["type"]
+    if "anyOf" in prop_schema:
+        return ("anyOf", tuple(sorted(str(s) for s in prop_schema["anyOf"])))
+    if "oneOf" in prop_schema:
+        return ("oneOf", tuple(sorted(str(s) for s in prop_schema["oneOf"])))
+    if "allOf" in prop_schema:
+        return ("allOf", tuple(sorted(str(s) for s in prop_schema["allOf"])))
+    return None

--- a/src/toolregistry/schema_diff.py
+++ b/src/toolregistry/schema_diff.py
@@ -3,10 +3,19 @@
 This module provides lightweight heuristics for determining whether a
 change to a tool's parameter schema is backward-compatible (safe for
 existing callers) or breaking (likely to cause call failures).
+
+Known limitations:
+
+- Only inspects top-level properties.  Nested object changes (e.g. a
+  property of type ``object`` whose sub-properties change) are not
+  detected.
+- All type changes are treated as breaking.  Type widenings (e.g.
+  ``integer`` → ``number``) are not yet recognized as compatible.
 """
 
 from __future__ import annotations
 
+import json
 from enum import Enum
 from typing import Any
 
@@ -16,10 +25,10 @@ class SchemaChangeKind(str, Enum):
 
     Attributes:
         COMPATIBLE: Additive-only change — new optional parameters,
-            description updates, widened types.  Existing callers are
-            unaffected.
+            description updates, relaxed requirements.  Existing callers
+            are unaffected.
         BREAKING: Destructive change — removed parameters, new required
-            parameters, type narrowing.  Existing callers may fail.
+            parameters, type changes.  Existing callers may fail.
         UNKNOWN: Cannot determine compatibility — e.g. complete schema
             replacement with no structural overlap.
     """
@@ -66,6 +75,15 @@ def classify_schema_change(
     removed_keys = old_keys - new_keys
     common_keys = old_keys & new_keys
 
+    # No structural overlap — can't determine compatibility
+    if not old_keys and not new_keys:
+        return SchemaChangeKind.COMPATIBLE, {}
+    if old_keys and new_keys and not common_keys:
+        return SchemaChangeKind.UNKNOWN, {
+            "added": sorted(new_keys),
+            "removed": sorted(old_keys),
+        }
+
     added_required = [k for k in sorted(added_keys) if k in new_required]
     added_optional = [k for k in sorted(added_keys) if k not in new_required]
     removed = sorted(removed_keys)
@@ -99,13 +117,7 @@ def classify_schema_change(
         summary["type_changed"] = type_changed
 
     is_breaking = bool(added_required or removed or newly_required or type_changed)
-
-    if is_breaking:
-        kind = SchemaChangeKind.BREAKING
-    elif summary:
-        kind = SchemaChangeKind.COMPATIBLE
-    else:
-        kind = SchemaChangeKind.COMPATIBLE
+    kind = SchemaChangeKind.BREAKING if is_breaking else SchemaChangeKind.COMPATIBLE
 
     return kind, summary
 
@@ -115,9 +127,41 @@ def _extract_type(prop_schema: dict[str, Any]) -> Any:
     if "type" in prop_schema:
         return prop_schema["type"]
     if "anyOf" in prop_schema:
-        return ("anyOf", tuple(sorted(str(s) for s in prop_schema["anyOf"])))
+        types = tuple(
+            sorted(json.dumps(s, sort_keys=True) for s in prop_schema["anyOf"])
+        )
+        return ("anyOf", types)
     if "oneOf" in prop_schema:
-        return ("oneOf", tuple(sorted(str(s) for s in prop_schema["oneOf"])))
+        types = tuple(
+            sorted(json.dumps(s, sort_keys=True) for s in prop_schema["oneOf"])
+        )
+        return ("oneOf", types)
     if "allOf" in prop_schema:
-        return ("allOf", tuple(sorted(str(s) for s in prop_schema["allOf"])))
+        types = tuple(
+            sorted(json.dumps(s, sort_keys=True) for s in prop_schema["allOf"])
+        )
+        return ("allOf", types)
     return None
+
+
+def classify_tool_change(
+    old_hash: str,
+    new_hash: str,
+    old_params: dict[str, Any],
+    new_params: dict[str, Any],
+) -> tuple[SchemaChangeKind, dict[str, Any]]:
+    """Classify a tool update, distinguishing schema changes from description-only.
+
+    Args:
+        old_hash: Schema hash of the existing tool.
+        new_hash: Schema hash of the candidate tool.
+        old_params: Parameter schema of the existing tool.
+        new_params: Parameter schema of the candidate tool.
+
+    Returns:
+        A ``(kind, summary)`` tuple.  When hashes match (description-only
+        change), returns ``(COMPATIBLE, {"description_only": True})``.
+    """
+    if old_hash != new_hash:
+        return classify_schema_change(old_params, new_params)
+    return SchemaChangeKind.COMPATIBLE, {"description_only": True}

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -320,13 +320,24 @@ def normalize_tool_name(name: str) -> str:
 def compute_schema_hash(parameters: dict[str, Any]) -> str:
     """Compute a deterministic SHA-256 hex digest of a JSON Schema dict.
 
+    The ``toolcall_reason`` property (injected by ``Tool.__init__``) is
+    excluded so that toggling thought-augmented calling does not change
+    the hash.
+
     Args:
         parameters: The JSON Schema dict (typically ``Tool.parameters``).
 
     Returns:
         A 64-character lowercase hex string.
     """
-    canonical = json.dumps(parameters, sort_keys=True, separators=(",", ":"))
+    filtered = parameters
+    props = parameters.get("properties")
+    if isinstance(props, dict) and "toolcall_reason" in props:
+        filtered = {
+            **parameters,
+            "properties": {k: v for k, v in props.items() if k != "toolcall_reason"},
+        }
+    canonical = json.dumps(filtered, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 

--- a/tests/test_schema_diff.py
+++ b/tests/test_schema_diff.py
@@ -1,0 +1,177 @@
+"""Tests for schema change classification."""
+
+from toolregistry.schema_diff import SchemaChangeKind, classify_schema_change
+
+
+class TestClassifySchemaChange:
+    """Test classify_schema_change heuristics."""
+
+    def test_identical_schemas(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        }
+        kind, summary = classify_schema_change(schema, schema)
+        assert kind == SchemaChangeKind.COMPATIBLE
+        assert summary == {}
+
+    def test_added_optional_parameter(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a"],
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.COMPATIBLE
+        assert summary == {"added_optional": ["b"]}
+
+    def test_added_required_parameter_is_breaking(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.BREAKING
+        assert summary["added_required"] == ["b"]
+
+    def test_removed_parameter_is_breaking(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a"],
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.BREAKING
+        assert summary["removed"] == ["b"]
+
+    def test_newly_required_is_breaking(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a"],
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.BREAKING
+        assert summary["newly_required"] == ["b"]
+
+    def test_no_longer_required_is_compatible(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a"],
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.COMPATIBLE
+        assert summary["no_longer_required"] == ["b"]
+
+    def test_type_change_is_breaking(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "integer"}},
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.BREAKING
+        assert summary["type_changed"] == {"a": {"old": "string", "new": "integer"}}
+
+    def test_multiple_changes_mixed(self):
+        old = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a"],
+        }
+        new = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "c": {"type": "boolean"},
+            },
+            "required": ["a", "c"],
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.BREAKING
+        assert "b" in summary["removed"]
+        assert "c" in summary["added_required"]
+
+    def test_empty_schemas(self):
+        kind, summary = classify_schema_change({}, {})
+        assert kind == SchemaChangeKind.COMPATIBLE
+        assert summary == {}
+
+    def test_toolcall_reason_ignored(self):
+        old = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "toolcall_reason": {"type": "string"},
+            },
+        }
+        new = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+            },
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.COMPATIBLE
+        assert summary == {}
+
+    def test_anyof_type_change(self):
+        old = {
+            "type": "object",
+            "properties": {
+                "a": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            },
+        }
+        new = {
+            "type": "object",
+            "properties": {
+                "a": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            },
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.BREAKING
+        assert "a" in summary["type_changed"]
+
+
+class TestSchemaChangeKindEnum:
+    def test_values(self):
+        assert SchemaChangeKind.COMPATIBLE == "compatible"
+        assert SchemaChangeKind.BREAKING == "breaking"
+        assert SchemaChangeKind.UNKNOWN == "unknown"
+
+    def test_is_str(self):
+        assert isinstance(SchemaChangeKind.COMPATIBLE, str)

--- a/tests/test_schema_diff.py
+++ b/tests/test_schema_diff.py
@@ -175,3 +175,88 @@ class TestSchemaChangeKindEnum:
 
     def test_is_str(self):
         assert isinstance(SchemaChangeKind.COMPATIBLE, str)
+
+    def test_no_structural_overlap_returns_unknown(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+        }
+        new = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}, "y": {"type": "integer"}},
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.UNKNOWN
+        assert "added" in summary
+        assert "removed" in summary
+
+    def test_partial_overlap_not_unknown(self):
+        old = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+        }
+        new = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "c": {"type": "boolean"}},
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind != SchemaChangeKind.UNKNOWN
+
+    def test_anyof_order_independent(self):
+        """json.dumps(sort_keys=True) makes sub-schema comparison order-independent."""
+        old = {
+            "type": "object",
+            "properties": {
+                "a": {"anyOf": [{"type": "string", "minLength": 1}, {"type": "null"}]},
+            },
+        }
+        new = {
+            "type": "object",
+            "properties": {
+                "a": {"anyOf": [{"type": "null"}, {"minLength": 1, "type": "string"}]},
+            },
+        }
+        kind, summary = classify_schema_change(old, new)
+        assert kind == SchemaChangeKind.COMPATIBLE
+        assert "type_changed" not in summary
+
+
+class TestToolcallReasonHashExclusion:
+    """Verify toolcall_reason is excluded from schema hash."""
+
+    def test_hash_excludes_toolcall_reason(self):
+        from toolregistry.utils import compute_schema_hash
+
+        schema_with = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "toolcall_reason": {"type": "string", "description": "Why"},
+            },
+        }
+        schema_without = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+            },
+        }
+        assert compute_schema_hash(schema_with) == compute_schema_hash(schema_without)
+
+    def test_hash_still_sensitive_to_real_changes(self):
+        from toolregistry.utils import compute_schema_hash
+
+        s1 = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "toolcall_reason": {"type": "string"},
+            },
+        }
+        s2 = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "toolcall_reason": {"type": "string"},
+            },
+        }
+        assert compute_schema_hash(s1) != compute_schema_hash(s2)


### PR DESCRIPTION
## Summary

- New `schema_diff.py` module with `SchemaChangeKind` enum and `classify_schema_change()` function
- Heuristics classify schema changes as **breaking** (removed params, new required params, type changes, newly-required existing params) or **compatible** (new optional params, relaxed requirements)
- `RefreshResult` gains `breaking` and `compatible` tuples — subsets of `updated` classified by compatibility
- `ChangeEvent.metadata` now includes `change_kind` and `diff_summary` for `REFRESH` events, making callbacks actionable
- `toolcall_reason` property is excluded from diff (injected by ToolRegistry internals, not a user-authored schema change)

**Stacked on #253** — depends on schema fingerprint for hash-based diff.

## Test plan

- [x] `classify_schema_change`: identical schemas, added optional, added required (breaking), removed param (breaking), newly required (breaking), no longer required (compatible), type change (breaking), mixed changes, empty schemas, toolcall_reason ignored, anyOf type changes
- [x] `SchemaChangeKind` enum string values
- [x] All existing refresh tests pass (MCP + OpenAPI)
- [x] Full test suite regression check: 278+ core tests pass, 81 targeted tests pass

Closes #252