### PR TITLE
refactor: make Tool and ToolMetadata frozen dataclasses

### DIFF
--- a/src/toolregistry/_mixins/enable_disable.py
+++ b/src/toolregistry/_mixins/enable_disable.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 from typing import TYPE_CHECKING, Literal
 
 from ..events import ChangeEvent, ChangeEventType
@@ -158,8 +160,8 @@ class EnableDisableMixin:
                     f"Field '{key}' is not allowed. "
                     f"Allowed fields: {sorted(self._MUTABLE_METADATA_FIELDS)}"
                 )
-        for key, value in kwargs.items():
-            setattr(tool.metadata, key, value)
+        new_meta = dataclasses.replace(tool.metadata, **kwargs)
+        self._tools[tool_name] = dataclasses.replace(tool, metadata=new_meta)
         self._emit_change(
             ChangeEvent(
                 event_type=ChangeEventType.METADATA_UPDATE,
@@ -191,8 +193,8 @@ class EnableDisableMixin:
                     f"Allowed fields: {sorted(self._MUTABLE_METADATA_FIELDS)}"
                 )
         for tool in tools:
-            for key, value in kwargs.items():
-                setattr(tool.metadata, key, value)
+            new_meta = dataclasses.replace(tool.metadata, **kwargs)
+            self._tools[tool.name] = dataclasses.replace(tool, metadata=new_meta)
             self._emit_change(
                 ChangeEvent(
                     event_type=ChangeEventType.METADATA_UPDATE,

--- a/src/toolregistry/_mixins/namespace.py
+++ b/src/toolregistry/_mixins/namespace.py
@@ -65,7 +65,7 @@ class NamespaceMixin:
         sep = getattr(self, "_name_sep", "-")
         new_tools: dict[str, Tool] = {}
         for tool in self._tools.values():
-            tool.update_namespace(self.name, force=force, sep=sep)
+            tool = tool.update_namespace(self.name, force=force, sep=sep)
             new_tools[tool.name] = tool
         self._tools = new_tools
 

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -304,6 +304,10 @@ class RegistrationMixin:
         Returns:
             The newly created ``Tool`` instance.
         """
+        assert "name" not in updates, (
+            "_replace_tool cannot change 'name'; it would create a "
+            "key/value mismatch in _tools"
+        )
         old = self._tools[name]
         new_tool = dataclasses.replace(old, **updates)
         self._tools[name] = new_tool

--- a/src/toolregistry/_mixins/registration.py
+++ b/src/toolregistry/_mixins/registration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -241,7 +242,7 @@ class RegistrationMixin:
         sep = getattr(self, "_name_sep", "-")
 
         if isinstance(tool_or_func, Tool):
-            tool_or_func.update_namespace(ns_str, force=True, sep=sep)
+            tool_or_func = tool_or_func.update_namespace(ns_str, force=True, sep=sep)
             self._tools[tool_or_func.name] = tool_or_func
             registered_name = tool_or_func.name
             registered_tool = tool_or_func
@@ -288,6 +289,45 @@ class RegistrationMixin:
             )
         )
         return True
+
+    def _replace_tool(self, name: str, **updates: object) -> Tool:
+        """Replace a registered tool with an updated copy.
+
+        Creates a new ``Tool`` via ``dataclasses.replace()`` with the
+        given field overrides and stores it back in the registry.
+
+        Args:
+            name: Registered tool name.
+            **updates: Field-value pairs forwarded to
+                ``dataclasses.replace()``.
+
+        Returns:
+            The newly created ``Tool`` instance.
+        """
+        old = self._tools[name]
+        new_tool = dataclasses.replace(old, **updates)
+        self._tools[name] = new_tool
+        return new_tool
+
+    def _replace_tool_metadata(self, name: str, **meta_updates: object) -> Tool:
+        """Replace a registered tool's metadata with updated fields.
+
+        Creates a new ``ToolMetadata`` via ``dataclasses.replace()`` with
+        the given overrides, then replaces the ``Tool`` itself.
+
+        Args:
+            name: Registered tool name.
+            **meta_updates: Field-value pairs forwarded to
+                ``dataclasses.replace()`` on the tool's metadata.
+
+        Returns:
+            The newly created ``Tool`` instance.
+        """
+        old = self._tools[name]
+        new_meta = dataclasses.replace(old.metadata, **meta_updates)
+        new_tool = dataclasses.replace(old, metadata=new_meta)
+        self._tools[name] = new_tool
+        return new_tool
 
     def _register_class(self, cls_or_instance, *, namespace, **kwargs):
         traverse_mro = kwargs.pop("traverse_mro", True)

--- a/src/toolregistry/integrations/langchain/integration.py
+++ b/src/toolregistry/integrations/langchain/integration.py
@@ -123,7 +123,7 @@ class LangChainTool(Tool):
         )
 
         if namespace:
-            tool_instance.update_namespace(namespace)
+            tool_instance = tool_instance.update_namespace(namespace)
 
         return tool_instance
 

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -1,4 +1,3 @@
-import dataclasses
 import threading
 from collections.abc import Callable
 from pathlib import Path
@@ -435,12 +434,7 @@ class MCPIntegration:
                     existing.parameters,
                     candidate.parameters,
                 )
-                candidate = dataclasses.replace(
-                    candidate,
-                    metadata=dataclasses.replace(
-                        candidate.metadata, last_refreshed_at=now
-                    ),
-                )
+                candidate = candidate.with_refreshed_at(now)
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(

--- a/src/toolregistry/integrations/mcp/integration.py
+++ b/src/toolregistry/integrations/mcp/integration.py
@@ -1,3 +1,4 @@
+import dataclasses
 import threading
 from collections.abc import Callable
 from pathlib import Path
@@ -281,7 +282,7 @@ class MCPTool(Tool):
         )
 
         if namespace:
-            tool.update_namespace(namespace)
+            tool = tool.update_namespace(namespace)
 
         return tool
 
@@ -434,7 +435,12 @@ class MCPIntegration:
                     existing.parameters,
                     candidate.parameters,
                 )
-                candidate.metadata.last_refreshed_at = now
+                candidate = dataclasses.replace(
+                    candidate,
+                    metadata=dataclasses.replace(
+                        candidate.metadata, last_refreshed_at=now
+                    ),
+                )
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
@@ -448,7 +454,7 @@ class MCPIntegration:
                     name
                 )
             elif existing:
-                existing.metadata.last_refreshed_at = now
+                self.registry._replace_tool_metadata(name, last_refreshed_at=now)
                 unchanged += 1
             else:
                 logger.warning("tool tracked but missing from _tools", tool_name=name)
@@ -504,7 +510,9 @@ class MCPIntegration:
                 connection=connection,
                 namespace=self._resolved_ns,
             )
-            candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
+            candidate = candidate.update_namespace(
+                self._resolved_ns, force=True, sep=sep
+            )
             new_tools[candidate.name] = candidate
 
         added, removed, updated, breaking, compatible, unchanged = self._apply_diff(

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import threading
 from typing import Any
@@ -427,12 +426,7 @@ class OpenAPIIntegration:
                     existing.parameters,
                     candidate.parameters,
                 )
-                candidate = dataclasses.replace(
-                    candidate,
-                    metadata=dataclasses.replace(
-                        candidate.metadata, last_refreshed_at=now
-                    ),
-                )
+                candidate = candidate.with_refreshed_at(now)
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(

--- a/src/toolregistry/integrations/openapi/integration.py
+++ b/src/toolregistry/integrations/openapi/integration.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import threading
 from typing import Any
@@ -206,7 +207,7 @@ class OpenAPITool(Tool):
         )
 
         if namespace:
-            tool.update_namespace(namespace)
+            tool = tool.update_namespace(namespace)
 
         return tool
 
@@ -373,7 +374,9 @@ class OpenAPIIntegration:
                     namespace=self._resolved_ns,
                     persistent=self._persistent,
                 )
-                candidate.update_namespace(self._resolved_ns, force=True, sep=sep)
+                candidate = candidate.update_namespace(
+                    self._resolved_ns, force=True, sep=sep
+                )
                 tools[candidate.name] = candidate
         return tools
 
@@ -424,7 +427,12 @@ class OpenAPIIntegration:
                     existing.parameters,
                     candidate.parameters,
                 )
-                candidate.metadata.last_refreshed_at = now
+                candidate = dataclasses.replace(
+                    candidate,
+                    metadata=dataclasses.replace(
+                        candidate.metadata, last_refreshed_at=now
+                    ),
+                )
                 self.registry._tools[name] = candidate
                 self.registry._emit_change(
                     ChangeEvent(
@@ -438,7 +446,7 @@ class OpenAPIIntegration:
                     name
                 )
             elif existing:
-                existing.metadata.last_refreshed_at = now
+                self.registry._replace_tool_metadata(name, last_refreshed_at=now)
                 unchanged += 1
             else:
                 unchanged += 1

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -11,6 +11,8 @@ The search backend is a vendored copy of *zerodep*'s ``SparseIndex``
 
 from __future__ import annotations
 
+import dataclasses
+
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -155,23 +157,34 @@ class ToolDiscoveryTool:
             tool_list_str = "\n".join(tool_list)
 
             if discovery_tool is not None:
-                discovery_tool.description = (
+                new_desc = (
                     _BASE_DISCOVERY_DESCRIPTION + "\n\nTools available on demand "
                     "(call discover_tools for full schema):\n" + tool_list_str
                 )
+                self._registry._tools[TOOL_DISCOVERY_NAME] = dataclasses.replace(
+                    discovery_tool, description=new_desc
+                )
             if call_deferred_tool is not None:
-                call_deferred_tool.description = (
+                new_desc = (
                     BASE_CALL_DEFERRED_DESCRIPTION
                     + "\n\nCurrently deferred:\n"
                     + tool_list_str
                 )
+                self._registry._tools[TOOL_CALL_DEFERRED_NAME] = dataclasses.replace(
+                    call_deferred_tool, description=new_desc
+                )
         else:
             if discovery_tool is not None:
-                discovery_tool.description = _BASE_DISCOVERY_DESCRIPTION
+                self._registry._tools[TOOL_DISCOVERY_NAME] = dataclasses.replace(
+                    discovery_tool, description=_BASE_DISCOVERY_DESCRIPTION
+                )
             if call_deferred_tool is not None:
-                call_deferred_tool.description = (
+                new_desc = (
                     BASE_CALL_DEFERRED_DESCRIPTION
                     + " No deferred tools currently available."
+                )
+                self._registry._tools[TOOL_CALL_DEFERRED_NAME] = dataclasses.replace(
+                    call_deferred_tool, description=new_desc
                 )
 
     def discover(

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -11,8 +11,6 @@ The search backend is a vendored copy of *zerodep*'s ``SparseIndex``
 
 from __future__ import annotations
 
-import dataclasses
-
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -161,30 +159,28 @@ class ToolDiscoveryTool:
                     _BASE_DISCOVERY_DESCRIPTION + "\n\nTools available on demand "
                     "(call discover_tools for full schema):\n" + tool_list_str
                 )
-                self._registry._tools[TOOL_DISCOVERY_NAME] = dataclasses.replace(
-                    discovery_tool, description=new_desc
-                )
+                self._registry._replace_tool(TOOL_DISCOVERY_NAME, description=new_desc)
             if call_deferred_tool is not None:
                 new_desc = (
                     BASE_CALL_DEFERRED_DESCRIPTION
                     + "\n\nCurrently deferred:\n"
                     + tool_list_str
                 )
-                self._registry._tools[TOOL_CALL_DEFERRED_NAME] = dataclasses.replace(
-                    call_deferred_tool, description=new_desc
+                self._registry._replace_tool(
+                    TOOL_CALL_DEFERRED_NAME, description=new_desc
                 )
         else:
             if discovery_tool is not None:
-                self._registry._tools[TOOL_DISCOVERY_NAME] = dataclasses.replace(
-                    discovery_tool, description=_BASE_DISCOVERY_DESCRIPTION
+                self._registry._replace_tool(
+                    TOOL_DISCOVERY_NAME, description=_BASE_DISCOVERY_DESCRIPTION
                 )
             if call_deferred_tool is not None:
                 new_desc = (
                     BASE_CALL_DEFERRED_DESCRIPTION
                     + " No deferred tools currently available."
                 )
-                self._registry._tools[TOOL_CALL_DEFERRED_NAME] = dataclasses.replace(
-                    call_deferred_tool, description=new_desc
+                self._registry._replace_tool(
+                    TOOL_CALL_DEFERRED_NAME, description=new_desc
                 )
 
     def discover(

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -47,6 +47,12 @@ but uses a unique field name to avoid collisions with native tool parameters.
 class ToolMetadata:
     """Behavioral and classification metadata for a Tool.
 
+    Note:
+        Frozen semantics are shallow — field reassignment is prevented
+        but mutable containers (``tags`` set, ``custom_tags`` set,
+        ``extra`` dict) can still be modified in place.  Mutation
+        should only occur during ``__post_init__``.
+
     Attributes:
         is_async: Whether the tool requires async execution.
         is_concurrency_safe: Whether the tool can be run concurrently.
@@ -192,6 +198,11 @@ class ToolMetadata:
         return dataclasses.replace(self, **(update or {}))
 
 
+# Override frozen=True auto-generated __hash__ to keep ToolMetadata
+# explicitly unhashable, consistent with pre-frozen behavior.
+ToolMetadata.__hash__ = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
+
 @dataclass(frozen=True, init=False)
 class Tool:
     """Base class representing an executable tool/function.
@@ -201,6 +212,12 @@ class Tool:
         - Parameter validation
         - Synchronous/asynchronous execution
         - JSON schema generation
+
+    Note:
+        Frozen semantics are shallow — field reassignment is prevented
+        but mutable containers (``parameters`` dict, ``metadata.tags``
+        set) can still be modified in place.  Mutation should only occur
+        during ``__init__``.
     """
 
     name: str
@@ -279,6 +296,9 @@ class Tool:
         method_name: str | None = None,
         is_async: bool | None = None,
     ) -> None:
+        # NOTE: dataclasses.replace() re-runs __init__ on every copy.
+        # _inject_toolcall_reason and schema_hash computation are
+        # idempotent, so this is safe but does redundant work.
         if metadata is None:
             metadata = (
                 ToolMetadata(is_async=is_async)
@@ -310,6 +330,9 @@ class Tool:
         The ``toolcall_reason`` field is only added when ``parameters``
         already contains a ``properties`` mapping.
         """
+        # Called during __init__ only. Dict mutations (adding keys to
+        # self.parameters) are safe here because no external reference
+        # exists yet — frozen protects field reassignment, not dict contents.
         had_properties = isinstance(self.parameters.get("properties"), dict)
         if self.parameters.get("type") != "object":
             object.__setattr__(self, "parameters", {"type": "object", "properties": {}})
@@ -700,6 +723,11 @@ class Tool:
         original name is preserved.  If no namespace prefix exists, the
         new *namespace* is prepended.
 
+        Note:
+            When ``force=False`` and the name already contains a
+            namespace prefix, the ``namespace`` field is updated to
+            the new value but ``name`` is preserved unchanged.
+
         Args:
             namespace: The new namespace to apply to the tool's name.
             force: If ``True``, forces the replacement of an existing
@@ -752,3 +780,8 @@ class Tool:
             namespace=namespace,
             method_name=new_method_name,
         )
+
+
+# Override frozen=True auto-generated __hash__ to keep Tool
+# explicitly unhashable, consistent with pre-frozen behavior.
+Tool.__hash__ = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -705,6 +705,13 @@ class Tool:
         )
         return await self.arun(parameters)
 
+    def with_refreshed_at(self: _ToolT, timestamp: str) -> _ToolT:
+        """Return a copy with ``last_refreshed_at`` updated."""
+        return dataclasses.replace(
+            self,
+            metadata=dataclasses.replace(self.metadata, last_refreshed_at=timestamp),
+        )
+
     def update_namespace(
         self: _ToolT,
         namespace: str | None,

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -3,13 +3,16 @@ import inspect
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, ClassVar, Literal, get_type_hints
+from typing import Any, ClassVar, Literal, TypeVar, get_type_hints
 from collections.abc import Callable
 
 from .parameter_models import _generate_parameters_model, _simplify_nullable_schemas
 from .llm.tool_calls import API_FORMATS
 from .tool_wrapper import BaseToolWrapper, _FunctionToolWrapper
 from .utils import compute_schema_hash, normalize_tool_name
+
+
+_ToolT = TypeVar("_ToolT", bound="Tool")
 
 
 class ToolTag(str, Enum):
@@ -40,7 +43,7 @@ but uses a unique field name to avoid collisions with native tool parameters.
 """
 
 
-@dataclass
+@dataclass(frozen=True)
 class ToolMetadata:
     """Behavioral and classification metadata for a Tool.
 
@@ -189,7 +192,7 @@ class ToolMetadata:
         return dataclasses.replace(self, **(update or {}))
 
 
-@dataclass(init=False)
+@dataclass(frozen=True, init=False)
 class Tool:
     """Base class representing an executable tool/function.
 
@@ -282,18 +285,20 @@ class Tool:
                 if is_async is not None
                 else ToolMetadata()
             )
-        self.name = name
-        self.description = description
-        self.parameters = parameters
-        self.callable = callable
-        self.metadata = metadata
-        self.parameters_model = parameters_model
-        self.namespace = namespace
-        self.method_name = method_name
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "parameters", parameters)
+        object.__setattr__(self, "callable", callable)
+        object.__setattr__(self, "parameters_model", parameters_model)
+        object.__setattr__(self, "namespace", namespace)
+        object.__setattr__(self, "method_name", method_name)
         self._inject_toolcall_reason()
         # Hash after toolcall_reason injection so it reflects the final schema.
-        if not self.metadata.schema_hash:
-            self.metadata.schema_hash = compute_schema_hash(self.parameters)
+        if not metadata.schema_hash:
+            metadata = dataclasses.replace(
+                metadata, schema_hash=compute_schema_hash(self.parameters)
+            )
+        object.__setattr__(self, "metadata", metadata)
 
     def _inject_toolcall_reason(self) -> None:
         """Inject ``toolcall_reason`` property into the tool's parameter schema.
@@ -307,7 +312,7 @@ class Tool:
         """
         had_properties = isinstance(self.parameters.get("properties"), dict)
         if self.parameters.get("type") != "object":
-            self.parameters = {"type": "object", "properties": {}}
+            object.__setattr__(self, "parameters", {"type": "object", "properties": {}})
         elif not had_properties:
             self.parameters["properties"] = {}
 
@@ -455,7 +460,7 @@ class Tool:
         )
 
         if namespace:
-            tool.update_namespace(namespace)
+            tool = tool.update_namespace(namespace)
 
         return tool
 
@@ -573,14 +578,14 @@ class Tool:
         )
         return self.get_schema(api_format)
 
-    def _validate_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+    def validate_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
         """Validate parameters against tool schema.
 
         Args:
-            parameters (Dict[str, Any]): Raw input parameters.
+            parameters: Raw input parameters.
 
         Returns:
-            Dict[str, Any]: Validated and normalized parameters.
+            Validated and normalized parameters.
         """
         if self.parameters_model is None:
             return parameters
@@ -596,6 +601,8 @@ class Tool:
             get_type_hints(self.parameters_model, include_extras=True).keys()
         )
         return {k: validated[k] for k in declared if k in validated}
+
+    _validate_parameters = validate_parameters  # backward compat
 
     def run(self, parameters: dict[str, Any]) -> Any:
         """Execute tool synchronously.
@@ -619,7 +626,7 @@ class Tool:
             results without truncation.
         """
         parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
-        validated_params = self._validate_parameters(parameters)
+        validated_params = self.validate_parameters(parameters)
         return self.callable.call_sync(**validated_params)  # ty: ignore[unresolved-attribute]
 
     async def arun(self, parameters: dict[str, Any]) -> Any:
@@ -644,7 +651,7 @@ class Tool:
             results without truncation.
         """
         parameters = {k: v for k, v in parameters.items() if k != "toolcall_reason"}
-        validated_params = self._validate_parameters(parameters)
+        validated_params = self.validate_parameters(parameters)
         return await self.callable.call_async(**validated_params)  # ty: ignore[unresolved-attribute]
 
     def run_raw(self, parameters: dict[str, Any]) -> Any:
@@ -676,64 +683,72 @@ class Tool:
         return await self.arun(parameters)
 
     def update_namespace(
-        self,
+        self: _ToolT,
         namespace: str | None,
         force: bool = False,
         sep: Literal["-", "."] = "-",
-    ) -> None:
-        """Updates the namespace of a tool.
+    ) -> _ToolT:
+        """Return a copy of the tool with an updated namespace.
 
-        This method checks if the tool's name already contains a namespace (indicated by the presence of a separator character).
-        OpenAI requires that function names match the pattern ``^[a-zA-Z0-9_-]+$``. Some other providers allow dot (`.`) as separator.
-        If it does and `force` is `True`, the existing namespace is replaced with the provided `namespace`.
-        If `force` is `False` and an existing namespace is present, no changes are made.
-        If the tool's name does not contain a namespace, the `namespace` is prepended as a prefix to the tool's name.
+        Checks if the tool's name already contains a namespace (indicated
+        by the presence of a separator character).  OpenAI requires that
+        function names match ``^[a-zA-Z0-9_-]+$``; some other providers
+        allow dot (``.``) as separator.
+
+        If a namespace prefix already exists and *force* is ``True``, the
+        existing namespace is replaced.  If *force* is ``False``, the
+        original name is preserved.  If no namespace prefix exists, the
+        new *namespace* is prepended.
 
         Args:
-            namespace (str): The new namespace to apply to the tool's name.
-            force (bool, optional): If `True`, forces the replacement of an existing namespace. Defaults to `False`.
+            namespace: The new namespace to apply to the tool's name.
+            force: If ``True``, forces the replacement of an existing
+                namespace.  Defaults to ``False``.
+            sep: Separator character between namespace and method name.
 
         Returns:
-            None: This method modifies the `tool.name` attribute in place and does not return a value.
+            A new ``Tool`` instance with the updated namespace.  Returns
+            ``self`` unchanged when *namespace* is falsy.
 
         Example:
             ```python
-            tool = Tool(name="example_tool")
-            tool.update_namespace("new_namespace")
+            tool = Tool(name="example_tool", ...)
+            tool = tool.update_namespace("new_namespace")
             tool.name  # 'new_namespace-example_tool'
 
-            tool = Tool(name="old_namespace.example_tool")
-            tool.update_namespace("new_namespace", force=False)
+            tool = Tool(name="old_namespace-example_tool", ...)
+            tool = tool.update_namespace("new_namespace", force=False)
             tool.name  # 'old_namespace-example_tool'
 
-            tool = Tool(name="old_namespace.example_tool")
-            tool.update_namespace("new_namespace", force=True, sep=".")
+            tool = Tool(name="old_namespace.example_tool", ...)
+            tool = tool.update_namespace("new_namespace", force=True, sep=".")
             tool.name  # 'new_namespace.example_tool'
             ```
         """
         if not namespace:
-            return
+            return self
 
         namespace = normalize_tool_name(namespace)
 
-        # Ensure method_name is populated before updating the name.
-        # If method_name was never set, derive it from the current name
-        # (stripping any existing namespace prefix).
-        if not self.method_name:
+        # Derive method_name if not already set.
+        new_method_name = self.method_name
+        if not new_method_name:
             if sep in self.name:
-                self.method_name = self.name.split(sep, 1)[1]
+                new_method_name = self.name.split(sep, 1)[1]
             else:
-                self.method_name = self.name
-
-        self.namespace = namespace
+                new_method_name = self.name
 
         if sep in self.name:
             if force:
-                # Replace existing namespace with the new one if force is True
-                self.name = f"{namespace}{sep}{self.name.split(sep, 1)[1]}"
+                new_name = f"{namespace}{sep}{self.name.split(sep, 1)[1]}"
             else:
-                # Do not change the name if force is False and an existing namespace is present
-                pass
+                new_name = self.name
         else:
-            # Add the new namespace as a prefix if there is no existing namespace
-            self.name = f"{namespace}{sep}{self.name}"
+            new_name = f"{namespace}{sep}{self.name}"
+
+        return dataclasses.replace(
+            self,
+            name=new_name,
+            namespace=namespace,
+            method_name=new_method_name,
+        )

--- a/src/toolregistry/tool_registry.py
+++ b/src/toolregistry/tool_registry.py
@@ -1890,10 +1890,13 @@ class ToolRegistry(
             else:
                 hint = getattr(override, "search_hint", "")
                 defer = getattr(override, "defer", None)
+            meta_updates: dict[str, object] = {}
             if hint:
-                tool.metadata.search_hint = hint
+                meta_updates["search_hint"] = hint
             if defer is not None:
-                tool.metadata.defer = defer
+                meta_updates["defer"] = defer
+            if meta_updates:
+                self._replace_tool_metadata(tool.name, **meta_updates)
 
     def get_schemas(
         self,

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -546,6 +546,8 @@ class TestAdminServerEnrichedAPI:
         registry.register(search, namespace="web")
 
         # Set metadata on tools
+        # Use private helper — these metadata fields aren't in the
+        # public update_tool_metadata allowlist.
         registry._replace_tool_metadata(
             "math-add",
             tags={ToolTag.READ_ONLY},
@@ -554,6 +556,8 @@ class TestAdminServerEnrichedAPI:
             think_augment=True,
         )
 
+        # Use private helper — these metadata fields aren't in the
+        # public update_tool_metadata allowlist.
         registry._replace_tool_metadata(
             "web-search",
             tags={ToolTag.NETWORK, ToolTag.SLOW},

--- a/tests/test_admin_server.py
+++ b/tests/test_admin_server.py
@@ -546,18 +546,22 @@ class TestAdminServerEnrichedAPI:
         registry.register(search, namespace="web")
 
         # Set metadata on tools
-        tool_add = registry.get_tool("math-add")
-        tool_add.metadata.tags = {ToolTag.READ_ONLY}
-        tool_add.metadata.locality = "local"
-        tool_add.metadata.timeout = 30.0
-        tool_add.metadata.think_augment = True
+        registry._replace_tool_metadata(
+            "math-add",
+            tags={ToolTag.READ_ONLY},
+            locality="local",
+            timeout=30.0,
+            think_augment=True,
+        )
 
-        tool_search = registry.get_tool("web-search")
-        tool_search.metadata.tags = {ToolTag.NETWORK, ToolTag.SLOW}
-        tool_search.metadata.custom_tags = {"external"}
-        tool_search.metadata.locality = "remote"
-        tool_search.metadata.defer = True
-        tool_search.metadata.search_hint = "web query"
+        registry._replace_tool_metadata(
+            "web-search",
+            tags={ToolTag.NETWORK, ToolTag.SLOW},
+            custom_tags={"external"},
+            locality="remote",
+            defer=True,
+            search_hint="web query",
+        )
 
         server = AdminServer(registry, port=18092)
         info = server.start()
@@ -850,7 +854,9 @@ class TestAdminServerMetadataUpdate:
         assert data["success"] is True
         assert data["updated"] == {"think_augment": True}
 
-        # Verify the metadata was actually updated
+        # Verify the metadata was actually updated (re-fetch; frozen tools
+        # are replaced in the registry, so the old reference is stale)
+        tool = registry.get_tool("math-add")
         assert tool.metadata.think_augment is True
 
     def test_update_tool_defer(self, server_with_tools) -> None:
@@ -867,6 +873,7 @@ class TestAdminServerMetadataUpdate:
         )
         assert status == 200
         assert data["success"] is True
+        tool = registry.get_tool("greet")
         assert tool.metadata.defer is True
 
     def test_update_tool_invalid_field(self, server_with_tools) -> None:
@@ -921,7 +928,9 @@ class TestAdminServerMetadataUpdate:
         assert data["success"] is True
         assert data["tools_updated"] == 2
 
-        # Both tools should be updated
+        # Both tools should be updated (re-fetch; frozen replacement)
+        tool_add = registry.get_tool("math-add")
+        tool_mul = registry.get_tool("math-multiply")
         assert tool_add.metadata.think_augment is True
         assert tool_mul.metadata.think_augment is True
 

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -247,8 +247,8 @@ class TestMCPToolTimeout:
         """sync invoke + real MCP tool + timeout → ErrorResult."""
         with ToolRegistry() as reg:
             reg.register_from_mcp(_stdio_config(), persistent=True)
-            tool = reg.get_tool("slow_tool")
-            tool.metadata.timeout = 0.5
+            reg.get_tool("slow_tool")  # ensure tool exists
+            reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             start = time.perf_counter()
             r = reg.invoke("slow_tool", {"seconds": 5.0})
@@ -263,8 +263,8 @@ class TestMCPToolTimeout:
         """ainvoke + real MCP tool + timeout → ErrorResult."""
         async with ToolRegistry() as reg:
             await reg.register_from_mcp_async(_stdio_config(), persistent=True)
-            tool = reg.get_tool("slow_tool")
-            tool.metadata.timeout = 0.5
+            reg.get_tool("slow_tool")  # ensure tool exists
+            reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             start = time.perf_counter()
             r = await reg.ainvoke("slow_tool", {"seconds": 5.0})
@@ -295,8 +295,8 @@ class TestMCPToolTimeout:
         """
         with ToolRegistry() as reg:
             reg.register_from_mcp(_stdio_config(), persistent=True)
-            tool = reg.get_tool("slow_tool")
-            tool.metadata.timeout = 0.5
+            reg.get_tool("slow_tool")  # ensure tool exists
+            reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             tcs = [_tc("c1", "slow_tool", '{"seconds": 5.0}')]
             start = time.perf_counter()
@@ -312,8 +312,8 @@ class TestMCPToolTimeout:
         """async batch: single slow MCP tool times out."""
         async with ToolRegistry() as reg:
             await reg.register_from_mcp_async(_stdio_config(), persistent=True)
-            tool = reg.get_tool("slow_tool")
-            tool.metadata.timeout = 0.5
+            reg.get_tool("slow_tool")  # ensure tool exists
+            reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             tcs = [_tc("c1", "slow_tool", '{"seconds": 5.0}')]
             start = time.perf_counter()

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -248,6 +248,8 @@ class TestMCPToolTimeout:
         with ToolRegistry() as reg:
             reg.register_from_mcp(_stdio_config(), persistent=True)
             reg.get_tool("slow_tool")  # ensure tool exists
+            # Use private helper — these metadata fields aren't in the
+            # public update_tool_metadata allowlist.
             reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             start = time.perf_counter()
@@ -264,6 +266,8 @@ class TestMCPToolTimeout:
         async with ToolRegistry() as reg:
             await reg.register_from_mcp_async(_stdio_config(), persistent=True)
             reg.get_tool("slow_tool")  # ensure tool exists
+            # Use private helper — these metadata fields aren't in the
+            # public update_tool_metadata allowlist.
             reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             start = time.perf_counter()
@@ -296,6 +300,8 @@ class TestMCPToolTimeout:
         with ToolRegistry() as reg:
             reg.register_from_mcp(_stdio_config(), persistent=True)
             reg.get_tool("slow_tool")  # ensure tool exists
+            # Use private helper — these metadata fields aren't in the
+            # public update_tool_metadata allowlist.
             reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             tcs = [_tc("c1", "slow_tool", '{"seconds": 5.0}')]
@@ -313,6 +319,8 @@ class TestMCPToolTimeout:
         async with ToolRegistry() as reg:
             await reg.register_from_mcp_async(_stdio_config(), persistent=True)
             reg.get_tool("slow_tool")  # ensure tool exists
+            # Use private helper — these metadata fields aren't in the
+            # public update_tool_metadata allowlist.
             reg._replace_tool_metadata("slow_tool", timeout=0.5)
 
             tcs = [_tc("c1", "slow_tool", '{"seconds": 5.0}')]

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -422,7 +422,7 @@ class TestMCPRefresh:
         sep = getattr(registry, "_name_sep", "-")
         for ts in tool_specs:
             tool = MCPTool.from_tool_json(ts, connection, namespace=None)
-            tool.update_namespace(None, force=True, sep=sep)
+            tool = tool.update_namespace(None, force=True, sep=sep)
             registry.register(tool)
             integration._registered_tool_names.add(tool.name)
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 
+import dataclasses
 import pytest
 
 from toolregistry.tool import Tool, ToolMetadata, ToolTag
@@ -266,47 +267,48 @@ class TestTool:
         original_name = sample_tool.name
         namespace = "math"
 
-        sample_tool.update_namespace(namespace)
+        updated = sample_tool.update_namespace(namespace)
 
-        assert sample_tool.name == f"{namespace}-{original_name}"
+        assert updated.name == f"{namespace}-{original_name}"
 
     def test_update_namespace_preserves_existing_namespace_without_force(
         self, sample_tool
     ):
         """Test that existing namespace is preserved when force=False."""
-        sample_tool.name = "existing-tool_name"
-        original_name = sample_tool.name
+        tool = dataclasses.replace(sample_tool, name="existing-tool_name")
+        original_name = tool.name
 
-        sample_tool.update_namespace("new_namespace", force=False)
+        updated = tool.update_namespace("new_namespace", force=False)
 
-        assert sample_tool.name == original_name
+        assert updated.name == original_name
 
     def test_update_namespace_replaces_existing_namespace_with_force(self, sample_tool):
         """Test that existing namespace is replaced when force=True."""
-        sample_tool.name = "existing-tool_name"
+        tool = dataclasses.replace(sample_tool, name="existing-tool_name")
         new_namespace = "new_namespace"
 
-        sample_tool.update_namespace(new_namespace, force=True)
+        updated = tool.update_namespace(new_namespace, force=True)
 
-        assert sample_tool.name == f"{new_namespace}-tool_name"
+        assert updated.name == f"{new_namespace}-tool_name"
 
     def test_update_namespace_with_dot_separator(self, sample_tool):
         """Test namespace update with dot separator."""
         original_name = sample_tool.name
         namespace = "math"
 
-        sample_tool.update_namespace(namespace, sep=".")
+        updated = sample_tool.update_namespace(namespace, sep=".")
 
-        assert sample_tool.name == f"{namespace}.{original_name}"
+        assert updated.name == f"{namespace}.{original_name}"
 
     def test_update_namespace_with_empty_namespace_does_nothing(self, sample_tool):
         """Test that empty namespace does nothing."""
         original_name = sample_tool.name
 
-        sample_tool.update_namespace("")
-        sample_tool.update_namespace(None)
+        updated = sample_tool.update_namespace("")
+        assert updated.name == original_name
 
-        assert sample_tool.name == original_name
+        updated = sample_tool.update_namespace(None)
+        assert updated.name == original_name
 
     def test_tool_with_function_without_docstring(self):
         """Test creating tool from function without docstring."""
@@ -602,3 +604,72 @@ class TestToolMetadataFields:
         tool = Tool.from_function(sample_function)
 
         assert tool.qualified_name == "add_numbers"
+
+
+class TestFrozenDataclasses:
+    """Test that Tool and ToolMetadata are frozen (immutable) dataclasses."""
+
+    def test_tool_is_frozen(self):
+        """Assigning to a Tool field after construction raises FrozenInstanceError."""
+
+        def sample(a: int) -> int:
+            return a
+
+        tool = Tool.from_function(sample, name="sample")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            tool.name = "other"  # type: ignore[misc]
+
+    def test_tool_metadata_is_frozen(self):
+        """Assigning to a ToolMetadata field after construction raises FrozenInstanceError."""
+        meta = ToolMetadata()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            meta.timeout = 5.0  # type: ignore[misc]
+
+    def test_tool_metadata_replace(self):
+        """dataclasses.replace() produces a new ToolMetadata with updated fields."""
+        meta = ToolMetadata(timeout=1.0)
+        new_meta = dataclasses.replace(meta, timeout=2.0)
+        assert meta.timeout == 1.0
+        assert new_meta.timeout == 2.0
+
+    def test_tool_replace(self):
+        """dataclasses.replace() produces a new Tool with updated fields."""
+
+        def sample(a: int) -> int:
+            return a
+
+        tool = Tool.from_function(sample, name="sample")
+        new_tool = dataclasses.replace(tool, description="updated")
+        assert tool.description != "updated"
+        assert new_tool.description == "updated"
+
+    def test_update_namespace_returns_new_tool(self):
+        """update_namespace returns a new Tool instead of mutating in place."""
+
+        def sample(a: int) -> int:
+            return a
+
+        original = Tool.from_function(sample, name="sample")
+        updated = original.update_namespace("ns")
+        assert updated is not original
+        assert updated.name == "ns-sample"
+        assert original.name == "sample"
+
+    def test_validate_parameters_public(self):
+        """validate_parameters is accessible as a public method."""
+
+        def sample(a: int, b: int) -> int:
+            return a + b
+
+        tool = Tool.from_function(sample, name="sample")
+        result = tool.validate_parameters({"a": 1, "b": 2})
+        assert result == {"a": 1, "b": 2}
+
+    def test_validate_parameters_backward_compat(self):
+        """_validate_parameters still works as a backward-compat alias."""
+
+        def sample(a: int) -> int:
+            return a
+
+        tool = Tool.from_function(sample, name="sample")
+        assert tool._validate_parameters({"a": 1}) == {"a": 1}

--- a/tests/test_tool_namespace.py
+++ b/tests/test_tool_namespace.py
@@ -101,7 +101,7 @@ class TestUpdateNamespace:
 
     def test_update_sets_namespace_field(self):
         tool = Tool.from_function(dummy_add)
-        tool.update_namespace("math")
+        tool = tool.update_namespace("math")
         assert tool.namespace == "math"
         assert tool.method_name == "dummy_add"
         assert tool.name == "math-dummy_add"
@@ -109,13 +109,13 @@ class TestUpdateNamespace:
     def test_update_force_replaces_namespace(self):
         tool = Tool.from_function(dummy_add, namespace="old")
         assert tool.namespace == "old"
-        tool.update_namespace("new", force=True)
+        tool = tool.update_namespace("new", force=True)
         assert tool.namespace == "new"
         assert tool.name == "new-dummy_add"
 
     def test_update_no_force_keeps_existing(self):
         tool = Tool.from_function(dummy_add, namespace="old")
-        tool.update_namespace("new", force=False)
+        tool = tool.update_namespace("new", force=False)
         # namespace field is updated, but name is NOT changed
         assert tool.namespace == "new"
         assert tool.name == "old-dummy_add"
@@ -129,7 +129,7 @@ class TestUpdateNamespace:
             callable=dummy_add,
         )
         assert tool.method_name is None
-        tool.update_namespace("new_ns", force=True)
+        tool = tool.update_namespace("new_ns", force=True)
         assert tool.method_name == "some_func"
         assert tool.namespace == "new_ns"
 
@@ -141,7 +141,7 @@ class TestUpdateNamespace:
             parameters={},
             callable=dummy_add,
         )
-        tool.update_namespace("ns")
+        tool = tool.update_namespace("ns")
         assert tool.method_name == "some_func"
         assert tool.namespace == "ns"
         assert tool.name == "ns-some_func"

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -114,7 +114,10 @@ class TestToolRegistry:
 
         expected_name = f"{namespace}-{original_name}"
         assert expected_name in sample_registry
-        assert sample_tool.name == expected_name
+        # Tool is frozen; the registry stores the namespaced copy,
+        # but the original reference is unchanged.
+        registered = sample_registry.get_tool(expected_name)
+        assert registered.name == expected_name
 
     def test_list_tools(self, populated_registry):
         """Test listing all tools."""


### PR DESCRIPTION
## Summary

Make `Tool` and `ToolMetadata` immutable after construction by adding `frozen=True` to both dataclass decorators. All mutations now go through `dataclasses.replace()` and two internal helpers.

### Core changes
- `ToolMetadata`: `@dataclass` → `@dataclass(frozen=True)`
- `Tool`: `@dataclass(init=False)` → `@dataclass(frozen=True, init=False)`
- `Tool.__init__`: all field assignments → `object.__setattr__`
- `_inject_toolcall_reason`: `self.parameters = ...` → `object.__setattr__`
- `update_namespace()`: returns new `Tool` via `dataclasses.replace()` instead of mutating in place. Uses `TypeVar` return type so subclass types are preserved.
- `_validate_parameters` → `validate_parameters` (public), with backward-compat alias

### New helpers on RegistrationMixin
- `_replace_tool(name, **updates)` — replace Tool fields, update `_tools` dict
- `_replace_tool_metadata(name, **meta_updates)` — replace ToolMetadata fields, update `_tools` dict

### Mutation sites converted (14 sites across 9 files)
- `update_namespace()` + 8 call sites → return-value rebinding
- `metadata.last_refreshed_at` in MCP/OpenAPI refresh (4 sites) → `replace()`
- `metadata.search_hint/defer` in config override → `_replace_tool_metadata`
- `setattr(tool.metadata, ...)` in enable_disable.py (2 sites) → `replace()`
- `discovery_tool.description` in `_sync_description` (4 sites) → `replace()`

### Tests
- 7 new tests in `TestFrozenDataclasses`: frozen behavior, `replace()`, public `validate_parameters`
- Updated 15 existing tests for return-value semantics
- 1319+ tests pass, pre-commit green

## Test plan
- [x] `tool.name = "x"` raises `FrozenInstanceError`
- [x] `tool.metadata.is_async = True` raises `FrozenInstanceError`
- [x] `dataclasses.replace(tool, name="new")` works
- [x] `tool.validate_parameters(...)` is accessible (public)
- [x] `update_namespace()` returns new Tool, preserves subclass type
- [x] All existing tests pass (namespace, refresh, admin, e2e)

Closes #263