### PR TITLE
feat: expose cookie support in HttpClientConfig

### DIFF
--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -117,6 +117,10 @@ class HttpClientConfig:
         headers: Custom request headers. Default is None.
         timeout: Request timeout in seconds. Default is 10.0.
         auth: Basic authentication credentials (username, password). Default is None.
+        cookies: Initial cookies to send with requests. The underlying
+            client maintains a persistent cookie jar — cookies from
+            ``Set-Cookie`` response headers are accumulated across
+            requests on the same persistent client. Default is None.
         **extra_options: Additional client parameters (e.g. verify, proxy, pool_size).
     """
 
@@ -129,12 +133,14 @@ class HttpClientConfig:
         headers: dict[str, str] | None = None,
         timeout: float = 10.0,
         auth: tuple[str, str] | None = None,
+        cookies: dict[str, str] | None = None,
         **extra_options: Any,
     ):
         self.base_url = base_url.rstrip("/")
         self.headers = headers or {}
         self.timeout = timeout
         self.auth = auth
+        self.cookies = cookies
         self.extra_options = extra_options
         self._sync_client: _BaseUrlClient | None = None
         self._async_client: _BaseUrlAsyncClient | None = None
@@ -145,6 +151,7 @@ class HttpClientConfig:
             "headers": self.headers,
             "timeout": self.timeout,
             "auth": self.auth,
+            "cookies": self.cookies,
         }
         for key in self._KNOWN_CLIENT_PARAMS:
             if key in self.extra_options:
@@ -252,6 +259,7 @@ class HttpClientConfig:
             "headers": self.headers,
             "timeout": self.timeout,
             "auth": self.auth,
+            "cookies": self.cookies,
             "extra_options": self.extra_options,
         }
 
@@ -261,6 +269,7 @@ class HttpClientConfig:
         self.headers = state["headers"]
         self.timeout = state["timeout"]
         self.auth = state["auth"]
+        self.cookies = state.get("cookies")
         self.extra_options = state["extra_options"]
         self._sync_client = None
         self._async_client = None

--- a/tests/test_httpclient_cookies.py
+++ b/tests/test_httpclient_cookies.py
@@ -1,0 +1,75 @@
+"""Tests for cookie support in HttpClientConfig."""
+
+import pickle
+
+
+from toolregistry.utils import HttpClientConfig
+
+
+class TestHttpClientConfigCookies:
+    """Test cookie parameter on HttpClientConfig."""
+
+    def test_default_cookies_none(self):
+        config = HttpClientConfig(base_url="https://example.com")
+        assert config.cookies is None
+
+    def test_cookies_stored(self):
+        cookies = {"session_id": "abc123", "csrf": "xyz"}
+        config = HttpClientConfig(base_url="https://example.com", cookies=cookies)
+        assert config.cookies == cookies
+
+    def test_cookies_in_client_kwargs(self):
+        cookies = {"JSESSIONID": "abc"}
+        config = HttpClientConfig(base_url="https://example.com", cookies=cookies)
+        kwargs = config._client_kwargs()
+        assert kwargs["cookies"] == cookies
+
+    def test_no_cookies_in_client_kwargs(self):
+        config = HttpClientConfig(base_url="https://example.com")
+        kwargs = config._client_kwargs()
+        assert kwargs["cookies"] is None
+
+    def test_cookies_passed_to_sync_client(self):
+        cookies = {"session": "test123"}
+        config = HttpClientConfig(base_url="https://example.com", cookies=cookies)
+        client = config.to_client(use_async=False)
+        assert client._client._cookies == cookies
+
+    def test_cookies_passed_to_async_client(self):
+        cookies = {"session": "test123"}
+        config = HttpClientConfig(base_url="https://example.com", cookies=cookies)
+        client = config.to_client(use_async=True)
+        assert client._client._cookies == cookies
+
+    def test_persistent_client_preserves_cookies(self):
+        cookies = {"session": "persistent"}
+        config = HttpClientConfig(base_url="https://example.com", cookies=cookies)
+        client1 = config.get_persistent_client(use_async=False)
+        client2 = config.get_persistent_client(use_async=False)
+        assert client1 is client2
+        assert client1._client._cookies == cookies
+
+
+class TestHttpClientConfigCookiesPickle:
+    """Test that cookies survive pickling (for ProcessPoolBackend)."""
+
+    def test_pickle_preserves_cookies(self):
+        cookies = {"JSESSIONID": "abc123"}
+        config = HttpClientConfig(base_url="https://example.com", cookies=cookies)
+        restored = pickle.loads(pickle.dumps(config))
+        assert restored.cookies == cookies
+        assert restored.base_url == "https://example.com"
+
+    def test_pickle_none_cookies(self):
+        config = HttpClientConfig(base_url="https://example.com")
+        restored = pickle.loads(pickle.dumps(config))
+        assert restored.cookies is None
+
+    def test_pickle_backward_compat(self):
+        """Old pickled state without cookies key should work."""
+        config = HttpClientConfig(base_url="https://example.com")
+        state = config.__getstate__()
+        del state["cookies"]
+        config2 = HttpClientConfig.__new__(HttpClientConfig)
+        config2.__setstate__(state)
+        assert config2.cookies is None


### PR DESCRIPTION
## Summary

- Add `cookies` parameter to `HttpClientConfig` — a `dict[str, str]` that seeds the vendored httpclient 0.5.0's persistent cookie jar
- Cookies flow through `_client_kwargs()` → `Client(cookies=...)` / `AsyncClient(cookies=...)`
- Persistent clients (`get_persistent_client()`) accumulate cookies from `Set-Cookie` response headers across requests — enabling session-cookie flows (login → session cookie → subsequent calls)
- Cookies survive pickling for `ProcessPoolBackend` workers, with backward-compatible `__setstate__`

Enables cookie-based session auth for OpenAPI-registered tools without requiring an external HTTP client. Common APIs that use this pattern:

| Service | Cookie | Auth flow |
|---------|--------|-----------|
| Jenkins | `JSESSIONID` | POST `/j_security_check` → session cookie |
| Jira Server/DC | `JSESSIONID` | POST `/rest/auth/1/session` → session cookie |
| SonarQube | Session cookie | POST `/api/authentication/login` → cookie |
| Grafana | `grafana_session` | POST `/api/login` → session cookie |

## Test plan

- [x] `cookies` defaults to `None`
- [x] `cookies` stored and included in `_client_kwargs()`
- [x] Cookies reach underlying sync and async `Client._cookies`
- [x] Persistent client preserves cookies (same instance)
- [x] Pickle round-trip preserves cookies
- [x] Backward-compatible unpickle (old state without `cookies` key)
- [x] All existing `test_utils.py` tests pass (no regressions)

Closes #257