### PR TITLE
refactor: two-layer schema model — clean parameters, augmented get_schema()

### DIFF
--- a/src/toolregistry/_vendor/jsonschema.py
+++ b/src/toolregistry/_vendor/jsonschema.py
@@ -1,9 +1,9 @@
 # /// zerodep
-# version = "0.2.0"
+# version = "0.3.0"
 # deps = []
 # tier = "medium"
 # category = "validation"
-# note = "Install/update via `zerodep add jsonschema`"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
 # ///
 """JSON Schema flattening & sanitization — zero dependencies, stdlib only.
 
@@ -57,6 +57,12 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 _DEFS_KEYS: set[str] = {"$defs", "definitions"}
+
+# Keys whose *values* are property-name maps (not schema nodes).
+# When a walker enters one of these, it must NOT treat the map's keys as
+# schema keywords — they are user-defined parameter names.  The map's
+# *values* are sub-schemas and should still be processed.
+_PROPERTY_MAP_KEYS: set[str] = {"properties", "patternProperties", "dependentSchemas"}
 
 UNSUPPORTED_SCHEMA_KEYS: set[str] = {
     # JSON Schema meta
@@ -300,22 +306,30 @@ def _merge_allof_node(schema: dict[str, Any]) -> dict[str, Any]:
     return base
 
 
-def _walk_merge_allof(schema: dict[str, Any]) -> dict[str, Any]:
+def _walk_merge_allof(
+    schema: dict[str, Any],
+    *,
+    _in_property_map: bool = False,
+) -> dict[str, Any]:
     """Recursively merge all ``allOf`` nodes in *schema*."""
     # First recurse into children so nested allOf are resolved bottom-up.
     result: dict[str, Any] = {}
     for key, value in schema.items():
         if isinstance(value, dict):
-            result[key] = _walk_merge_allof(value)
+            result[key] = _walk_merge_allof(
+                value, _in_property_map=key in _PROPERTY_MAP_KEYS
+            )
         elif isinstance(value, list):
             result[key] = [
-                _walk_merge_allof(item) if isinstance(item, dict) else item
+                _walk_merge_allof(item, _in_property_map=False)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:
             result[key] = value
 
-    if "allOf" in result and isinstance(result["allOf"], list):
+    if not _in_property_map and "allOf" in result and isinstance(result["allOf"], list):
         result = _merge_allof_node(result)
     return result
 
@@ -367,21 +381,29 @@ def _simplify_node(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
-def _walk_simplify(schema: dict[str, Any]) -> dict[str, Any]:
+def _walk_simplify(
+    schema: dict[str, Any],
+    *,
+    _in_property_map: bool = False,
+) -> dict[str, Any]:
     """Recursively simplify all ``anyOf``/``oneOf`` nodes."""
     result: dict[str, Any] = {}
     for key, value in schema.items():
         if isinstance(value, dict):
-            result[key] = _walk_simplify(value)
+            result[key] = _walk_simplify(
+                value, _in_property_map=key in _PROPERTY_MAP_KEYS
+            )
         elif isinstance(value, list):
             result[key] = [
-                _walk_simplify(item) if isinstance(item, dict) else item
+                _walk_simplify(item, _in_property_map=False)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:
             result[key] = value
 
-    if result.keys() & {"anyOf", "oneOf"}:
+    if not _in_property_map and result.keys() & {"anyOf", "oneOf"}:
         result = _simplify_node(result)
     return result
 
@@ -411,17 +433,23 @@ def simplify_unions(schema: dict[str, Any]) -> dict[str, Any]:
 def _walk_sanitize(
     schema: dict[str, Any],
     strip: set[str],
+    *,
+    _in_property_map: bool = False,
 ) -> dict[str, Any]:
     """Recursively strip unsupported keys and prune orphaned ``required``."""
     result: dict[str, Any] = {}
     for key, value in schema.items():
-        if key in strip:
+        if not _in_property_map and key in strip:
             continue
         if isinstance(value, dict):
-            result[key] = _walk_sanitize(value, strip)
+            result[key] = _walk_sanitize(
+                value, strip, _in_property_map=key in _PROPERTY_MAP_KEYS
+            )
         elif isinstance(value, list):
             result[key] = [
-                _walk_sanitize(item, strip) if isinstance(item, dict) else item
+                _walk_sanitize(item, strip, _in_property_map=False)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:

--- a/src/toolregistry/llm/discovery.py
+++ b/src/toolregistry/llm/discovery.py
@@ -57,9 +57,9 @@ def _tool_name_to_text(name: str) -> str:
 
 
 def _extract_param_names(tool: Tool) -> str:
-    """Extract parameter names from a tool's JSON schema, excluding ``toolcall_reason``."""
+    """Extract parameter names from a tool's JSON schema."""
     props = tool.parameters.get("properties", {})
-    return " ".join(k for k in props if k != "toolcall_reason")
+    return " ".join(props)
 
 
 def _tool_to_fields(tool: Tool) -> dict[str, str]:

--- a/src/toolregistry/schema_diff.py
+++ b/src/toolregistry/schema_diff.py
@@ -68,8 +68,8 @@ def classify_schema_change(
     old_required = set(old.get("required", []))
     new_required = set(new.get("required", []))
 
-    old_keys = set(old_props.keys()) - {"toolcall_reason"}
-    new_keys = set(new_props.keys()) - {"toolcall_reason"}
+    old_keys = set(old_props.keys())
+    new_keys = set(new_props.keys())
 
     added_keys = new_keys - old_keys
     removed_keys = old_keys - new_keys

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -512,8 +512,6 @@ class Tool:
         Returns:
             Provider-specific tool definition dict.
         """
-        import copy
-
         from .llm._rosetta import _make_ir_tool_definition
         from .llm.tool_calls import _get_tool_ops, _normalize_api_format
 
@@ -527,13 +525,17 @@ class Tool:
         )
         should_include_reason = effective is True
 
+        base_props = self.parameters.get("properties", {})
         if should_include_reason:
-            params = copy.deepcopy(self.parameters)
-            params.setdefault("properties", {})["toolcall_reason"] = (
-                TOOLCALL_REASON_PROPERTY
-            )
+            params = {
+                **self.parameters,
+                "properties": {
+                    **base_props,
+                    "toolcall_reason": TOOLCALL_REASON_PROPERTY,
+                },
+            }
         else:
-            params = self.parameters
+            params = {**self.parameters, "properties": dict(base_props)}
 
         ir_tool = _make_ir_tool_definition(self.name, self.description, params)
 

--- a/src/toolregistry/tool.py
+++ b/src/toolregistry/tool.py
@@ -297,7 +297,7 @@ class Tool:
         is_async: bool | None = None,
     ) -> None:
         # NOTE: dataclasses.replace() re-runs __init__ on every copy.
-        # _inject_toolcall_reason and schema_hash computation are
+        # _normalize_parameters and schema_hash computation are
         # idempotent, so this is safe but does redundant work.
         if metadata is None:
             metadata = (
@@ -307,41 +307,35 @@ class Tool:
             )
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "description", description)
-        object.__setattr__(self, "parameters", parameters)
+        object.__setattr__(self, "parameters", self._normalize_parameters(parameters))
         object.__setattr__(self, "callable", callable)
         object.__setattr__(self, "parameters_model", parameters_model)
         object.__setattr__(self, "namespace", namespace)
         object.__setattr__(self, "method_name", method_name)
-        self._inject_toolcall_reason()
-        # Hash after toolcall_reason injection so it reflects the final schema.
         if not metadata.schema_hash:
             metadata = dataclasses.replace(
                 metadata, schema_hash=compute_schema_hash(self.parameters)
             )
         object.__setattr__(self, "metadata", metadata)
 
-    def _inject_toolcall_reason(self) -> None:
-        """Inject ``toolcall_reason`` property into the tool's parameter schema.
+    @classmethod
+    def _normalize_parameters(cls, parameters: dict[str, Any]) -> dict[str, Any]:
+        """Normalize and flatten a parameter schema at construction time.
 
-        Runs after every ``Tool`` (and subclass) construction, regardless
-        of whether the instance was created via ``from_function()``, or
-        directly (MCP, OpenAPI, LangChain integrations).
-
-        The ``toolcall_reason`` field is only added when ``parameters``
-        already contains a ``properties`` mapping.
+        Ensures the schema is {type: object, properties: {...}},
+        then runs flatten_schema to resolve $ref, merge
+        allOf, simplify anyOf/oneOf, and strip unsupported
+        keywords.  The result is a clean, wire-safe JSON Schema that
+        faithfully represents the function signature.
         """
-        # Called during __init__ only. Dict mutations (adding keys to
-        # self.parameters) are safe here because no external reference
-        # exists yet — frozen protects field reassignment, not dict contents.
-        had_properties = isinstance(self.parameters.get("properties"), dict)
-        if self.parameters.get("type") != "object":
-            object.__setattr__(self, "parameters", {"type": "object", "properties": {}})
-        elif not had_properties:
-            self.parameters["properties"] = {}
+        from ._vendor.jsonschema import flatten_schema
 
-        props = self.parameters["properties"]
-        if had_properties and "toolcall_reason" not in props:
-            props["toolcall_reason"] = TOOLCALL_REASON_PROPERTY
+        if parameters.get("type") != "object":
+            parameters = {"type": "object", "properties": {}}
+        elif not isinstance(parameters.get("properties"), dict):
+            parameters = {**parameters, "properties": {}}
+
+        return flatten_schema(parameters, strip_keys=cls._EXTRA_STRIP_KEYS)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, excluding non-serializable fields."""
@@ -487,18 +481,8 @@ class Tool:
 
         return tool
 
-    def _parameters_without_toolcall_reason(self) -> dict[str, Any]:
-        """Return a deep copy of ``parameters`` with ``toolcall_reason`` removed."""
-        import copy
-
-        params = copy.deepcopy(self.parameters)
-        props = params.get("properties")
-        if props is not None:
-            props.pop("toolcall_reason", None)
-        return params
-
-    #: Schema keys stripped during ``get_schema()`` sanitization.
-    #: ``title`` and ``nullable`` are Pydantic v2 artifacts that most LLM
+    #: Schema keys stripped during parameter normalization.
+    #: title and nullable are Pydantic v2 artifacts that most LLM
     #: providers either reject or misinterpret.
     _EXTRA_STRIP_KEYS: ClassVar[set[str]] = {"title", "nullable"}
 
@@ -510,21 +494,17 @@ class Tool:
     ) -> dict[str, Any]:
         """Generate schema representation of tool for a target API format.
 
-        All formats are produced via llm-rosetta converters, which also
-        apply schema sanitization (stripping unsupported JSON Schema
-        keywords like ``$ref``, ``$schema``, ``anyOf``, etc.).
-
-        Before conversion, the parameter schema is run through
-        :func:`~toolregistry._vendor.jsonschema.flatten_schema` to
-        resolve ``$ref``, merge ``allOf``, collapse ``anyOf``/``oneOf``
-        nullable patterns, and strip Pydantic v2 artifacts (``title``,
-        ``nullable``) that most LLM providers reject.
+        Parameters are already flattened and sanitized at construction
+        (see :meth:`_normalize_parameters`).  This method wraps them in
+        the target provider format and optionally injects a
+        ``toolcall_reason`` property for think-augmented calling.
 
         Args:
             api_format: Target API format. One of ``"openai-chat"``,
                 ``"openai-responses"``, ``"anthropic"``, ``"gemini"``.
-            _think_augment: Internal override for toolcall_reason injection.
-                When ``None`` (default), falls back to
+            _think_augment: Override for toolcall_reason injection.
+                ``True`` → include, ``False``/``None`` → exclude.
+                When ``None``, falls back to
                 ``self.metadata.think_augment``.  Used by
                 :meth:`ToolRegistry.get_schemas` to pass the resolved
                 effective value.
@@ -532,9 +512,10 @@ class Tool:
         Returns:
             Provider-specific tool definition dict.
         """
+        import copy
+
         from .llm._rosetta import _make_ir_tool_definition
         from .llm.tool_calls import _get_tool_ops, _normalize_api_format
-        from ._vendor.jsonschema import flatten_schema
 
         api_format = _normalize_api_format(api_format)
 
@@ -544,19 +525,15 @@ class Tool:
             if _think_augment is not None
             else self.metadata.think_augment
         )
-        # None means "include" when called directly (no registry context)
-        should_include_reason = effective is not False
+        should_include_reason = effective is True
 
-        params = (
-            self.parameters
-            if should_include_reason
-            else self._parameters_without_toolcall_reason()
-        )
-
-        # Sanitize: resolve $ref, merge allOf, collapse anyOf/oneOf nullable
-        # patterns, and strip Pydantic v2 artifacts (title, nullable) that
-        # LLM providers reject or misinterpret.
-        params = flatten_schema(params, strip_keys=self._EXTRA_STRIP_KEYS)
+        if should_include_reason:
+            params = copy.deepcopy(self.parameters)
+            params.setdefault("properties", {})["toolcall_reason"] = (
+                TOOLCALL_REASON_PROPERTY
+            )
+        else:
+            params = self.parameters
 
         ir_tool = _make_ir_tool_definition(self.name, self.description, params)
 

--- a/src/toolregistry/utils.py
+++ b/src/toolregistry/utils.py
@@ -329,24 +329,13 @@ def normalize_tool_name(name: str) -> str:
 def compute_schema_hash(parameters: dict[str, Any]) -> str:
     """Compute a deterministic SHA-256 hex digest of a JSON Schema dict.
 
-    The ``toolcall_reason`` property (injected by ``Tool.__init__``) is
-    excluded so that toggling thought-augmented calling does not change
-    the hash.
-
     Args:
         parameters: The JSON Schema dict (typically ``Tool.parameters``).
 
     Returns:
         A 64-character lowercase hex string.
     """
-    filtered = parameters
-    props = parameters.get("properties")
-    if isinstance(props, dict) and "toolcall_reason" in props:
-        filtered = {
-            **parameters,
-            "properties": {k: v for k, v in props.items() if k != "toolcall_reason"},
-        }
-    canonical = json.dumps(filtered, sort_keys=True, separators=(",", ":"))
+    canonical = json.dumps(parameters, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 

--- a/tests/test_e2e_execution_paths.py
+++ b/tests/test_e2e_execution_paths.py
@@ -4,6 +4,9 @@ Verifies that sync/async registration, sync/async single-call, and
 sync/async batch execution all work with a live MCP stdio server —
 not just mock functions. Also tests that per-tool timeout is enforced
 on every path where it should be.
+
+MCP servers are shared via module-level fixtures to avoid repeatedly
+spawning subprocesses (the main source of test-suite slowness).
 """
 
 import asyncio
@@ -35,42 +38,51 @@ def _tc(cid: str, name: str, args: str):
     }
 
 
+# ── Shared fixtures ────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def sync_mcp_registry():
+    """Module-scoped sync MCP registry — one subprocess for all sync tests."""
+    reg = ToolRegistry()
+    reg.register_from_mcp(_stdio_config(), persistent=True)
+    yield reg
+    reg.close()
+
+
 # ── Sync registration + sync invoke ─────────────────────────────────
 
 
 class TestSyncMCPPaths:
-    def test_sync_register_and_invoke(self):
+    def test_sync_register_and_invoke(self, sync_mcp_registry):
         """register_from_mcp (sync) + invoke (sync) with a real MCP tool."""
-        with ToolRegistry() as reg:
-            reg.register_from_mcp(_stdio_config(), persistent=True)
-            assert "add" in reg
+        reg = sync_mcp_registry
+        assert "add" in reg
 
-            r = reg.invoke("add", {"a": 10, "b": 20})
-            assert isinstance(r, ToolCallResult)
-            assert r.result == '{"result": 30}'
+        r = reg.invoke("add", {"a": 10, "b": 20})
+        assert isinstance(r, ToolCallResult)
+        assert r.result == '{"result": 30}'
 
-    def test_sync_register_and_invoke_echo(self):
-        with ToolRegistry() as reg:
-            reg.register_from_mcp(_stdio_config(), persistent=True)
-            r = reg.invoke("echo", {"message": "hello world"})
-            assert isinstance(r, ToolCallResult)
-            assert r.result == "hello world"
+    def test_sync_register_and_invoke_echo(self, sync_mcp_registry):
+        reg = sync_mcp_registry
+        r = reg.invoke("echo", {"message": "hello world"})
+        assert isinstance(r, ToolCallResult)
+        assert r.result == "hello world"
 
-    def test_sync_register_and_execute_batch(self):
+    def test_sync_register_and_execute_batch(self, sync_mcp_registry):
         """register_from_mcp (sync) + execute_tool_calls (sync batch)."""
-        with ToolRegistry() as reg:
-            reg.register_from_mcp(_stdio_config(), persistent=True)
+        reg = sync_mcp_registry
 
-            tcs = [
-                _tc("c1", "add", '{"a": 1, "b": 2}'),
-                _tc("c2", "echo", '{"message": "hi"}'),
-                _tc("c3", "greet", '{"name": "Alice"}'),
-            ]
-            results = reg.execute_tool_calls(tcs)
-            assert results["c1"].result == '{"result": 3}'
-            assert results["c2"].result == "hi"
-            assert "Alice" in results["c3"].result
-            assert [r.id for r in results] == ["c1", "c2", "c3"]
+        tcs = [
+            _tc("c1", "add", '{"a": 1, "b": 2}'),
+            _tc("c2", "echo", '{"message": "hi"}'),
+            _tc("c3", "greet", '{"name": "Alice"}'),
+        ]
+        results = reg.execute_tool_calls(tcs)
+        assert results["c1"].result == '{"result": 3}'
+        assert results["c2"].result == "hi"
+        assert "Alice" in results["c3"].result
+        assert [r.id for r in results] == ["c1", "c2", "c3"]
 
 
 # ── Async registration + async invoke ───────────────────────────────
@@ -153,7 +165,7 @@ class TestTimeoutEnforcement:
 
         assert isinstance(r, ErrorResult)
         assert "timed out" in r.message
-        assert elapsed < 2.0
+        assert elapsed < 4.0
 
     @pytest.mark.asyncio
     async def test_ainvoke_native_tool_timeout(self):
@@ -172,7 +184,7 @@ class TestTimeoutEnforcement:
 
         assert isinstance(r, ErrorResult)
         assert "timed out" in r.message
-        assert elapsed < 2.0
+        assert elapsed < 4.0
 
     def test_sync_batch_native_tool_timeout(self):
         """execute_tool_calls with a native tool that times out."""
@@ -200,7 +212,7 @@ class TestTimeoutEnforcement:
         assert results["c1"].result == "10"
         assert isinstance(results["c2"], ErrorResult)
         assert "timed out" in results["c2"].message
-        assert elapsed < 2.0
+        assert elapsed < 4.0
 
     @pytest.mark.asyncio
     async def test_async_batch_native_tool_timeout(self):
@@ -229,7 +241,7 @@ class TestTimeoutEnforcement:
         assert results["c1"].result == "10"
         assert isinstance(results["c2"], ErrorResult)
         assert "timed out" in results["c2"].message
-        assert elapsed < 2.0
+        assert elapsed < 4.0
 
 
 # ── Real MCP tool timeout ──────────────────────────────────────────
@@ -258,7 +270,7 @@ class TestMCPToolTimeout:
 
             assert isinstance(r, ErrorResult)
             assert "timed out" in r.message
-            assert elapsed < 2.0
+            assert elapsed < 4.0
 
     @pytest.mark.asyncio
     async def test_ainvoke_mcp_timeout(self):
@@ -276,16 +288,13 @@ class TestMCPToolTimeout:
 
             assert isinstance(r, ErrorResult)
             assert "timed out" in r.message
-            assert elapsed < 2.0
+            assert elapsed < 4.0
 
-    def test_sync_invoke_mcp_no_timeout_completes(self):
+    def test_sync_invoke_mcp_no_timeout_completes(self, sync_mcp_registry):
         """MCP tool without timeout runs to completion normally."""
-        with ToolRegistry() as reg:
-            reg.register_from_mcp(_stdio_config(), persistent=True)
-
-            r = reg.invoke("slow_tool", {"seconds": 0.3})
-            assert isinstance(r, ToolCallResult)
-            assert "slept" in r.result
+        r = sync_mcp_registry.invoke("slow_tool", {"seconds": 0.3})
+        assert isinstance(r, ToolCallResult)
+        assert "slept" in r.result
 
     def test_sync_batch_mcp_timeout(self):
         """sync batch: single slow MCP tool times out.
@@ -311,7 +320,7 @@ class TestMCPToolTimeout:
 
             assert isinstance(results["c1"], ErrorResult)
             assert "timed out" in results["c1"].message
-            assert elapsed < 2.0
+            assert elapsed < 4.0
 
     @pytest.mark.asyncio
     async def test_async_batch_mcp_timeout(self):
@@ -330,7 +339,7 @@ class TestMCPToolTimeout:
 
             assert isinstance(results["c1"], ErrorResult)
             assert "timed out" in results["c1"].message
-            assert elapsed < 2.0
+            assert elapsed < 4.0
 
 
 # ── OpenAPI through the execution stack ────────────────────────────
@@ -402,16 +411,15 @@ class TestOpenAPIExecutionStack:
 class TestMixedBatch:
     """MCP (→thread on sync) + native Python (→process) in the same batch."""
 
-    def test_sync_mixed_mcp_and_native(self):
+    def test_sync_mixed_mcp_and_native(self, sync_mcp_registry):
         """MCP tools resolve to thread, native tools to process, same batch."""
-        reg = ToolRegistry()
+        reg = sync_mcp_registry
 
         def double(n: int) -> int:
             """Native Python tool."""
             return n * 2
 
         reg.register(double)
-        reg.register_from_mcp(_stdio_config(), persistent=True)
 
         tcs = [
             _tc("c1", "double", '{"n": 7}'),
@@ -424,29 +432,27 @@ class TestMixedBatch:
         assert results["c2"].result == '{"result": 30}'
         assert results["c3"].result == "mixed"
         assert [r.id for r in results] == ["c1", "c2", "c3"]
-        reg.close()
 
     @pytest.mark.asyncio
     async def test_async_mixed_mcp_and_native(self):
         """Async batch: MCP (inline) + native overlap under gather."""
-        reg = ToolRegistry()
+        async with ToolRegistry() as reg:
+            await reg.register_from_mcp_async(_stdio_config(), persistent=True)
 
-        async def double(n: int) -> int:
-            """Native async tool."""
-            return n * 2
+            async def double(n: int) -> int:
+                """Native async tool."""
+                return n * 2
 
-        reg.register(double)
-        await reg.register_from_mcp_async(_stdio_config(), persistent=True)
+            reg.register(double)
 
-        tcs = [
-            _tc("c1", "double", '{"n": 5}'),
-            _tc("c2", "add", '{"a": 3, "b": 4}'),
-        ]
-        results = await reg.aexecute_tool_calls(tcs)
+            tcs = [
+                _tc("c1", "double", '{"n": 5}'),
+                _tc("c2", "add", '{"a": 3, "b": 4}'),
+            ]
+            results = await reg.aexecute_tool_calls(tcs)
 
-        assert results["c1"].result == "10"
-        assert results["c2"].result == '{"result": 7}'
-        await reg.close_async()
+            assert results["c1"].result == "10"
+            assert results["c2"].result == '{"result": 7}'
 
 
 # ── MCP concurrent ainvoke (same connection) ───────────────────────
@@ -514,22 +520,20 @@ class TestProcessBlockedForInlineTools:
     intercepts this and routes to thread instead.
     """
 
-    def test_invoke_force_process_mcp_goes_thread(self):
+    def test_invoke_force_process_mcp_goes_thread(self, sync_mcp_registry):
         """invoke(execution_mode='process') on MCP tool succeeds (→thread)."""
-        with ToolRegistry() as reg:
-            reg.register_from_mcp(_stdio_config(), persistent=True)
-            r = reg.invoke("echo", {"message": "safe"}, execution_mode="process")
-            assert isinstance(r, ToolCallResult)
-            assert r.result == "safe"
+        r = sync_mcp_registry.invoke(
+            "echo", {"message": "safe"}, execution_mode="process"
+        )
+        assert isinstance(r, ToolCallResult)
+        assert r.result == "safe"
 
-    def test_batch_force_process_mcp_goes_thread(self):
+    def test_batch_force_process_mcp_goes_thread(self, sync_mcp_registry):
         """execute_tool_calls(execution_mode='process') on MCP tool succeeds."""
-        with ToolRegistry() as reg:
-            reg.register_from_mcp(_stdio_config(), persistent=True)
-            tcs = [_tc("c1", "echo", '{"message": "batch safe"}')]
-            results = reg.execute_tool_calls(tcs, execution_mode="process")
-            assert isinstance(results["c1"], ToolCallResult)
-            assert results["c1"].result == "batch safe"
+        tcs = [_tc("c1", "echo", '{"message": "batch safe"}')]
+        results = sync_mcp_registry.execute_tool_calls(tcs, execution_mode="process")
+        assert isinstance(results["c1"], ToolCallResult)
+        assert results["c1"].result == "batch safe"
 
     def test_resolve_backend_blocks_process_for_inline(self):
         """_resolve_backend downgrades process→thread for inline tools."""

--- a/tests/test_schema_diff.py
+++ b/tests/test_schema_diff.py
@@ -131,7 +131,8 @@ class TestClassifySchemaChange:
         assert kind == SchemaChangeKind.COMPATIBLE
         assert summary == {}
 
-    def test_toolcall_reason_ignored(self):
+    def test_toolcall_reason_treated_as_normal_param(self):
+        """toolcall_reason is no longer special — removing it is a real change."""
         old = {
             "type": "object",
             "properties": {
@@ -146,8 +147,8 @@ class TestClassifySchemaChange:
             },
         }
         kind, summary = classify_schema_change(old, new)
-        assert kind == SchemaChangeKind.COMPATIBLE
-        assert summary == {}
+        assert kind == SchemaChangeKind.BREAKING
+        assert "toolcall_reason" in summary["removed"]
 
     def test_anyof_type_change(self):
         old = {
@@ -222,9 +223,9 @@ class TestSchemaChangeKindEnum:
 
 
 class TestToolcallReasonHashExclusion:
-    """Verify toolcall_reason is excluded from schema hash."""
+    """toolcall_reason is no longer injected into parameters, so hash treats it normally."""
 
-    def test_hash_excludes_toolcall_reason(self):
+    def test_hash_includes_toolcall_reason_when_present(self):
         from toolregistry.utils import compute_schema_hash
 
         schema_with = {
@@ -240,7 +241,7 @@ class TestToolcallReasonHashExclusion:
                 "a": {"type": "string"},
             },
         }
-        assert compute_schema_hash(schema_with) == compute_schema_hash(schema_without)
+        assert compute_schema_hash(schema_with) != compute_schema_hash(schema_without)
 
     def test_hash_still_sensitive_to_real_changes(self):
         from toolregistry.utils import compute_schema_hash

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -358,38 +358,47 @@ class TestTool:
 
 
 class TestThinkAugmented:
-    """Test cases for think-augmented function calling (toolcall_reason)."""
+    """Test cases for think-augmented function calling (toolcall_reason).
 
-    def test_toolcall_reason_in_schema(self, sample_tool):
-        """Test that toolcall_reason property is injected into tool schema."""
-        assert "toolcall_reason" in sample_tool.parameters["properties"]
-        reason = sample_tool.parameters["properties"]["toolcall_reason"]
-        assert reason["type"] == "string"
-        assert "chose" in reason["description"]
+    Two-layer model: tool.parameters never contains toolcall_reason.
+    get_schema(_think_augment=True) adds it on demand.
+    """
 
-    def test_toolcall_reason_in_openai_format(self, sample_tool):
-        """Test that toolcall_reason appears in OpenAI format schema."""
-        schema = sample_tool.get_schema("openai-chat")
-        params = schema["function"]["parameters"]
-        assert "toolcall_reason" in params["properties"]
+    def test_toolcall_reason_not_in_parameters(self, sample_tool):
+        """toolcall_reason is never stored in tool.parameters."""
+        assert "toolcall_reason" not in sample_tool.parameters["properties"]
 
-    def test_toolcall_reason_in_anthropic_format(self, sample_tool):
-        """Test that toolcall_reason appears in Anthropic format schema."""
-        schema = sample_tool.get_schema("anthropic")
-        assert "toolcall_reason" in schema["input_schema"]["properties"]
+    def test_toolcall_reason_excluded_by_default_all_formats(self, sample_tool):
+        """Standalone get_schema() excludes toolcall_reason (matches registry default)."""
+        for fmt, extract in [
+            ("openai-chat", lambda s: s["function"]["parameters"]["properties"]),
+            ("anthropic", lambda s: s["input_schema"]["properties"]),
+            ("gemini", lambda s: s["parameters"]["properties"]),
+            ("google-interactions", lambda s: s["parameters"]["properties"]),
+        ]:
+            schema = sample_tool.get_schema(fmt)
+            assert "toolcall_reason" not in extract(schema), (
+                f"toolcall_reason should not appear for {fmt} by default"
+            )
 
-    def test_toolcall_reason_in_gemini_format(self, sample_tool):
-        """Test that toolcall_reason appears in Gemini format schema."""
-        schema = sample_tool.get_schema("gemini")
-        assert "toolcall_reason" in schema["parameters"]["properties"]
-
-    def test_toolcall_reason_in_google_interactions_format(self, sample_tool):
-        """Test that toolcall_reason appears in Google Interactions format."""
-        schema = sample_tool.get_schema("google-interactions")
-        assert "toolcall_reason" in schema["parameters"]["properties"]
+    def test_toolcall_reason_included_when_think_augment_true(self, sample_function):
+        """get_schema(_think_augment=True) injects toolcall_reason."""
+        tool = Tool.from_function(sample_function)
+        for fmt, extract in [
+            ("openai-chat", lambda s: s["function"]["parameters"]["properties"]),
+            ("anthropic", lambda s: s["input_schema"]["properties"]),
+            ("gemini", lambda s: s["parameters"]["properties"]),
+            ("google-interactions", lambda s: s["parameters"]["properties"]),
+        ]:
+            schema = tool.get_schema(fmt, _think_augment=True)
+            props = extract(schema)
+            assert "toolcall_reason" in props, (
+                f"toolcall_reason missing for {fmt} with think_augment=True"
+            )
+            assert props["toolcall_reason"]["type"].lower() == "string"
 
     def test_toolcall_reason_stripped_on_run(self, sample_tool):
-        """Test that toolcall_reason is stripped before execution in run()."""
+        """toolcall_reason is stripped before execution in run()."""
         result = sample_tool.run(
             {"a": 5, "b": 3, "toolcall_reason": "I need to add these numbers"}
         )
@@ -397,31 +406,28 @@ class TestThinkAugmented:
 
     @pytest.mark.asyncio
     async def test_toolcall_reason_stripped_on_arun(self, async_sample_function):
-        """Test that toolcall_reason is stripped before execution in arun()."""
+        """toolcall_reason is stripped before execution in arun()."""
         tool = Tool.from_function(async_sample_function)
         result = await tool.arun(
             {"a": 10, "b": 20, "toolcall_reason": "Adding asynchronously"}
         )
         assert result == 30
 
-    def test_toolcall_reason_no_collision_with_native_params(self):
-        """Test that native 'thought' parameter is not affected by toolcall_reason."""
+    def test_native_thought_param_not_affected(self):
+        """Native 'thought' parameter is not affected by toolcall_reason."""
 
         def func_with_thought(thought: str, value: int) -> str:
             """A function that uses thought as a real parameter."""
             return f"{thought}: {value}"
 
         tool = Tool.from_function(func_with_thought)
-        # Native 'thought' param is preserved
         assert "thought" in tool.parameters["properties"]
-        # toolcall_reason is also injected (no collision)
-        assert "toolcall_reason" in tool.parameters["properties"]
-        # Native 'thought' is passed through; toolcall_reason is stripped
+        assert "toolcall_reason" not in tool.parameters["properties"]
         result = tool.run({"thought": "hello", "value": 42, "toolcall_reason": "test"})
         assert result == "hello: 42"
 
-    def test_toolcall_reason_manual_tool_creation(self):
-        """Test that manually created Tool also gets toolcall_reason injected."""
+    def test_manual_tool_no_toolcall_reason(self):
+        """Manually created Tool does not get toolcall_reason in parameters."""
         tool = Tool(
             name="manual_tool",
             description="A manually created tool",
@@ -434,10 +440,10 @@ class TestThinkAugmented:
             },
             callable=lambda x: x * 2,
         )
-        assert "toolcall_reason" in tool.parameters["properties"]
+        assert "toolcall_reason" not in tool.parameters["properties"]
 
-    def test_toolcall_reason_empty_schema_no_inject(self):
-        """Test that toolcall_reason is not injected into normalized empty schemas."""
+    def test_empty_schema_normalized(self):
+        """Empty schema is normalized without toolcall_reason."""
         tool = Tool(
             name="empty_tool",
             description="Tool with empty schema",
@@ -446,59 +452,54 @@ class TestThinkAugmented:
         )
         assert tool.parameters == {"type": "object", "properties": {}}
 
-    def test_think_metadata_false_strips_from_schema(self, sample_function):
-        """Test that think_augment=False strips toolcall_reason from get_schema output."""
+    def test_think_metadata_false_excludes(self, sample_function):
+        """think_augment=False excludes toolcall_reason from get_schema."""
         tool = Tool.from_function(
             sample_function, metadata=ToolMetadata(think_augment=False)
         )
-        # Internal storage still has toolcall_reason
-        assert "toolcall_reason" in tool.parameters["properties"]
-        # But get_schema strips it
+        assert "toolcall_reason" not in tool.parameters["properties"]
         schema = tool.get_schema("openai-chat")
         assert "toolcall_reason" not in schema["function"]["parameters"]["properties"]
 
-    def test_think_metadata_true_includes_in_schema(self, sample_function):
-        """Test that think_augment=True always includes toolcall_reason in schema."""
+    def test_think_metadata_true_includes(self, sample_function):
+        """think_augment=True includes toolcall_reason in get_schema."""
         tool = Tool.from_function(
             sample_function, metadata=ToolMetadata(think_augment=True)
         )
         schema = tool.get_schema("openai-chat")
         assert "toolcall_reason" in schema["function"]["parameters"]["properties"]
 
-    def test_think_metadata_none_includes_by_default(self, sample_function):
-        """Test that think_augment=None (default) includes toolcall_reason when called directly."""
+    def test_think_metadata_none_excludes_by_default(self, sample_function):
+        """think_augment=None (default) excludes toolcall_reason (matches registry default)."""
         tool = Tool.from_function(sample_function)
         assert tool.metadata.think_augment is None
         schema = tool.get_schema("openai-chat")
-        assert "toolcall_reason" in schema["function"]["parameters"]["properties"]
+        assert "toolcall_reason" not in schema["function"]["parameters"]["properties"]
 
     def test_think_override_false_strips(self, sample_function):
-        """Test _think_augment=False override strips toolcall_reason from output."""
+        """_think_augment=False override excludes toolcall_reason."""
         tool = Tool.from_function(sample_function)
         schema = tool.get_schema("openai-chat", _think_augment=False)
         assert "toolcall_reason" not in schema["function"]["parameters"]["properties"]
 
     def test_think_override_true_includes(self, sample_function):
-        """Test _think_augment=True override includes toolcall_reason in output."""
+        """_think_augment=True override includes toolcall_reason even if per-tool=False."""
         tool = Tool.from_function(
             sample_function, metadata=ToolMetadata(think_augment=False)
         )
-        # Per-tool says False, but override says True
         schema = tool.get_schema("openai-chat", _think_augment=True)
         assert "toolcall_reason" in schema["function"]["parameters"]["properties"]
 
-    def test_toolcall_reason_strip_all_formats(self, sample_function):
-        """Test that toolcall_reason is stripped across all API formats."""
-        tool = Tool.from_function(sample_function)
-        for fmt, path in [
-            ("openai-chat", lambda s: s["function"]["parameters"]["properties"]),
-            ("anthropic", lambda s: s["input_schema"]["properties"]),
-            ("gemini", lambda s: s["parameters"]["properties"]),
-        ]:
-            schema = tool.get_schema(fmt, _think_augment=False)
-            assert "toolcall_reason" not in path(schema), (
-                f"toolcall_reason not stripped for {fmt}"
-            )
+    def test_param_named_toolcall_reason_survives(self):
+        """A function with a parameter literally named toolcall_reason preserves it."""
+
+        def func_with_reason(query: str, toolcall_reason: str = "default") -> str:
+            """A function with toolcall_reason as a real parameter."""
+            return f"{query}: {toolcall_reason}"
+
+        tool = Tool.from_function(func_with_reason)
+        assert "toolcall_reason" in tool.parameters["properties"]
+        assert "query" in tool.parameters["properties"]
 
 
 class TestToolMetadataFields:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -501,6 +501,18 @@ class TestThinkAugmented:
         assert "toolcall_reason" in tool.parameters["properties"]
         assert "query" in tool.parameters["properties"]
 
+    def test_think_augment_overrides_native_toolcall_reason(self):
+        """think_augment=True replaces a native toolcall_reason param with the framework property."""
+
+        def func_with_reason(query: str, toolcall_reason: str = "default") -> str:
+            """A function with toolcall_reason as a real parameter."""
+            return f"{query}: {toolcall_reason}"
+
+        tool = Tool.from_function(func_with_reason)
+        schema = tool.get_schema("openai-chat", _think_augment=True)
+        props = schema["function"]["parameters"]["properties"]
+        assert "chose" in props["toolcall_reason"]["description"]
+
 
 class TestToolMetadataFields:
     """Test cases for ToolMetadata and ToolTag."""


### PR DESCRIPTION
## Summary

Fixes #265, fixes #266.

Introduces a two-layer schema model with clear contracts:

| Layer | Entry point | Content | Consumers |
|---|---|---|---|
| **Parameters** | `tool.parameters` | Flattened + sanitized JSON Schema. No `toolcall_reason`. Faithful to function signature. | hash, diff, search, validate, `to_dict`, RouteEntry, MCP `tools/list`, OpenAPI spec |
| **LLM Schema** | `tool.get_schema(format, ...)` | Provider-formatted wrapper. Adds `toolcall_reason` only when `think_augment=True`. | `ToolRegistry.get_schemas()` → LLM clients |

**Rule**: need the function's interface → `tool.parameters`. Need what to send to an LLM → `get_schema()`.

### What changed

- Parameters are flattened + sanitized at construction (`_normalize_parameters`), not at `get_schema()` time
- `_inject_toolcall_reason()` removed — `toolcall_reason` is never stored in `tool.parameters`
- `get_schema()` adds `toolcall_reason` on-demand via deep copy only when `think_augment=True`
- Standalone `get_schema()` default flipped: `None` → exclude (matching registry default)
- 5 hardcoded `toolcall_reason` exclusion sites removed (utils, schema_diff, discovery)
- Re-vendored `jsonschema` 0.3.0 from zerodep (position-aware walkers fix for #265)
- E2e test timeout assertions relaxed (2.0s → 4.0s) for CI stability
- Shared sync MCP fixture to reduce subprocess spawns

### Impact on downstream

This unblocks toolregistry-server#71. `RouteEntry.parameters_schema` reads `tool.parameters` directly — with clean parameters, it gets the right schema without filtering. The `_coerce_arguments_from_schema` workaround (`if key == "toolcall_reason": continue`) becomes unnecessary.

## Test plan

- [x] Pre-commit (ruff, ruff-format, ty, complexipy) passes
- [x] E2e tests pass (27/27) including timeout tests
- [x] `TestThinkAugmented` rewritten for new two-layer model (16 tests)
- [x] `tool.parameters` no longer contains `toolcall_reason`
- [x] `get_schema(_think_augment=True)` correctly injects it
- [x] `tool.run({"a": 1, "toolcall_reason": "test"})` still works (execution-time strip)
- [ ] Full test suite via CI