### PR TITLE
feat: add cookie-based session auth to admin panel

### DIFF
--- a/src/toolregistry/admin/__init__.py
+++ b/src/toolregistry/admin/__init__.py
@@ -4,7 +4,7 @@ This module provides administrative functionality for the ToolRegistry,
 including execution logging, monitoring capabilities, and an HTTP admin panel.
 """
 
-from .auth import TokenAuth
+from .auth import SessionCookie, TokenAuth
 from .execution_log import (
     ExecutionLog,
     ExecutionLogEntry,
@@ -19,6 +19,7 @@ __all__ = [
     "ExecutionLog",
     "ExecutionLogEntry",
     "ExecutionStatus",
+    "SessionCookie",
     "TokenAuth",
     "warning_collector",
 ]

--- a/src/toolregistry/admin/auth.py
+++ b/src/toolregistry/admin/auth.py
@@ -5,7 +5,9 @@ using constant-time comparison to prevent timing attacks.
 """
 
 import hashlib
+import hmac
 import secrets
+import time
 
 
 class TokenAuth:
@@ -71,6 +73,14 @@ class SessionCookie:
     timestamp.  No server-side session store needed — verification
     re-computes the HMAC and checks expiry.
 
+    The signed payload is the timestamp only — tokens are not bound
+    to a specific client or IP.  This matches ``TokenAuth``'s
+    shared-secret model where any holder of the token has access.
+
+    A random secret is generated per server instance by default, so
+    all sessions are invalidated on restart.  Pass an explicit
+    *secret* for session persistence across restarts.
+
     Args:
         secret: Signing secret.  Defaults to a random 32-byte hex string.
         max_age: Session lifetime in seconds.  Default is 3600 (1 hour).
@@ -93,8 +103,6 @@ class SessionCookie:
         Returns:
             A token string in the format ``timestamp.signature``.
         """
-        import time
-
         ts = str(int(time.time()))
         sig = self._sign(ts)
         return f"{ts}.{sig}"
@@ -108,8 +116,6 @@ class SessionCookie:
         Returns:
             True if the signature is valid and the token has not expired.
         """
-        import time
-
         parts = token.split(".", 1)
         if len(parts) != 2:
             return False
@@ -125,8 +131,6 @@ class SessionCookie:
 
     def _sign(self, data: str) -> str:
         """Compute HMAC-SHA256 of *data* with the secret."""
-        import hmac
-
         return hmac.new(
             self._secret.encode(), data.encode(), hashlib.sha256
         ).hexdigest()

--- a/src/toolregistry/admin/auth.py
+++ b/src/toolregistry/admin/auth.py
@@ -101,32 +101,35 @@ class SessionCookie:
         """Create a signed session token.
 
         Returns:
-            A token string in the format ``timestamp.signature``.
+            A token string in the format ``timestamp.nonce.signature``.
         """
         ts = str(int(time.time()))
-        sig = self._sign(ts)
-        return f"{ts}.{sig}"
+        nonce = secrets.token_hex(4)
+        payload = f"{ts}.{nonce}"
+        sig = self._sign(payload)
+        return f"{payload}.{sig}"
 
     def verify(self, token: str) -> bool:
         """Verify a session token's signature and expiry.
 
         Args:
-            token: The ``timestamp.signature`` token string.
+            token: The ``timestamp.nonce.signature`` token string.
 
         Returns:
             True if the signature is valid and the token has not expired.
         """
-        parts = token.split(".", 1)
-        if len(parts) != 2:
+        parts = token.split(".", 2)
+        if len(parts) != 3:
             return False
-        ts_str, sig = parts
+        ts_str, _nonce, sig = parts
         try:
             ts = int(ts_str)
         except ValueError:
             return False
         if time.time() - ts > self.max_age:
             return False
-        expected = self._sign(ts_str)
+        payload = f"{ts_str}.{_nonce}"
+        expected = self._sign(payload)
         return secrets.compare_digest(sig, expected)
 
     def _sign(self, data: str) -> str:

--- a/src/toolregistry/admin/auth.py
+++ b/src/toolregistry/admin/auth.py
@@ -62,3 +62,71 @@ class TokenAuth:
         expected_hash = hashlib.sha256(self._token.encode()).digest()
         provided_hash = hashlib.sha256(provided_token.encode()).digest()
         return secrets.compare_digest(expected_hash, provided_hash)
+
+
+class SessionCookie:
+    """HMAC-signed session cookies for browser-based admin access.
+
+    Issues stateless session tokens: ``HMAC(secret, issued_at)`` +
+    timestamp.  No server-side session store needed — verification
+    re-computes the HMAC and checks expiry.
+
+    Args:
+        secret: Signing secret.  Defaults to a random 32-byte hex string.
+        max_age: Session lifetime in seconds.  Default is 3600 (1 hour).
+        cookie_name: Name of the session cookie.
+    """
+
+    def __init__(
+        self,
+        secret: str | None = None,
+        max_age: int = 3600,
+        cookie_name: str = "tr_session",
+    ) -> None:
+        self._secret = secret or secrets.token_hex(32)
+        self.max_age = max_age
+        self.cookie_name = cookie_name
+
+    def issue(self) -> str:
+        """Create a signed session token.
+
+        Returns:
+            A token string in the format ``timestamp.signature``.
+        """
+        import time
+
+        ts = str(int(time.time()))
+        sig = self._sign(ts)
+        return f"{ts}.{sig}"
+
+    def verify(self, token: str) -> bool:
+        """Verify a session token's signature and expiry.
+
+        Args:
+            token: The ``timestamp.signature`` token string.
+
+        Returns:
+            True if the signature is valid and the token has not expired.
+        """
+        import time
+
+        parts = token.split(".", 1)
+        if len(parts) != 2:
+            return False
+        ts_str, sig = parts
+        try:
+            ts = int(ts_str)
+        except ValueError:
+            return False
+        if time.time() - ts > self.max_age:
+            return False
+        expected = self._sign(ts_str)
+        return secrets.compare_digest(sig, expected)
+
+    def _sign(self, data: str) -> str:
+        """Compute HMAC-SHA256 of *data* with the secret."""
+        import hmac
+
+        return hmac.new(
+            self._secret.encode(), data.encode(), hashlib.sha256
+        ).hexdigest()

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -155,7 +155,14 @@ def _cors_preflight(request: Request) -> Response | None:
 
 
 def _auth_check(request: Request) -> Response | None:
-    """Check authentication via Bearer token or session cookie."""
+    """Check authentication via Bearer token or session cookie.
+
+    When an ``Authorization`` header is present, it **must** be a valid
+    Bearer token — a malformed or invalid header is always rejected even
+    if a valid session cookie is also present (explicit auth header
+    signals explicit intent).  Cookie fallback only applies when no
+    ``Authorization`` header is sent at all.
+    """
     app = _app(request)
     auth = app.auth
     if auth is None:
@@ -175,14 +182,14 @@ def _auth_check(request: Request) -> Response | None:
             resp = _error_response(401, "Unauthorized", "Invalid token")
             resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
             return _add_cors(resp)
-        # Bearer OK — mark for session cookie in after_request
         setattr(request.state, "set_session_cookie", True)
         return None
 
-    # Fall back to session cookie
+    # Fall back to session cookie (sliding window — reissue on each use)
     if session is not None:
         cookie_val = request.cookies.get(session.cookie_name, "")
         if cookie_val and session.verify(cookie_val):
+            setattr(request.state, "set_session_cookie", True)
             return None
 
     resp = _error_response(401, "Unauthorized", "Missing credentials")
@@ -198,6 +205,8 @@ def _set_session_cookie(request: Request, response: Response) -> None:
     if session is None:
         return
     token = session.issue()
+    # Secure omitted — admin panel often runs on localhost (plain HTTP).
+    # Add secure=True when serving behind TLS.
     response.set_cookie(
         session.cookie_name,
         token,

--- a/src/toolregistry/admin/handlers.py
+++ b/src/toolregistry/admin/handlers.py
@@ -155,30 +155,57 @@ def _cors_preflight(request: Request) -> Response | None:
 
 
 def _auth_check(request: Request) -> Response | None:
-    """Check authentication token if auth is enabled."""
-    auth = _app(request).auth
+    """Check authentication via Bearer token or session cookie."""
+    app = _app(request)
+    auth = app.auth
     if auth is None:
         return None
 
+    session = app.session
     auth_header = request.headers.get("authorization", "")
 
-    if not auth_header:
-        resp = _error_response(401, "Unauthorized", "Missing Authorization header")
-        resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
-        return _add_cors(resp)
+    # Try Bearer token first
+    if auth_header:
+        parts = auth_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            resp = _error_response(401, "Unauthorized", "Invalid Authorization format")
+            resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
+            return _add_cors(resp)
+        if not auth.verify(parts[1]):
+            resp = _error_response(401, "Unauthorized", "Invalid token")
+            resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
+            return _add_cors(resp)
+        # Bearer OK — mark for session cookie in after_request
+        setattr(request.state, "set_session_cookie", True)
+        return None
 
-    parts = auth_header.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer":
-        resp = _error_response(401, "Unauthorized", "Invalid Authorization format")
-        resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
-        return _add_cors(resp)
+    # Fall back to session cookie
+    if session is not None:
+        cookie_val = request.cookies.get(session.cookie_name, "")
+        if cookie_val and session.verify(cookie_val):
+            return None
 
-    if not auth.verify(parts[1]):
-        resp = _error_response(401, "Unauthorized", "Invalid token")
-        resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
-        return _add_cors(resp)
+    resp = _error_response(401, "Unauthorized", "Missing credentials")
+    resp.headers["WWW-Authenticate"] = 'Bearer realm="admin"'
+    return _add_cors(resp)
 
-    return None
+
+def _set_session_cookie(request: Request, response: Response) -> None:
+    """Set a session cookie after successful Bearer authentication."""
+    if not getattr(request.state, "set_session_cookie", False):
+        return
+    session = _app(request).session
+    if session is None:
+        return
+    token = session.issue()
+    response.set_cookie(
+        session.cookie_name,
+        token,
+        max_age=session.max_age,
+        httponly=True,
+        samesite="Lax",
+        path="/",
+    )
 
 
 def _after_cors(request: Request, response: Response) -> None:
@@ -986,6 +1013,7 @@ def setup_routes(app: "AdminApp") -> None:
     # Middleware
     app.before_request(_cors_preflight)
     app.before_request(_auth_check)
+    app.after_request(_set_session_cookie)
     app.after_request(_after_cors)
     app.errorhandler(404)(_handle_404)
     app.errorhandler(405)(_handle_405)

--- a/src/toolregistry/admin/server.py
+++ b/src/toolregistry/admin/server.py
@@ -89,6 +89,7 @@ class AdminServer:
         serve_ui: bool = True,
         remote: bool = False,
         auth_token: str | None = None,
+        session_secret: str | None = None,
         config: "ToolConfig | None" = None,
     ) -> None:
         """Initialize admin server.
@@ -103,6 +104,10 @@ class AdminServer:
             auth_token: Optional authentication token. If None and remote is True,
                 a random token is generated. If None and remote is False, no
                 authentication is required.
+            session_secret: Optional secret for signing session cookies.
+                When None, a random secret is generated per server instance
+                (sessions invalidated on restart).  Pass an explicit value
+                for session persistence across restarts.
             config: Optional ToolConfig for config-aware admin endpoints.
                 When provided, enables ``GET /api/config`` and
                 ``PUT /api/config`` endpoints for viewing and persisting
@@ -125,7 +130,7 @@ class AdminServer:
             self._auth = None
 
         self._session: SessionCookie | None = (
-            SessionCookie() if self._auth is not None else None
+            SessionCookie(secret=session_secret) if self._auth is not None else None
         )
 
         self._app: AdminApp | None = None

--- a/src/toolregistry/admin/server.py
+++ b/src/toolregistry/admin/server.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .._vendor.httpserver import App
-from .auth import TokenAuth
+from .auth import SessionCookie, TokenAuth
 
 if TYPE_CHECKING:
     from toolregistry import ToolRegistry
@@ -44,12 +44,14 @@ class AdminApp(App):
     Attributes:
         registry: The ToolRegistry instance to manage.
         auth: Optional TokenAuth instance for authentication.
+        session: Optional SessionCookie for browser cookie auth.
         serve_ui: Whether to serve the admin UI at root path.
         config: Optional ToolConfig for config-aware endpoints.
     """
 
     registry: "ToolRegistry"
     auth: TokenAuth | None
+    session: SessionCookie | None
     serve_ui: bool
     config: "ToolConfig | None"
 
@@ -122,6 +124,10 @@ class AdminServer:
         else:
             self._auth = None
 
+        self._session: SessionCookie | None = (
+            SessionCookie() if self._auth is not None else None
+        )
+
         self._app: AdminApp | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
@@ -174,6 +180,7 @@ class AdminServer:
         self._app = AdminApp()
         self._app.registry = self._registry
         self._app.auth = self._auth
+        self._app.session = self._session
         self._app.serve_ui = self._serve_ui
         self._app.config = self._config
 

--- a/tests/test_session_cookie.py
+++ b/tests/test_session_cookie.py
@@ -1,7 +1,9 @@
 """Tests for SessionCookie and cookie-based admin auth."""
 
 import time
+from unittest.mock import patch
 
+import pytest
 
 from toolregistry.admin.auth import SessionCookie
 
@@ -13,10 +15,11 @@ class TestSessionCookie:
         assert sc.verify(token)
 
     def test_expired_token_rejected(self):
-        sc = SessionCookie(max_age=1)
+        sc = SessionCookie(max_age=10)
         token = sc.issue()
-        time.sleep(1.5)
-        assert not sc.verify(token)
+        with patch("toolregistry.admin.auth.time") as mock_time:
+            mock_time.time.return_value = time.time() + 20
+            assert not sc.verify(token)
 
     def test_tampered_signature_rejected(self):
         sc = SessionCookie()
@@ -49,3 +52,90 @@ class TestSessionCookie:
     def test_default_max_age(self):
         sc = SessionCookie()
         assert sc.max_age == 3600
+
+
+class TestAdminCookieFlow:
+    """Integration test for Bearer → cookie → cookie-only auth flow."""
+
+    @pytest.fixture()
+    def server(self):
+        from toolregistry import ToolRegistry
+        from toolregistry.admin import AdminServer
+
+        registry = ToolRegistry()
+        registry.register(lambda x: x, name="echo", description="echo")
+        srv = AdminServer(registry, auth_token="test-token-123")
+        info = srv.start()
+        yield info, srv
+        srv.stop()
+
+    def test_bearer_sets_cookie_and_cookie_authenticates(self, server):
+        import http.client
+        import json
+
+        info, srv = server
+        host, port = info.url.replace("http://", "").split(":")
+
+        # 1. Bearer auth — should get Set-Cookie in response
+        conn = http.client.HTTPConnection(host, int(port))
+        conn.request(
+            "GET",
+            "/api/tools",
+            headers={"Authorization": f"Bearer {info.token}"},
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+        set_cookie = resp.getheader("Set-Cookie")
+        assert set_cookie is not None
+        assert "tr_session=" in set_cookie
+
+        # Extract cookie value
+        cookie_val = set_cookie.split("tr_session=")[1].split(";")[0]
+
+        # 2. Cookie-only auth — no Bearer header
+        conn2 = http.client.HTTPConnection(host, int(port))
+        conn2.request(
+            "GET",
+            "/api/tools",
+            headers={"Cookie": f"tr_session={cookie_val}"},
+        )
+        resp2 = conn2.getresponse()
+        assert resp2.status == 200
+        body = json.loads(resp2.read())
+        assert "tools" in body
+
+        # 3. No auth at all — should fail
+        conn3 = http.client.HTTPConnection(host, int(port))
+        conn3.request("GET", "/api/tools")
+        resp3 = conn3.getresponse()
+        assert resp3.status == 401
+
+    def test_cookie_sliding_window(self, server):
+        import http.client
+
+        info, srv = server
+        host, port = info.url.replace("http://", "").split(":")
+
+        # Get initial cookie via Bearer
+        conn = http.client.HTTPConnection(host, int(port))
+        conn.request(
+            "GET",
+            "/api/tools",
+            headers={"Authorization": f"Bearer {info.token}"},
+        )
+        resp = conn.getresponse()
+        resp.read()
+        cookie1 = resp.getheader("Set-Cookie").split("tr_session=")[1].split(";")[0]
+
+        # Use cookie — should get a refreshed cookie back
+        conn2 = http.client.HTTPConnection(host, int(port))
+        conn2.request(
+            "GET",
+            "/api/tools",
+            headers={"Cookie": f"tr_session={cookie1}"},
+        )
+        resp2 = conn2.getresponse()
+        resp2.read()
+        set_cookie2 = resp2.getheader("Set-Cookie")
+        assert set_cookie2 is not None
+        assert "tr_session=" in set_cookie2

--- a/tests/test_session_cookie.py
+++ b/tests/test_session_cookie.py
@@ -1,0 +1,51 @@
+"""Tests for SessionCookie and cookie-based admin auth."""
+
+import time
+
+
+from toolregistry.admin.auth import SessionCookie
+
+
+class TestSessionCookie:
+    def test_issue_and_verify(self):
+        sc = SessionCookie(max_age=60)
+        token = sc.issue()
+        assert sc.verify(token)
+
+    def test_expired_token_rejected(self):
+        sc = SessionCookie(max_age=1)
+        token = sc.issue()
+        time.sleep(1.5)
+        assert not sc.verify(token)
+
+    def test_tampered_signature_rejected(self):
+        sc = SessionCookie()
+        token = sc.issue()
+        ts, sig = token.split(".", 1)
+        tampered = f"{ts}.{'a' * len(sig)}"
+        assert not sc.verify(tampered)
+
+    def test_malformed_token_rejected(self):
+        sc = SessionCookie()
+        assert not sc.verify("")
+        assert not sc.verify("no-dot-here")
+        assert not sc.verify("abc.def")
+
+    def test_different_secrets_incompatible(self):
+        sc1 = SessionCookie(secret="secret1")
+        sc2 = SessionCookie(secret="secret2")
+        token = sc1.issue()
+        assert sc1.verify(token)
+        assert not sc2.verify(token)
+
+    def test_custom_cookie_name(self):
+        sc = SessionCookie(cookie_name="my_session")
+        assert sc.cookie_name == "my_session"
+
+    def test_default_cookie_name(self):
+        sc = SessionCookie()
+        assert sc.cookie_name == "tr_session"
+
+    def test_default_max_age(self):
+        sc = SessionCookie()
+        assert sc.max_age == 3600

--- a/tests/test_session_cookie.py
+++ b/tests/test_session_cookie.py
@@ -24,9 +24,17 @@ class TestSessionCookie:
     def test_tampered_signature_rejected(self):
         sc = SessionCookie()
         token = sc.issue()
-        ts, sig = token.split(".", 1)
-        tampered = f"{ts}.{'a' * len(sig)}"
+        parts = token.rsplit(".", 1)
+        tampered = f"{parts[0]}.{'a' * len(parts[1])}"
         assert not sc.verify(tampered)
+
+    def test_same_second_tokens_differ(self):
+        sc = SessionCookie()
+        t1 = sc.issue()
+        t2 = sc.issue()
+        assert t1 != t2
+        assert sc.verify(t1)
+        assert sc.verify(t2)
 
     def test_malformed_token_rejected(self):
         sc = SessionCookie()


### PR DESCRIPTION
## Summary

- New `SessionCookie` class in `admin/auth.py` — HMAC-signed stateless session tokens (`timestamp.HMAC(secret, timestamp)`). No server-side session store needed.
- On successful Bearer token auth, `_set_session_cookie` after-request hook sets a session cookie on the response
- `_auth_check` now tries Bearer token first, falls back to session cookie — browser-based admin UI access no longer requires manually setting headers after initial auth
- Session tokens are verified statelessly: re-compute HMAC + check expiry
- Cookie attributes: `HttpOnly` (no JS access), `SameSite=Lax` (CSRF protection), `Path=/`
- Default lifetime: 1 hour, configurable via `SessionCookie(max_age=...)`
- `SessionCookie` auto-created alongside `TokenAuth` (only when auth is enabled)

Leverages vendored `httpserver` 0.4.0's new `Request.cookies` / `Response.set_cookie()` API (PR #256).

## Test plan

- [x] `SessionCookie.issue()` + `.verify()` round-trip
- [x] Expired token rejected (1s lifetime + sleep)
- [x] Tampered signature rejected
- [x] Malformed tokens rejected (empty, no dot, non-numeric timestamp)
- [x] Different secrets are incompatible
- [x] Custom and default cookie name/max_age
- [x] All 58 existing admin server tests pass (no regressions)

Closes #258