### PR TITLE
feat: add call_deferred proxy tool for invoking deferred tools

### DIFF
--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -28,7 +28,7 @@ from .permissions import (
     PermissionResult,
     PermissionRule,
 )
-from .llm.discovery import ToolDiscoveryTool
+from .llm.discovery import TOOL_CALL_DEFERRED_NAME, ToolDiscoveryTool
 from .llm.tool_calls import ErrorResult, ResultList, ToolCallResult
 from .tool import Tool, ToolMetadata, ToolTag
 from .tool_registry import ToolRegistry
@@ -61,6 +61,7 @@ __all__ = [
     "Tool",
     "ToolMetadata",
     "ToolRegistry",
+    "TOOL_CALL_DEFERRED_NAME",
     "ToolDiscoveryTool",
     "ToolTag",
     "SchemaChangeKind",

--- a/src/toolregistry/__init__.py
+++ b/src/toolregistry/__init__.py
@@ -28,7 +28,11 @@ from .permissions import (
     PermissionResult,
     PermissionRule,
 )
-from .llm.discovery import TOOL_CALL_DEFERRED_NAME, ToolDiscoveryTool
+from .llm.discovery import (
+    TOOL_CALL_DEFERRED_NAME,
+    TOOL_DISCOVERY_NAME,
+    ToolDiscoveryTool,
+)
 from .llm.tool_calls import ErrorResult, ResultList, ToolCallResult
 from .tool import Tool, ToolMetadata, ToolTag
 from .tool_registry import ToolRegistry
@@ -62,6 +66,7 @@ __all__ = [
     "ToolMetadata",
     "ToolRegistry",
     "TOOL_CALL_DEFERRED_NAME",
+    "TOOL_DISCOVERY_NAME",
     "ToolDiscoveryTool",
     "ToolTag",
     "SchemaChangeKind",

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -34,7 +34,7 @@ _SPLIT_RE = re.compile(r"[_\-]+")
 TOOL_DISCOVERY_NAME = "discover_tools"
 TOOL_CALL_DEFERRED_NAME = "call_deferred"
 
-_INFRASTRUCTURE_TOOLS = frozenset({TOOL_DISCOVERY_NAME, TOOL_CALL_DEFERRED_NAME})
+INFRASTRUCTURE_TOOLS = frozenset({TOOL_DISCOVERY_NAME, TOOL_CALL_DEFERRED_NAME})
 
 _BASE_DISCOVERY_DESCRIPTION = (
     "Discover registered tools by exact name or natural language query. "
@@ -43,7 +43,7 @@ _BASE_DISCOVERY_DESCRIPTION = (
     "your current tool list."
 )
 
-_BASE_CALL_DEFERRED_DESCRIPTION = (
+BASE_CALL_DEFERRED_DESCRIPTION = (
     "Call a deferred tool by name. Use this after discover_tools returns "
     "a deferred tool's schema — pass the tool name and its parameters as "
     "keyword arguments."
@@ -123,7 +123,7 @@ class ToolDiscoveryTool:
         self._index = SparseIndex(field_weights=self._field_weights)
 
         for name, tool in self._registry._tools.items():
-            if name in _INFRASTRUCTURE_TOOLS:
+            if name in INFRASTRUCTURE_TOOLS:
                 continue
             fields = _tool_to_fields(tool)
             metadata: dict[str, Any] = {
@@ -192,7 +192,7 @@ class ToolDiscoveryTool:
         """
         # 1. Exact match: return full schema immediately
         tool = self._registry.get_tool(query)
-        if tool is not None and query not in _INFRASTRUCTURE_TOOLS:
+        if tool is not None and query not in INFRASTRUCTURE_TOOLS:
             is_deferred = tool.metadata.defer if tool.metadata else False
             return [
                 {
@@ -223,7 +223,7 @@ class ToolDiscoveryTool:
             out.append(entry)
         return out
 
-    def call_deferred(self, tool_name: str, **kwargs: Any) -> Any:
+    def call_deferred(self, _target_tool: str, **kwargs: Any) -> Any:
         """Call a deferred tool by name with the given arguments.
 
         Intended as a proxy for MCP clients that cannot dynamically
@@ -231,31 +231,36 @@ class ToolDiscoveryTool:
         discovers a deferred tool's schema, then invokes this method
         with the tool name and its parameters as keyword arguments.
 
-        Delegates to :meth:`ToolRegistry.invoke` which runs the full
-        pipeline (permissions, execution backend, logging).
+        Delegates to :meth:`ToolRegistry._invoke_raw` which runs the
+        full pipeline (permissions, execution backend, logging) and
+        returns the raw Python value — the outer ``execute_tool_calls``
+        handles result wrapping.
+
+        The first parameter is named ``_target_tool`` (not ``tool_name``)
+        to avoid shadowing a deferred tool that has its own ``tool_name``
+        parameter.
 
         Args:
-            tool_name: Registered name of the deferred tool to call.
+            _target_tool: Registered name of the deferred tool to call.
             **kwargs: Parameters forwarded to the target tool.
 
         Returns:
-            The tool's result on success, or an error message string
-            on failure.
-        """
-        from .tool_calls import ErrorResult
+            The tool's raw result on success.
 
-        target = self._registry.get_tool(tool_name)
+        Raises:
+            KeyError: If the tool is not found.
+            ValueError: If the tool is not deferred.
+            Exception: Any exception raised by the target tool.
+        """
+        target = self._registry.get_tool(_target_tool)
         if target is None:
-            return f"Error: tool '{tool_name}' not found in registry."
+            raise KeyError(f"tool '{_target_tool}' not found in registry.")
 
         is_deferred = target.metadata.defer if target.metadata else False
         if not is_deferred:
-            return (
-                f"Error: '{tool_name}' is not a deferred tool — "
+            raise ValueError(
+                f"'{_target_tool}' is not a deferred tool — "
                 f"call it directly instead of using call_deferred."
             )
 
-        result = self._registry.invoke(tool_name, kwargs)
-        if isinstance(result, ErrorResult):
-            return result.message
-        return result.result
+        return self._registry._invoke_raw(_target_tool, kwargs)

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -32,12 +32,21 @@ _DEFAULT_FIELD_WEIGHTS: dict[str, float] = {
 _SPLIT_RE = re.compile(r"[_\-]+")
 
 TOOL_DISCOVERY_NAME = "discover_tools"
+TOOL_CALL_DEFERRED_NAME = "call_deferred"
+
+_INFRASTRUCTURE_TOOLS = frozenset({TOOL_DISCOVERY_NAME, TOOL_CALL_DEFERRED_NAME})
 
 _BASE_DISCOVERY_DESCRIPTION = (
     "Discover registered tools by exact name or natural language query. "
     "Use this to inspect a specific tool by name (returns full schema) or "
     "to search for relevant tools when you need a capability not visible in "
     "your current tool list."
+)
+
+_BASE_CALL_DEFERRED_DESCRIPTION = (
+    "Call a deferred tool by name. Use this after discover_tools returns "
+    "a deferred tool's schema — pass the tool name and its parameters as "
+    "keyword arguments."
 )
 
 
@@ -114,8 +123,7 @@ class ToolDiscoveryTool:
         self._index = SparseIndex(field_weights=self._field_weights)
 
         for name, tool in self._registry._tools.items():
-            # Skip the discovery tool itself to avoid circular results
-            if name == TOOL_DISCOVERY_NAME:
+            if name in _INFRASTRUCTURE_TOOLS:
                 continue
             fields = _tool_to_fields(tool)
             metadata: dict[str, Any] = {
@@ -184,7 +192,7 @@ class ToolDiscoveryTool:
         """
         # 1. Exact match: return full schema immediately
         tool = self._registry.get_tool(query)
-        if tool is not None and query != TOOL_DISCOVERY_NAME:
+        if tool is not None and query not in _INFRASTRUCTURE_TOOLS:
             is_deferred = tool.metadata.defer if tool.metadata else False
             return [
                 {
@@ -214,3 +222,40 @@ class ToolDiscoveryTool:
                 entry["schema"] = tool.get_schema(api_format)
             out.append(entry)
         return out
+
+    def call_deferred(self, tool_name: str, **kwargs: Any) -> Any:
+        """Call a deferred tool by name with the given arguments.
+
+        Intended as a proxy for MCP clients that cannot dynamically
+        register tools discovered via :meth:`discover`.  The LLM
+        discovers a deferred tool's schema, then invokes this method
+        with the tool name and its parameters as keyword arguments.
+
+        Delegates to :meth:`ToolRegistry.invoke` which runs the full
+        pipeline (permissions, execution backend, logging).
+
+        Args:
+            tool_name: Registered name of the deferred tool to call.
+            **kwargs: Parameters forwarded to the target tool.
+
+        Returns:
+            The tool's result on success, or an error message string
+            on failure.
+        """
+        from .tool_calls import ErrorResult
+
+        target = self._registry.get_tool(tool_name)
+        if target is None:
+            return f"Error: tool '{tool_name}' not found in registry."
+
+        is_deferred = target.metadata.defer if target.metadata else False
+        if not is_deferred:
+            return (
+                f"Error: '{tool_name}' is not a deferred tool — "
+                f"call it directly instead of using call_deferred."
+            )
+
+        result = self._registry.invoke(tool_name, kwargs)
+        if isinstance(result, ErrorResult):
+            return result.message
+        return result.result

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -45,8 +45,9 @@ _BASE_DISCOVERY_DESCRIPTION = (
 
 BASE_CALL_DEFERRED_DESCRIPTION = (
     "Call a deferred tool by name. Use this after discover_tools returns "
-    "a deferred tool's schema — pass the tool name and its parameters as "
-    "keyword arguments."
+    "a deferred tool's schema — pass the tool name as _target_tool and "
+    "its parameters as keyword arguments. "
+    "Example: call_deferred(_target_tool='search', query='hello')"
 )
 
 
@@ -135,30 +136,43 @@ class ToolDiscoveryTool:
         self._sync_description()
 
     def _sync_description(self) -> None:
-        """Update the ``discover_tools`` description with deferred tool summaries.
+        """Update tool descriptions with deferred tool summaries.
 
-        Injects a bullet list of deferred tool names and their one-line
-        descriptions so LLMs know which capabilities exist but are not
-        shown in full.  No-ops if ``discover_tools`` is not yet registered.
+        Updates both ``discover_tools`` and ``call_deferred`` descriptions
+        so LLMs know which capabilities exist but are not shown in full.
+        No-ops if the tools are not yet registered.
         """
         discovery_tool = self._registry._tools.get(TOOL_DISCOVERY_NAME)
-        if discovery_tool is None:
-            return
+        call_deferred_tool = self._registry._tools.get(TOOL_CALL_DEFERRED_NAME)
 
         summaries = self._registry.get_deferred_summaries()
         if summaries:
-            lines = [
-                _BASE_DISCOVERY_DESCRIPTION,
-                "",
-                "Tools available on demand (call discover_tools for full schema):",
-            ]
+            tool_list = []
             for s in summaries:
                 desc = s["description"]
                 suffix = f": {desc}" if desc else ""
-                lines.append(f"- {s['name']}{suffix}")
-            discovery_tool.description = "\n".join(lines)
+                tool_list.append(f"- {s['name']}{suffix}")
+            tool_list_str = "\n".join(tool_list)
+
+            if discovery_tool is not None:
+                discovery_tool.description = (
+                    _BASE_DISCOVERY_DESCRIPTION + "\n\nTools available on demand "
+                    "(call discover_tools for full schema):\n" + tool_list_str
+                )
+            if call_deferred_tool is not None:
+                call_deferred_tool.description = (
+                    BASE_CALL_DEFERRED_DESCRIPTION
+                    + "\n\nCurrently deferred:\n"
+                    + tool_list_str
+                )
         else:
-            discovery_tool.description = _BASE_DISCOVERY_DESCRIPTION
+            if discovery_tool is not None:
+                discovery_tool.description = _BASE_DISCOVERY_DESCRIPTION
+            if call_deferred_tool is not None:
+                call_deferred_tool.description = (
+                    BASE_CALL_DEFERRED_DESCRIPTION
+                    + " No deferred tools currently available."
+                )
 
     def discover(
         self,
@@ -224,6 +238,8 @@ class ToolDiscoveryTool:
         return out
 
     def call_deferred(self, _target_tool: str, **kwargs: Any) -> Any:
+        # **kwargs produces additionalProperties: true in the JSON Schema,
+        # which is essential for this proxy to accept arbitrary parameters.
         """Call a deferred tool by name with the given arguments.
 
         Intended as a proxy for MCP clients that cannot dynamically

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -32,7 +32,10 @@ from .llm.tool_calls import (
 
 from .events import ChangeCallback, ChangeEvent, ChangeEventType
 from .llm.discovery import (
+    TOOL_CALL_DEFERRED_NAME,
     TOOL_DISCOVERY_NAME,
+    _BASE_CALL_DEFERRED_DESCRIPTION,
+    _INFRASTRUCTURE_TOOLS,
     ToolDiscoveryTool,
     _BASE_DISCOVERY_DESCRIPTION,
 )
@@ -293,26 +296,33 @@ class ToolRegistry(
             metadata=ToolMetadata(defer=False),
         )
         self.register(discovery_tool)
+
+        call_deferred_tool = Tool.from_function(
+            discoverer.call_deferred,
+            name=TOOL_CALL_DEFERRED_NAME,
+            description=_BASE_CALL_DEFERRED_DESCRIPTION,
+            metadata=ToolMetadata(defer=False),
+        )
+        self.register(call_deferred_tool)
+
         # Sync description now that discover_tools is registered and deferred
         # tools are known.
         discoverer._sync_description()
 
         def _on_registry_change(event: ChangeEvent) -> None:
+            if event.tool_name in _INFRASTRUCTURE_TOOLS:
+                return
             if event.event_type in {
                 ChangeEventType.REGISTER,
                 ChangeEventType.UNREGISTER,
             }:
-                if event.tool_name != TOOL_DISCOVERY_NAME:
-                    discoverer.rebuild_index()
+                discoverer.rebuild_index()
             elif event.event_type in {
                 ChangeEventType.ENABLE,
                 ChangeEventType.DISABLE,
                 ChangeEventType.METADATA_UPDATE,
             }:
-                if event.tool_name != TOOL_DISCOVERY_NAME:
-                    # Cheap sync — no full index rebuild needed, just update
-                    # the discover_tools description to reflect current state.
-                    discoverer._sync_description()
+                discoverer._sync_description()
 
         self.on_change(_on_registry_change)
 
@@ -325,8 +335,9 @@ class ToolRegistry(
         if self._tool_discovery is None:
             return
 
-        # Remove the discovery tool from registry
+        # Remove infrastructure tools from registry
         self._tools.pop(TOOL_DISCOVERY_NAME, None)
+        self._tools.pop(TOOL_CALL_DEFERRED_NAME, None)
 
         # Remove the change callback
         if self._tool_discovery_callback is not None:

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -34,8 +34,8 @@ from .events import ChangeCallback, ChangeEvent, ChangeEventType
 from .llm.discovery import (
     TOOL_CALL_DEFERRED_NAME,
     TOOL_DISCOVERY_NAME,
-    _BASE_CALL_DEFERRED_DESCRIPTION,
-    _INFRASTRUCTURE_TOOLS,
+    BASE_CALL_DEFERRED_DESCRIPTION,
+    INFRASTRUCTURE_TOOLS,
     ToolDiscoveryTool,
     _BASE_DISCOVERY_DESCRIPTION,
 )
@@ -300,7 +300,7 @@ class ToolRegistry(
         call_deferred_tool = Tool.from_function(
             discoverer.call_deferred,
             name=TOOL_CALL_DEFERRED_NAME,
-            description=_BASE_CALL_DEFERRED_DESCRIPTION,
+            description=BASE_CALL_DEFERRED_DESCRIPTION,
             metadata=ToolMetadata(defer=False),
         )
         self.register(call_deferred_tool)
@@ -310,7 +310,7 @@ class ToolRegistry(
         discoverer._sync_description()
 
         def _on_registry_change(event: ChangeEvent) -> None:
-            if event.tool_name in _INFRASTRUCTURE_TOOLS:
+            if event.tool_name in INFRASTRUCTURE_TOOLS:
                 return
             if event.event_type in {
                 ChangeEventType.REGISTER,
@@ -322,6 +322,7 @@ class ToolRegistry(
                 ChangeEventType.DISABLE,
                 ChangeEventType.METADATA_UPDATE,
             }:
+                # Cheap sync — no full index rebuild, just update description
                 discoverer._sync_description()
 
         self.on_change(_on_registry_change)

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -600,3 +600,130 @@ class TestGetDeferredSummaries:
 
         registry.register(normal)
         assert registry.get_deferred_summaries() == []
+
+
+# -- tests: call_deferred ----------------------------------------------------
+
+
+class TestCallDeferred:
+    """Test cases for ToolDiscoveryTool.call_deferred()."""
+
+    def test_call_deferred_success(self):
+        """Calling a deferred tool should execute it and return the result."""
+        registry = ToolRegistry()
+
+        def secret_add(a: int, b: int) -> int:
+            """Add two numbers (deferred)."""
+            return a + b
+
+        registry.register(
+            Tool.from_function(secret_add, metadata=ToolMetadata(defer=True))
+        )
+        registry.enable_tool_discovery()
+
+        discoverer = registry._tool_discovery
+        assert discoverer is not None
+        result = discoverer.call_deferred("secret_add", a=3, b=4)
+        assert result == "7"
+
+    def test_call_deferred_nonexistent_tool(self):
+        """Calling a non-existent tool should return an error message."""
+        registry = ToolRegistry()
+        registry.enable_tool_discovery()
+
+        discoverer = registry._tool_discovery
+        assert discoverer is not None
+        result = discoverer.call_deferred("no_such_tool")
+        assert "not found" in result
+
+    def test_call_deferred_non_deferred_tool(self):
+        """Calling a non-deferred tool should return an error message."""
+        registry = ToolRegistry()
+
+        def normal_tool(x: int) -> int:
+            """A normal tool."""
+            return x
+
+        registry.register(normal_tool)
+        registry.enable_tool_discovery()
+
+        discoverer = registry._tool_discovery
+        assert discoverer is not None
+        result = discoverer.call_deferred("normal_tool", x=5)
+        assert "not a deferred tool" in result
+        assert "call it directly" in result
+
+    def test_call_deferred_with_validation_error(self):
+        """Bad parameters should propagate an error via invoke()."""
+        registry = ToolRegistry()
+
+        def typed_tool(x: int) -> int:
+            """Typed deferred tool."""
+            return x
+
+        registry.register(
+            Tool.from_function(typed_tool, metadata=ToolMetadata(defer=True))
+        )
+        registry.enable_tool_discovery()
+
+        discoverer = registry._tool_discovery
+        assert discoverer is not None
+        result = discoverer.call_deferred("typed_tool", x="not_an_int")
+        # coerce should handle "not_an_int" → error since it can't become int
+        assert isinstance(result, str)
+        assert "Error" in result or "error" in result
+
+    def test_call_deferred_registered_on_enable(self):
+        """enable_tool_discovery() should register call_deferred in schemas."""
+        registry = ToolRegistry()
+        registry.enable_tool_discovery()
+
+        schemas = registry.get_schemas()
+        names = [s["function"]["name"] for s in schemas]
+        assert "call_deferred" in names
+
+    def test_call_deferred_removed_on_disable(self):
+        """disable_tool_discovery() should remove call_deferred."""
+        registry = ToolRegistry()
+        registry.enable_tool_discovery()
+        registry.disable_tool_discovery()
+
+        schemas = registry.get_schemas()
+        names = [s["function"]["name"] for s in schemas]
+        assert "call_deferred" not in names
+        assert "discover_tools" not in names
+
+    def test_call_deferred_not_deferred_itself(self):
+        """call_deferred should not be deferred — it must be in initial schema."""
+        registry = ToolRegistry()
+        registry.enable_tool_discovery()
+
+        schemas = registry.get_schemas(include_deferred=False)
+        names = [s["function"]["name"] for s in schemas]
+        assert "call_deferred" in names
+
+    def test_call_deferred_has_additional_properties(self):
+        """call_deferred schema should have additionalProperties: true."""
+        registry = ToolRegistry()
+        registry.enable_tool_discovery()
+
+        tool = registry.get_tool("call_deferred")
+        assert tool is not None
+        assert tool.parameters.get("additionalProperties") is True
+
+    def test_call_deferred_not_in_discovery_results(self):
+        """call_deferred should not appear in discover_tools results."""
+        registry = ToolRegistry()
+
+        def add(a: int, b: int) -> int:
+            """Add numbers."""
+            return a + b
+
+        registry.register(add)
+        registry.enable_tool_discovery()
+
+        discoverer = registry._tool_discovery
+        assert discoverer is not None
+        results = discoverer.discover("call deferred")
+        result_names = [r["name"] for r in results]
+        assert "call_deferred" not in result_names

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -725,3 +725,23 @@ class TestCallDeferred:
         results = discoverer.discover("call deferred")
         result_names = [r["name"] for r in results]
         assert "call_deferred" not in result_names
+
+    def test_call_deferred_target_tool_no_collision(self):
+        """_target_tool param name should not collide with tool's own params."""
+        registry = ToolRegistry()
+
+        def tool_with_tool_name(tool_name: str, value: int) -> str:
+            """A deferred tool that has its own tool_name parameter."""
+            return f"{tool_name}={value}"
+
+        registry.register(
+            Tool.from_function(tool_with_tool_name, metadata=ToolMetadata(defer=True))
+        )
+        registry.enable_tool_discovery()
+
+        discoverer = registry._tool_discovery
+        assert discoverer is not None
+        result = discoverer.call_deferred(
+            _target_tool="tool_with_tool_name", tool_name="search", value=42
+        )
+        assert result == "search=42"

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -609,7 +609,7 @@ class TestCallDeferred:
     """Test cases for ToolDiscoveryTool.call_deferred()."""
 
     def test_call_deferred_success(self):
-        """Calling a deferred tool should execute it and return the result."""
+        """Calling a deferred tool should execute it and return the raw result."""
         registry = ToolRegistry()
 
         def secret_add(a: int, b: int) -> int:
@@ -623,21 +623,21 @@ class TestCallDeferred:
 
         discoverer = registry._tool_discovery
         assert discoverer is not None
-        result = discoverer.call_deferred("secret_add", a=3, b=4)
-        assert result == "7"
+        result = discoverer.call_deferred(_target_tool="secret_add", a=3, b=4)
+        assert result == 7
 
     def test_call_deferred_nonexistent_tool(self):
-        """Calling a non-existent tool should return an error message."""
+        """Calling a non-existent tool should raise KeyError."""
         registry = ToolRegistry()
         registry.enable_tool_discovery()
 
         discoverer = registry._tool_discovery
         assert discoverer is not None
-        result = discoverer.call_deferred("no_such_tool")
-        assert "not found" in result
+        with pytest.raises(KeyError, match="not found"):
+            discoverer.call_deferred(_target_tool="no_such_tool")
 
     def test_call_deferred_non_deferred_tool(self):
-        """Calling a non-deferred tool should return an error message."""
+        """Calling a non-deferred tool should raise ValueError."""
         registry = ToolRegistry()
 
         def normal_tool(x: int) -> int:
@@ -649,12 +649,11 @@ class TestCallDeferred:
 
         discoverer = registry._tool_discovery
         assert discoverer is not None
-        result = discoverer.call_deferred("normal_tool", x=5)
-        assert "not a deferred tool" in result
-        assert "call it directly" in result
+        with pytest.raises(ValueError, match="not a deferred tool"):
+            discoverer.call_deferred(_target_tool="normal_tool", x=5)
 
     def test_call_deferred_with_validation_error(self):
-        """Bad parameters should propagate an error via invoke()."""
+        """Bad parameters should propagate the exception from _invoke_raw."""
         registry = ToolRegistry()
 
         def typed_tool(x: int) -> int:
@@ -668,10 +667,8 @@ class TestCallDeferred:
 
         discoverer = registry._tool_discovery
         assert discoverer is not None
-        result = discoverer.call_deferred("typed_tool", x="not_an_int")
-        # coerce should handle "not_an_int" → error since it can't become int
-        assert isinstance(result, str)
-        assert "Error" in result or "error" in result
+        with pytest.raises(Exception):
+            discoverer.call_deferred(_target_tool="typed_tool", x="not_an_int")
 
     def test_call_deferred_registered_on_enable(self):
         """enable_tool_discovery() should register call_deferred in schemas."""
@@ -703,13 +700,14 @@ class TestCallDeferred:
         assert "call_deferred" in names
 
     def test_call_deferred_has_additional_properties(self):
-        """call_deferred schema should have additionalProperties: true."""
+        """call_deferred schema should have additionalProperties: true and _target_tool param."""
         registry = ToolRegistry()
         registry.enable_tool_discovery()
 
         tool = registry.get_tool("call_deferred")
         assert tool is not None
         assert tool.parameters.get("additionalProperties") is True
+        assert "_target_tool" in tool.parameters.get("properties", {})
 
     def test_call_deferred_not_in_discovery_results(self):
         """call_deferred should not appear in discover_tools results."""


### PR DESCRIPTION
## Summary

- Adds `call_deferred` proxy tool alongside `discover_tools` in `ToolDiscoveryTool`, enabling LLMs to invoke deferred tools that aren't in the initial `tools/list`
- Deferred tools are discoverable via `discover_tools` but most MCP clients (Claude Code, Codex, OpenCode) cache the tool list at init and can't dynamically register new tools — `call_deferred` bridges this gap
- Uses `**kwargs` pass-through with `additionalProperties: true` in schema, delegating parameter validation and execution to `registry.invoke()` (full pipeline: permissions, backend, logging)

Closes #261

## Test plan

- [x] New `TestCallDeferred` class with 9 test cases (success, non-existent tool, non-deferred tool, validation error, registration on enable, removal on disable, not-deferred-itself, additionalProperties schema, not in discovery results)
- [x] All 46 discovery tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, ty, complexipy)
- [ ] Full test suite (266+ tests) — CI